### PR TITLE
fix: migrate GitVersion.yml to v6 config format

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,10 +1,10 @@
-mode: ContinuousDeployment
+workflow: ContinuousDeployment
 branches:
   main:
     regex: ^main$
-    tag: ''
+    label: ''
     increment: Patch
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
-    tag: preview
+    label: preview
     increment: Inherit

--- a/docs/plans/2026-03-06-cicd-pipeline-design.md
+++ b/docs/plans/2026-03-06-cicd-pipeline-design.md
@@ -25,15 +25,15 @@ Three GitHub Actions workflows with GitVersion for semantic versioning, Conventi
 
 `GitVersion.yml` at repo root:
 ```yaml
-mode: ContinuousDeployment
+workflow: ContinuousDeployment
 branches:
   main:
     regex: ^main$
-    tag: ''
+    label: ''
     increment: Patch
   pull-request:
     regex: ^(pull|pull\-requests|pr)[/-]
-    tag: preview
+    label: preview
     increment: Inherit
 ```
 
@@ -52,7 +52,7 @@ branches:
 
 **Steps:**
 1. Checkout with full history (`fetch-depth: 0`)
-2. Setup .NET 9 SDK
+2. Setup .NET 10 SDK
 3. Validate PR title (Conventional Commits)
 4. `dotnet restore`
 5. `dotnet build --no-restore`
@@ -66,7 +66,7 @@ branches:
 
 **Steps:**
 1. Checkout with full history
-2. Setup .NET 9 SDK
+2. Setup .NET 10 SDK
 3. Install GitVersion
 4. Calculate version → `$GITVERSION_SEMVER`
 5. `dotnet restore`


### PR DESCRIPTION
## Summary

- Migrate `GitVersion.yml` from v5 to v6 config format: `mode` → `workflow`, `tag` → `label`
- Update CI/CD design doc to reflect .NET 10 and new config format

The previous PR (#2) updated the action versions but missed the config file migration, causing the release workflow to output `undefined` instead of valid JSON.

## Test plan
- [ ] Release workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)