### PR TITLE
feat: add rebuild_solution MCP tool

### DIFF
--- a/plugins/roslyn-codegraph/skills/roslyn-codegraph/SKILL.md
+++ b/plugins/roslyn-codegraph/skills/roslyn-codegraph/SKILL.md
@@ -64,6 +64,10 @@ Use these tools **instead of Grep/Glob and instead of MSBuild** whenever you nee
 - Use `get_source_generators` to list source generators and their output per project (optional project filter)
 - Use `get_generated_code` to inspect generated source code from source generators (filter by generator name or file path)
 
+### Solution Management
+
+- Use `rebuild_solution` to force a full reload of the analyzed solution — re-opens the `.sln`, recompiles all projects, and rebuilds all indexes. Use after changing `Directory.Build.props`, adding/removing NuGet packages or analyzers, or when diagnostics seem stale.
+
 ### Planning Changes
 
 Before modifying code, use these tools to understand the impact:
@@ -106,3 +110,4 @@ Reference concrete types, interfaces, and call sites in your analysis. Example: 
 | `find_circular_dependencies` | "Any circular dependencies?" |
 | `get_source_generators` | "What source generators are active?" / "List generators for this project" |
 | `get_generated_code` | "Show generated code" / "What did this generator produce?" |
+| `rebuild_solution` | "Reload the solution" / "Pick up new analyzers" / "Diagnostics are stale" |

--- a/src/RoslynCodeGraph/SolutionManager.cs
+++ b/src/RoslynCodeGraph/SolutionManager.cs
@@ -132,6 +132,30 @@ public sealed class SolutionManager : IDisposable
         await Console.Error.WriteLineAsync("[roslyn-codegraph] Rebuild complete.").ConfigureAwait(false);
     }
 
+    public async Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync()
+    {
+        if (_solutionPath == null)
+            throw new InvalidOperationException("No solution path configured. Cannot reload.");
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+
+        var loader = new SolutionLoader();
+        var newLoaded = await loader.LoadAsync(_solutionPath).ConfigureAwait(false);
+        var newResolver = new SymbolResolver(newLoaded);
+
+        lock (_lock)
+        {
+            _loaded = newLoaded;
+            _resolver = newResolver;
+        }
+
+        _tracker?.UpdateMappings(newLoaded);
+        _tracker?.ClearStale();
+
+        sw.Stop();
+        return (newLoaded.Compilations.Count, sw.Elapsed);
+    }
+
     public void Dispose()
     {
         _tracker?.Dispose();

--- a/src/RoslynCodeGraph/Tools/RebuildSolutionTool.cs
+++ b/src/RoslynCodeGraph/Tools/RebuildSolutionTool.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynCodeGraph.Tools;
+
+[McpServerToolType]
+public static class RebuildSolutionTool
+{
+    [McpServerTool(Name = "rebuild_solution"),
+     Description("Force a full reload of the analyzed solution — re-opens the .sln, recompiles all projects, and rebuilds all indexes. Use after changing Directory.Build.props, adding/removing NuGet packages, or when diagnostics seem stale.")]
+    public static async Task<string> Execute(SolutionManager manager)
+    {
+        manager.EnsureLoaded();
+        var (projectCount, elapsed) = await manager.ForceReloadAsync().ConfigureAwait(false);
+        return $"Rebuild complete. {projectCount} project(s) compiled in {elapsed.TotalSeconds:F1}s.";
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `rebuild_solution` MCP tool that forces a full reload of the analyzed solution (re-open `.sln`, recompile all projects, rebuild indexes)
- Adds `ForceReloadAsync()` method to `SolutionManager`
- Updates SKILL.md with new "Solution Management" section and quick reference entry

Use case: after changing `Directory.Build.props`, adding/removing NuGet packages or analyzers, call `rebuild_solution` to pick up changes without restarting the server.

## Test plan
- [x] Build succeeds with no compile errors
- [x] All 74 unit tests pass
- [x] Manual: call `rebuild_solution` after modifying `Directory.Build.props` and verify new diagnostics appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)