### PR TITLE
refactor: rename NuGet PackageId to RoslynCodeGraph.Mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ claude install gh:MarcelRoozekrans/roslyn-codegraph-mcp
 ### As a .NET Global Tool
 
 ```bash
-dotnet tool install -g roslyn-codegraph-mcp
+dotnet tool install -g RoslynCodeGraph.Mcp
 ```
 
 ### Manual MCP Configuration

--- a/plugins/roslyn-codegraph/.claude-plugin/plugin.json
+++ b/plugins/roslyn-codegraph/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roslyn-codegraph",
-  "description": "Roslyn-based code graph intelligence for .NET codebases. Requires .NET 10 SDK and the global tool: dotnet tool install -g roslyn-codegraph-mcp",
+  "description": "Roslyn-based code graph intelligence for .NET codebases. Requires .NET 10 SDK and the global tool: dotnet tool install -g RoslynCodeGraph.Mcp",
   "author": {
     "name": "Marcel Roozekrans"
   },

--- a/plugins/roslyn-codegraph/README.md
+++ b/plugins/roslyn-codegraph/README.md
@@ -8,7 +8,7 @@ Before installing this plugin, ensure you have:
 2. **roslyn-codegraph-mcp global tool** — Install with:
 
 ```bash
-dotnet tool install -g roslyn-codegraph-mcp
+dotnet tool install -g RoslynCodeGraph.Mcp
 ```
 
 ## Install

--- a/src/RoslynCodeGraph/RoslynCodeGraph.csproj
+++ b/src/RoslynCodeGraph/RoslynCodeGraph.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>roslyn-codegraph-mcp</ToolCommandName>
-    <PackageId>RoslynCodeGraph</PackageId>
+    <PackageId>RoslynCodeGraph.Mcp</PackageId>
     <Authors>Marcel Roozekrans</Authors>
     <Description>Roslyn-based MCP server providing semantic code intelligence for .NET codebases</Description>
     <PackageProjectUrl>https://github.com/MarcelRoozekrans/roslyn-codegraph-mcp</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Rename `PackageId` from `RoslynCodeGraph` to `RoslynCodeGraph.Mcp` to follow .NET conventions and clarify purpose
- Update all install references in README, plugin.json, and plugin README
- Tool command remains `roslyn-codegraph-mcp` (unchanged)

## Test plan
- [x] `dotnet build` succeeds
- [x] All 16 tests pass
- [ ] Verify `dotnet pack` produces `RoslynCodeGraph.Mcp` nupkg

🤖 Generated with [Claude Code](https://claude.com/claude-code)