### PR TITLE
fix: code quality improvements from review

### DIFF
--- a/src/RoslynCodeGraph/CodeFixRunner.cs
+++ b/src/RoslynCodeGraph/CodeFixRunner.cs
@@ -33,44 +33,15 @@ public class CodeFixRunner
             {
                 await provider.RegisterCodeFixesAsync(context);
             }
-            catch
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"[roslyn-codegraph] CodeFix registration failed ({provider.GetType().Name}): {ex.Message}");
                 continue;
             }
 
             foreach (var action in actions)
             {
-                var operations = await action.GetOperationsAsync(ct);
-                var applyOp = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
-                if (applyOp == null) continue;
-
-                var changedSolution = applyOp.ChangedSolution;
-                var edits = new List<TextEdit>();
-
-                foreach (var changedDocId in changedSolution.GetChanges(project.Solution).GetProjectChanges()
-                    .SelectMany(pc => pc.GetChangedDocuments()))
-                {
-                    var originalDoc = project.Solution.GetDocument(changedDocId);
-                    var changedDoc = changedSolution.GetDocument(changedDocId);
-                    if (originalDoc == null || changedDoc == null) continue;
-
-                    var originalText = await originalDoc.GetTextAsync(ct);
-                    var changedText = await changedDoc.GetTextAsync(ct);
-                    var changes = changedText.GetTextChanges(originalText);
-
-                    foreach (var change in changes)
-                    {
-                        var startLine = originalText.Lines.GetLinePosition(change.Span.Start);
-                        var endLine = originalText.Lines.GetLinePosition(change.Span.End);
-
-                        edits.Add(new TextEdit(
-                            originalDoc.FilePath ?? "",
-                            startLine.Line + 1, startLine.Character + 1,
-                            endLine.Line + 1, endLine.Character + 1,
-                            change.NewText ?? ""));
-                    }
-                }
-
+                var edits = await ExtractTextEdits(action, project, ct);
                 if (edits.Count > 0)
                 {
                     suggestions.Add(new CodeFixSuggestion(action.Title, diagnostic.Id, edits));
@@ -79,6 +50,43 @@ public class CodeFixRunner
         }
 
         return suggestions;
+    }
+
+    private static async Task<List<TextEdit>> ExtractTextEdits(
+        CodeAction action, Project project, CancellationToken ct)
+    {
+        var operations = await action.GetOperationsAsync(ct);
+        var applyOp = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
+        if (applyOp == null) return [];
+
+        var changedSolution = applyOp.ChangedSolution;
+        var edits = new List<TextEdit>();
+
+        foreach (var changedDocId in changedSolution.GetChanges(project.Solution).GetProjectChanges()
+            .SelectMany(pc => pc.GetChangedDocuments()))
+        {
+            var originalDoc = project.Solution.GetDocument(changedDocId);
+            var changedDoc = changedSolution.GetDocument(changedDocId);
+            if (originalDoc == null || changedDoc == null) continue;
+
+            var originalText = await originalDoc.GetTextAsync(ct);
+            var changedText = await changedDoc.GetTextAsync(ct);
+            var changes = changedText.GetTextChanges(originalText);
+
+            foreach (var change in changes)
+            {
+                var startLine = originalText.Lines.GetLinePosition(change.Span.Start);
+                var endLine = originalText.Lines.GetLinePosition(change.Span.End);
+
+                edits.Add(new TextEdit(
+                    originalDoc.FilePath ?? "",
+                    startLine.Line + 1, startLine.Character + 1,
+                    endLine.Line + 1, endLine.Character + 1,
+                    change.NewText ?? ""));
+            }
+        }
+
+        return edits;
     }
 
     private static List<CodeFixProvider> GetCodeFixProviders(Project project, string diagnosticId)
@@ -96,8 +104,9 @@ public class CodeFixRunner
             {
                 assembly = Assembly.LoadFrom(fullPath);
             }
-            catch
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"[roslyn-codegraph] Failed to load analyzer assembly '{fullPath}': {ex.Message}");
                 continue;
             }
 
@@ -110,8 +119,9 @@ public class CodeFixRunner
             {
                 types = ex.Types.Where(t => t != null).ToArray()!;
             }
-            catch
+            catch (Exception ex)
             {
+                Console.Error.WriteLine($"[roslyn-codegraph] Failed to get types from '{fullPath}': {ex.Message}");
                 continue;
             }
 
@@ -134,8 +144,9 @@ public class CodeFixRunner
                 {
                     instance = (CodeFixProvider)Activator.CreateInstance(type)!;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Console.Error.WriteLine($"[roslyn-codegraph] Failed to create CodeFix provider '{type.Name}': {ex.Message}");
                     continue;
                 }
 

--- a/src/RoslynCodeGraph/FileChangeTracker.cs
+++ b/src/RoslynCodeGraph/FileChangeTracker.cs
@@ -16,33 +16,9 @@ public class FileChangeTracker : IDisposable
 
     public FileChangeTracker(LoadedSolution loaded, string solutionPath)
     {
-        // Build file-to-project mapping
         _fileToProject = new Dictionary<string, ProjectId>(StringComparer.OrdinalIgnoreCase);
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var doc in project.Documents)
-            {
-                if (doc.FilePath != null)
-                    _fileToProject[doc.FilePath] = project.Id;
-            }
-            if (project.FilePath != null)
-                _fileToProject[project.FilePath] = project.Id;
-        }
-
-        // Build reverse dependency graph: if A references B, then B → [A]
         _reverseDeps = new Dictionary<ProjectId, List<ProjectId>>();
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var projRef in project.ProjectReferences)
-            {
-                if (!_reverseDeps.TryGetValue(projRef.ProjectId, out var dependents))
-                {
-                    dependents = new List<ProjectId>();
-                    _reverseDeps[projRef.ProjectId] = dependents;
-                }
-                dependents.Add(project.Id);
-            }
-        }
+        PopulateMappings(loaded);
 
         // Start file watchers
         var solutionDir = Path.GetDirectoryName(solutionPath)!;
@@ -80,19 +56,19 @@ public class FileChangeTracker : IDisposable
         get { lock (_lock) return new HashSet<ProjectId>(_staleProjects); }
     }
 
-    public ProjectId? FindProjectForFile(string filePath)
-    {
-        lock (_lock)
-        {
-            return _fileToProject.TryGetValue(filePath, out var id) ? id : null;
-        }
-    }
-
     public void MarkProjectStale(ProjectId projectId)
     {
         lock (_lock)
         {
             MarkStaleTransitive(projectId);
+        }
+    }
+
+    public ProjectId? FindProjectForFile(string filePath)
+    {
+        lock (_lock)
+        {
+            return _fileToProject.TryGetValue(filePath, out var id) ? id : null;
         }
     }
 
@@ -109,29 +85,34 @@ public class FileChangeTracker : IDisposable
         lock (_lock)
         {
             _fileToProject.Clear();
-            foreach (var project in loaded.Solution.Projects)
-            {
-                foreach (var doc in project.Documents)
-                {
-                    if (doc.FilePath != null)
-                        _fileToProject[doc.FilePath] = project.Id;
-                }
-                if (project.FilePath != null)
-                    _fileToProject[project.FilePath] = project.Id;
-            }
-
             _reverseDeps.Clear();
-            foreach (var project in loaded.Solution.Projects)
+            PopulateMappings(loaded);
+        }
+    }
+
+    private void PopulateMappings(LoadedSolution loaded)
+    {
+        foreach (var project in loaded.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
             {
-                foreach (var projRef in project.ProjectReferences)
+                if (doc.FilePath != null)
+                    _fileToProject[doc.FilePath] = project.Id;
+            }
+            if (project.FilePath != null)
+                _fileToProject[project.FilePath] = project.Id;
+        }
+
+        foreach (var project in loaded.Solution.Projects)
+        {
+            foreach (var projRef in project.ProjectReferences)
+            {
+                if (!_reverseDeps.TryGetValue(projRef.ProjectId, out var dependents))
                 {
-                    if (!_reverseDeps.TryGetValue(projRef.ProjectId, out var dependents))
-                    {
-                        dependents = new List<ProjectId>();
-                        _reverseDeps[projRef.ProjectId] = dependents;
-                    }
-                    dependents.Add(project.Id);
+                    dependents = new List<ProjectId>();
+                    _reverseDeps[projRef.ProjectId] = dependents;
                 }
+                dependents.Add(project.Id);
             }
         }
     }
@@ -169,24 +150,20 @@ public class FileChangeTracker : IDisposable
 
     private void ProcessPendingChanges(object? state)
     {
-        HashSet<string> changes;
         lock (_lock)
         {
-            changes = new HashSet<string>(_pendingChanges);
+            var changes = new HashSet<string>(_pendingChanges);
             _pendingChanges.Clear();
-        }
 
-        foreach (var filePath in changes)
-        {
-            var projectId = FindProjectForFile(filePath);
-            if (projectId != null)
+            foreach (var filePath in changes)
             {
-                MarkProjectStale(projectId);
-            }
-            else
-            {
-                lock (_lock)
+                if (_fileToProject.TryGetValue(filePath, out var projectId))
                 {
+                    MarkStaleTransitive(projectId);
+                }
+                else
+                {
+                    // Unknown file — mark all projects stale
                     foreach (var pid in _fileToProject.Values.Distinct())
                         _staleProjects.Add(pid);
                 }

--- a/src/RoslynCodeGraph/SolutionManager.cs
+++ b/src/RoslynCodeGraph/SolutionManager.cs
@@ -10,6 +10,7 @@ public class SolutionManager : IDisposable
     private readonly string? _solutionPath;
     private readonly FileChangeTracker? _tracker;
     private readonly object _lock = new();
+    private volatile bool _rebuilding;
 
     private SolutionManager(LoadedSolution loaded, string? solutionPath)
     {
@@ -63,23 +64,32 @@ public class SolutionManager : IDisposable
         lock (_lock)
         {
             // Double-check after acquiring lock
-            if (!_tracker.HasStaleProjects)
+            if (_tracker == null || !_tracker.HasStaleProjects || _rebuilding)
                 return;
 
-            var staleIds = _tracker.StaleProjectIds;
+            _rebuilding = true;
+        }
+
+        // Rebuild outside the lock to avoid blocking other reads
+        var staleIds = _tracker.StaleProjectIds;
+        Console.Error.WriteLine(
+            $"[roslyn-codegraph] Rebuilding {staleIds.Count} stale project(s)...");
+
+        try
+        {
+            RebuildStaleProjects(staleIds).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
             Console.Error.WriteLine(
-                $"[roslyn-codegraph] Rebuilding {staleIds.Count} stale project(s)...");
-
-            try
+                $"[roslyn-codegraph] Rebuild failed: {ex}. Using cached data.");
+        }
+        finally
+        {
+            lock (_lock)
             {
-                RebuildStaleProjects(staleIds).GetAwaiter().GetResult();
+                _rebuilding = false;
             }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[roslyn-codegraph] Rebuild failed: {ex.Message}. Using cached data.");
-            }
-
             _tracker.ClearStale();
         }
     }
@@ -104,13 +114,20 @@ public class SolutionManager : IDisposable
                 compilations[project.Id] = compilation;
         }
 
-        _loaded = new LoadedSolution
+        var newLoaded = new LoadedSolution
         {
             Solution = solution,
             Compilations = compilations
         };
-        _resolver = new SymbolResolver(_loaded);
-        _tracker!.UpdateMappings(_loaded);
+        var newResolver = new SymbolResolver(newLoaded);
+
+        lock (_lock)
+        {
+            _loaded = newLoaded;
+            _resolver = newResolver;
+        }
+
+        _tracker!.UpdateMappings(newLoaded);
 
         Console.Error.WriteLine("[roslyn-codegraph] Rebuild complete.");
     }

--- a/src/RoslynCodeGraph/SymbolResolver.cs
+++ b/src/RoslynCodeGraph/SymbolResolver.cs
@@ -20,7 +20,20 @@ public class SymbolResolver
     {
         _loaded = loaded;
 
-        // Build cached type lists once
+        _allTypes = CollectAllTypes(loaded);
+        (_typesBySimpleName, _typesByFullName) = BuildTypeLookups(_allTypes);
+        (_fileToProjectName, _projectIdToName) = BuildProjectLookups(loaded);
+        (_interfaceImplementors, _derivedTypes) = BuildInheritanceMaps(_allTypes);
+
+        _membersBySimpleName = new Dictionary<string, List<ISymbol>>(StringComparer.OrdinalIgnoreCase);
+        _attributeIndex = new Dictionary<string, List<(ISymbol, AttributeData)>>(StringComparer.OrdinalIgnoreCase);
+        BuildMemberAndAttributeIndexes();
+
+        _generatedFilePaths = BuildGeneratedFileIndex(loaded);
+    }
+
+    private static List<INamedTypeSymbol> CollectAllTypes(LoadedSolution loaded)
+    {
         var allTypes = new List<INamedTypeSymbol>();
         var seen = new HashSet<string>();
 
@@ -28,87 +41,94 @@ public class SymbolResolver
         {
             foreach (var type in GetAllTypes(compilation.GlobalNamespace))
             {
-                var fullName = type.ToDisplayString();
-                if (seen.Add(fullName))
+                if (seen.Add(type.ToDisplayString()))
                     allTypes.Add(type);
             }
         }
 
-        _allTypes = allTypes;
+        return allTypes;
+    }
 
-        // Build lookup dictionaries
-        _typesBySimpleName = new Dictionary<string, List<INamedTypeSymbol>>();
-        _typesByFullName = new Dictionary<string, INamedTypeSymbol>();
+    private static (Dictionary<string, List<INamedTypeSymbol>>, Dictionary<string, INamedTypeSymbol>)
+        BuildTypeLookups(List<INamedTypeSymbol> allTypes)
+    {
+        var bySimple = new Dictionary<string, List<INamedTypeSymbol>>();
+        var byFull = new Dictionary<string, INamedTypeSymbol>();
 
-        foreach (var type in _allTypes)
+        foreach (var type in allTypes)
         {
-            var fullName = type.ToDisplayString();
-            _typesByFullName[fullName] = type;
+            byFull[type.ToDisplayString()] = type;
 
-            if (!_typesBySimpleName.TryGetValue(type.Name, out var list))
+            if (!bySimple.TryGetValue(type.Name, out var list))
             {
                 list = new List<INamedTypeSymbol>();
-                _typesBySimpleName[type.Name] = list;
+                bySimple[type.Name] = list;
             }
             list.Add(type);
         }
 
-        // Build file-to-project lookup
-        _fileToProjectName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        return (bySimple, byFull);
+    }
+
+    private static (Dictionary<string, string>, Dictionary<ProjectId, string>)
+        BuildProjectLookups(LoadedSolution loaded)
+    {
+        var fileToProject = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var idToName = new Dictionary<ProjectId, string>();
+
         foreach (var project in loaded.Solution.Projects)
         {
+            idToName[project.Id] = project.Name;
             foreach (var doc in project.Documents)
             {
                 if (doc.FilePath != null)
-                    _fileToProjectName[doc.FilePath] = project.Name;
+                    fileToProject[doc.FilePath] = project.Name;
             }
         }
 
-        // Build ProjectId-to-name lookup
-        _projectIdToName = new Dictionary<ProjectId, string>();
-        foreach (var project in loaded.Solution.Projects)
-            _projectIdToName[project.Id] = project.Name;
+        return (fileToProject, idToName);
+    }
 
-        // Build reverse inheritance maps
+    private static (Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>,
+                     Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>)
+        BuildInheritanceMaps(List<INamedTypeSymbol> allTypes)
+    {
         var comparer = SymbolEqualityComparer.Default;
-        _interfaceImplementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
-        _derivedTypes = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
+        var implementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
+        var derived = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
 
-        foreach (var type in _allTypes)
+        foreach (var type in allTypes)
         {
-            // Index interface implementations
             foreach (var iface in type.AllInterfaces)
             {
-                if (!_interfaceImplementors.TryGetValue(iface, out var implList))
+                if (!implementors.TryGetValue(iface, out var implList))
                 {
                     implList = new List<INamedTypeSymbol>();
-                    _interfaceImplementors[iface] = implList;
+                    implementors[iface] = implList;
                 }
                 implList.Add(type);
             }
 
-            // Index direct base type → derived
             var baseType = type.BaseType;
             while (baseType != null && baseType.SpecialType != SpecialType.System_Object)
             {
-                if (!_derivedTypes.TryGetValue(baseType, out var derivedList))
+                if (!derived.TryGetValue(baseType, out var derivedList))
                 {
                     derivedList = new List<INamedTypeSymbol>();
-                    _derivedTypes[baseType] = derivedList;
+                    derived[baseType] = derivedList;
                 }
                 derivedList.Add(type);
                 baseType = baseType.BaseType;
             }
         }
 
-        // Build member name index for fast search
-        _membersBySimpleName = new Dictionary<string, List<ISymbol>>(StringComparer.OrdinalIgnoreCase);
-        // Build attribute index keyed by attribute simple name (without "Attribute" suffix)
-        _attributeIndex = new Dictionary<string, List<(ISymbol, AttributeData)>>(StringComparer.OrdinalIgnoreCase);
+        return (implementors, derived);
+    }
 
+    private void BuildMemberAndAttributeIndexes()
+    {
         foreach (var type in _allTypes)
         {
-            // Index type-level attributes
             IndexAttributes(type);
 
             foreach (var member in type.GetMembers())
@@ -116,7 +136,6 @@ public class SymbolResolver
                 if (member.IsImplicitlyDeclared || string.IsNullOrEmpty(member.Name))
                     continue;
 
-                // Index member-level attributes
                 IndexAttributes(member);
 
                 if (member is IMethodSymbol { MethodKind: MethodKind.PropertyGet or MethodKind.PropertySet or MethodKind.EventAdd or MethodKind.EventRemove })
@@ -130,18 +149,20 @@ public class SymbolResolver
                 memberList.Add(member);
             }
         }
+    }
 
-        // Build generated file path index
-        _generatedFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    private static HashSet<string> BuildGeneratedFileIndex(LoadedSolution loaded)
+    {
+        var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var compilation in loaded.Compilations.Values)
         {
             foreach (var tree in compilation.SyntaxTrees)
             {
-                var path = tree.FilePath;
-                if (IsGeneratedPath(path))
-                    _generatedFilePaths.Add(path);
+                if (IsGeneratedPath(tree.FilePath))
+                    paths.Add(tree.FilePath);
             }
         }
+        return paths;
     }
 
     private void IndexAttributes(ISymbol symbol)

--- a/src/RoslynCodeGraph/Tools/FindCircularDependenciesTool.cs
+++ b/src/RoslynCodeGraph/Tools/FindCircularDependenciesTool.cs
@@ -39,92 +39,63 @@ public static class FindCircularDependenciesLogic
 
     private static List<CircularDependency> FindNamespaceCycles(LoadedSolution loaded)
     {
-        // Collect all namespaces defined in the solution
         var definedNamespaces = new HashSet<string>(StringComparer.Ordinal);
-        // Map: namespace -> set of namespaces it depends on (via using directives)
-        var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var adjacency = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
 
-        foreach (var project in loaded.Solution.Projects)
+        // Single pass: collect namespaces and build adjacency from syntax trees
+        foreach (var (_, compilation) in loaded.Compilations)
         {
-            foreach (var document in project.Documents)
+            foreach (var syntaxTree in compilation.SyntaxTrees)
             {
-                var tree = document.GetSyntaxTreeAsync().GetAwaiter().GetResult();
-                if (tree == null) continue;
+                var root = syntaxTree.GetRoot();
 
-                var root = tree.GetRoot();
+                // Collect file-level usings
+                var fileUsings = new List<string>();
+                foreach (var usingDirective in root.ChildNodes().OfType<UsingDirectiveSyntax>())
+                {
+                    var name = usingDirective.Name?.ToString();
+                    if (name != null)
+                        fileUsings.Add(name);
+                }
 
-                // Collect namespace declarations
+                // Process each namespace declaration
                 foreach (var nsDecl in root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>())
                 {
                     var nsName = nsDecl.Name.ToString();
                     definedNamespaces.Add(nsName);
-                }
-            }
-        }
 
-        // Build adjacency from using directives within each namespace
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var document in project.Documents)
-            {
-                var tree = document.GetSyntaxTreeAsync().GetAwaiter().GetResult();
-                if (tree == null) continue;
-
-                var root = tree.GetRoot();
-
-                // Get file-level usings and associate with namespaces in this file
-                var fileUsings = root.DescendantNodes().OfType<UsingDirectiveSyntax>()
-                    .Where(u => u.Parent is CompilationUnitSyntax)
-                    .Select(u => u.Name?.ToString())
-                    .Where(n => n != null && definedNamespaces.Contains(n))
-                    .ToList();
-
-                var namespacesInFile = root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
-                    .Select(ns => ns.Name.ToString())
-                    .ToList();
-
-                foreach (var ns in namespacesInFile)
-                {
-                    if (!adjacency.TryGetValue(ns, out var deps))
+                    if (!adjacency.TryGetValue(nsName, out var deps))
                     {
-                        deps = new List<string>();
-                        adjacency[ns] = deps;
+                        deps = new HashSet<string>(StringComparer.Ordinal);
+                        adjacency[nsName] = deps;
                     }
 
-                    // Add file-level usings as dependencies (exclude self-references)
-                    foreach (var usingNs in fileUsings)
+                    // Add file-level usings (will filter to defined namespaces later)
+                    foreach (var u in fileUsings)
                     {
-                        if (usingNs != null && !usingNs.Equals(ns, StringComparison.Ordinal))
-                            deps.Add(usingNs);
+                        if (!u.Equals(nsName, StringComparison.Ordinal))
+                            deps.Add(u);
                     }
 
                     // Add namespace-level usings
-                    var nsDecl = root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()
-                        .FirstOrDefault(n => n.Name.ToString() == ns);
-
-                    if (nsDecl != null)
+                    foreach (var usingDirective in nsDecl.ChildNodes().OfType<UsingDirectiveSyntax>())
                     {
-                        foreach (var usingDirective in nsDecl.DescendantNodes().OfType<UsingDirectiveSyntax>())
-                        {
-                            var usingName = usingDirective.Name?.ToString();
-                            if (usingName != null && definedNamespaces.Contains(usingName) &&
-                                !usingName.Equals(ns, StringComparison.Ordinal))
-                            {
-                                deps.Add(usingName);
-                            }
-                        }
+                        var usingName = usingDirective.Name?.ToString();
+                        if (usingName != null && !usingName.Equals(nsName, StringComparison.Ordinal))
+                            deps.Add(usingName);
                     }
                 }
             }
         }
 
-        // Deduplicate adjacency lists
-        foreach (var key in adjacency.Keys)
+        // Filter adjacency to only include defined namespaces
+        var filtered = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var (ns, deps) in adjacency)
         {
-            adjacency[key] = adjacency[key].Distinct(StringComparer.Ordinal).ToList();
+            filtered[ns] = deps.Where(d => definedNamespaces.Contains(d)).ToList();
         }
 
-        return DetectCycles(adjacency, "namespace");
+        return DetectCycles(filtered, "namespace");
     }
 
     private static List<CircularDependency> DetectCycles(Dictionary<string, List<string>> adjacency, string level)

--- a/src/RoslynCodeGraph/Tools/FindLargeClassesTool.cs
+++ b/src/RoslynCodeGraph/Tools/FindLargeClassesTool.cs
@@ -44,8 +44,9 @@ public static class FindLargeClassesLogic
         if (syntaxRef == null) return 0;
         var span = syntaxRef.Span;
         var tree = syntaxRef.SyntaxTree;
-        var startLine = tree.GetLineSpan(span).StartLinePosition.Line;
-        var endLine = tree.GetLineSpan(span).EndLinePosition.Line;
+        var lineSpan = tree.GetLineSpan(span);
+        var startLine = lineSpan.StartLinePosition.Line;
+        var endLine = lineSpan.EndLinePosition.Line;
         return endLine - startLine + 1;
     }
 }


### PR DESCRIPTION
## Summary

- **FileChangeTracker**: Fix race condition in `ProcessPendingChanges` by keeping lock for entire operation; extract duplicated constructor/UpdateMappings code into `PopulateMappings` helper
- **SolutionManager**: Move async rebuild outside lock to avoid blocking reads; log full exception instead of just `Message`
- **CodeFixRunner**: Add exception logging to all 4 bare `catch` blocks; extract `ExtractTextEdits` helper to reduce method length
- **SymbolResolver**: Extract 127-line constructor into 6 focused helper methods
- **FindCircularDependencies**: Eliminate blocking async by using compilation syntax trees directly; single-pass namespace collection; use HashSet for O(1) dedup
- **FindLargeClassesTool**: Deduplicate `GetLineSpan` call

## Test plan

- [x] 72 unit tests passing
- [x] Full benchmark suite — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)