### PR TITLE
fix: graceful startup when no .sln file is found

### DIFF
--- a/src/RoslynCodeGraph/Program.cs
+++ b/src/RoslynCodeGraph/Program.cs
@@ -10,26 +10,22 @@ var solutionPath = args.Length > 0
     ? args[0]
     : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory());
 
-if (solutionPath == null)
-{
-    Console.Error.WriteLine("[roslyn-codegraph] No .sln file found. Tools will return errors.");
-}
-
 var loader = new SolutionLoader();
-LoadedSolution? loaded = null;
+LoadedSolution loaded;
 
 if (solutionPath != null)
 {
     loaded = await loader.LoadAsync(solutionPath);
 }
+else
+{
+    Console.Error.WriteLine("[roslyn-codegraph] No .sln file found. Tools will return errors.");
+    loaded = LoadedSolution.Empty;
+}
 
 var builder = Host.CreateApplicationBuilder(args);
-
-if (loaded != null)
-{
-    builder.Services.AddSingleton(loaded);
-    builder.Services.AddSingleton<SymbolResolver>();
-}
+builder.Services.AddSingleton(loaded);
+builder.Services.AddSingleton<SymbolResolver>();
 
 builder.Services
     .AddMcpServer()

--- a/src/RoslynCodeGraph/SolutionGuard.cs
+++ b/src/RoslynCodeGraph/SolutionGuard.cs
@@ -1,0 +1,12 @@
+namespace RoslynCodeGraph;
+
+public static class SolutionGuard
+{
+    public static void EnsureLoaded(LoadedSolution loaded)
+    {
+        if (loaded.IsEmpty)
+            throw new InvalidOperationException(
+                "No .sln file found. Either run from a directory containing a .sln/.slnx file, " +
+                "or pass the solution path as argument: roslyn-codegraph-mcp /path/to/Solution.sln");
+    }
+}

--- a/src/RoslynCodeGraph/SolutionLoader.cs
+++ b/src/RoslynCodeGraph/SolutionLoader.cs
@@ -7,6 +7,19 @@ public class LoadedSolution
 {
     public required Solution Solution { get; init; }
     public required Dictionary<ProjectId, Compilation> Compilations { get; init; }
+    public bool IsEmpty => Compilations.Count == 0;
+
+    public static LoadedSolution Empty { get; } = CreateEmpty();
+
+    private static LoadedSolution CreateEmpty()
+    {
+        var workspace = new AdhocWorkspace();
+        return new LoadedSolution
+        {
+            Solution = workspace.CurrentSolution,
+            Compilations = new Dictionary<ProjectId, Compilation>()
+        };
+    }
 }
 
 public class SolutionLoader

--- a/src/RoslynCodeGraph/Tools/FindCallersTool.cs
+++ b/src/RoslynCodeGraph/Tools/FindCallersTool.cs
@@ -124,6 +124,7 @@ public static class FindCallersTool
         SymbolResolver resolver,
         [Description("Method name as Type.Method (simple or fully qualified)")] string symbol)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return FindCallersLogic.Execute(loaded, resolver, symbol);
     }
 }

--- a/src/RoslynCodeGraph/Tools/FindImplementationsTool.cs
+++ b/src/RoslynCodeGraph/Tools/FindImplementationsTool.cs
@@ -54,6 +54,7 @@ public static class FindImplementationsTool
         SymbolResolver resolver,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return FindImplementationsLogic.Execute(loaded, resolver, symbol);
     }
 }

--- a/src/RoslynCodeGraph/Tools/FindReflectionUsageTool.cs
+++ b/src/RoslynCodeGraph/Tools/FindReflectionUsageTool.cs
@@ -112,6 +112,7 @@ public static class FindReflectionUsageTool
         SymbolResolver resolver,
         [Description("Optional type name to filter results (omit to scan entire solution)")] string? symbol = null)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return FindReflectionUsageLogic.Execute(loaded, resolver, symbol);
     }
 }

--- a/src/RoslynCodeGraph/Tools/GetDiRegistrationsTool.cs
+++ b/src/RoslynCodeGraph/Tools/GetDiRegistrationsTool.cs
@@ -116,6 +116,7 @@ public static class GetDiRegistrationsTool
         SymbolResolver resolver,
         [Description("Type name to search for (simple or fully qualified)")] string symbol)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return GetDiRegistrationsLogic.Execute(loaded, resolver, symbol);
     }
 }

--- a/src/RoslynCodeGraph/Tools/GetProjectDependenciesTool.cs
+++ b/src/RoslynCodeGraph/Tools/GetProjectDependenciesTool.cs
@@ -65,6 +65,7 @@ public static class GetProjectDependenciesTool
         LoadedSolution loaded,
         [Description("Project name or .csproj filename")] string project)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return GetProjectDependenciesLogic.Execute(loaded, project);
     }
 }

--- a/src/RoslynCodeGraph/Tools/GetSymbolContextTool.cs
+++ b/src/RoslynCodeGraph/Tools/GetSymbolContextTool.cs
@@ -67,6 +67,7 @@ public static class GetSymbolContextTool
         SymbolResolver resolver,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return GetSymbolContextLogic.Execute(loaded, resolver, symbol);
     }
 }

--- a/src/RoslynCodeGraph/Tools/GetTypeHierarchyTool.cs
+++ b/src/RoslynCodeGraph/Tools/GetTypeHierarchyTool.cs
@@ -82,6 +82,7 @@ public static class GetTypeHierarchyTool
         SymbolResolver resolver,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
+        SolutionGuard.EnsureLoaded(loaded);
         return GetTypeHierarchyLogic.Execute(loaded, resolver, symbol);
     }
 }


### PR DESCRIPTION
## Summary
- Fix crash (JSON serialization of `System.Text.Encoding`) when starting without a `.sln` file
- Always register `LoadedSolution` and `SymbolResolver` in DI, using an empty fallback
- Add `SolutionGuard` that returns a clear error message when tools are called without a solution:
  > No .sln file found. Either run from a directory containing a .sln/.slnx file, or pass the solution path as argument: roslyn-codegraph-mcp /path/to/Solution.sln

## Test plan
- [x] All 16 tests pass
- [ ] Start server without a `.sln` in current directory — should start without crash
- [ ] Call any tool without a solution — should return helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)