### PR TITLE
fix: pin GitVersion to 6.0.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.2.1
         with:
-          versionSpec: '6.x'
+          versionSpec: '6.0.x'
 
       - name: Calculate Version
         id: gitversion


### PR DESCRIPTION
## Summary

Pin GitVersion `versionSpec` from `6.x` (resolves to 6.6.0) to `6.0.x`. GitVersion 6.6.0 outputs `undefined` instead of valid JSON with the v3.2.1 actions, breaking the release workflow.

## Test plan
- [ ] Release workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)