### PR TITLE
fix: use correct GitVersion 6.0.x config format

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-workflow: ContinuousDeployment
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$

--- a/docs/plans/2026-03-06-cicd-pipeline-design.md
+++ b/docs/plans/2026-03-06-cicd-pipeline-design.md
@@ -25,7 +25,7 @@ Three GitHub Actions workflows with GitVersion for semantic versioning, Conventi
 
 `GitVersion.yml` at repo root:
 ```yaml
-workflow: ContinuousDeployment
+mode: ContinuousDeployment
 branches:
   main:
     regex: ^main$


### PR DESCRIPTION
## Summary

Fix `GitVersion.yml` to use the correct 6.0.x config format:
- `mode` (not `workflow` — that's 6.1+)
- `label` (not `tag` — renamed in 6.0)

Verified locally: `dotnet-gitversion 6.0.5` outputs valid JSON with `SemVer: "0.0.1"`.

## Test plan
- [x] `dotnet-gitversion` works locally with 6.0.5
- [ ] Release workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)