### PR TITLE
fix: use camelCase mcpServers in plugin.json

### DIFF
--- a/plugins/roslyn-codegraph/.claude-plugin/plugin.json
+++ b/plugins/roslyn-codegraph/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "author": {
     "name": "Marcel Roozekrans"
   },
-  "mcp_servers": {
+  "mcpServers": {
     "roslyn-codegraph": {
       "command": "bootstrap",
       "args": [],


### PR DESCRIPTION
## Summary
- Rename `mcp_servers` to `mcpServers` in `plugin.json` to match the Claude Code plugin reference convention (camelCase)

## Test plan
- [ ] Verify plugin installs correctly with `claude install gh:MarcelRoozekrans/roslyn-codegraph-mcp`
- [ ] Verify MCP server starts and responds to tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)