### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 1.0.0
 mode: ContinuousDeployment
 branches:
   main:


### PR DESCRIPTION
## Summary

- Set `next-version: 1.0.0` in GitVersion.yml to mark the first stable release of RoslynCodeLens.Mcp

## Changes

- `GitVersion.yml`: added `next-version: 1.0.0`

## Test plan

- [ ] CI passes
- [ ] After merge, release workflow produces v1.0.0 tag and NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)