### PR TITLE
fix: update GitVersion actions to v3.2.1 for GitVersion 6.x compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v3.1.11
+        uses: gittools/actions/gitversion/setup@v3.2.1
         with:
           versionSpec: '6.x'
 
       - name: Calculate Version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v3.1.11
+        uses: gittools/actions/gitversion/execute@v3.2.1
 
       - name: Display Version
         run: echo "Version:${{ steps.gitversion.outputs.semVer }}"


### PR DESCRIPTION
## Summary

- Update `gittools/actions/gitversion/setup` and `execute` from `v3.1.11` to `v3.2.1`
- The v3.1.11 actions only support GitVersion `<6.1.0`, but the latest available is `6.6.0`
- This caused the release workflow to fail on merge to main

## Test plan
- [ ] Release workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)