### PR TITLE
fix: add -c Release to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,13 +40,13 @@ jobs:
         run: dotnet restore tests/RoslynCodeGraph.Tests/Fixtures/TestSolution/TestSolution.slnx
 
       - name: Build
-        run: dotnet build --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
+        run: dotnet build --no-restore -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Pack
-        run: dotnet pack src/RoslynCodeGraph/RoslynCodeGraph.csproj --no-build -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o ./artifacts
+        run: dotnet pack src/RoslynCodeGraph/RoslynCodeGraph.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o ./artifacts
 
       - name: Push to NuGet
         if: env.NUGET_API_KEY != ''


### PR DESCRIPTION
## Summary
- Build/test/pack steps now consistently use `-c Release` configuration
- Fixes `MSB3030: Could not copy file` errors in Pack step where `--no-build` looked for Release output but build produced Debug output

## Test plan
- [ ] Release workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)