### PR TITLE
docs: update project name to Roslyn CodeLens and fix tool count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Roslyn Code Graph MCP
+# Roslyn CodeLens MCP
 
 This is a Roslyn-based MCP server that provides semantic code intelligence for .NET codebases.
 
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 21 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 22 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Roslyn Code Graph MCP Server
+# Roslyn CodeLens MCP Server
 
-A Roslyn-based MCP server that provides 21 semantic code intelligence tools for .NET codebases. Designed for use with Claude Code to understand type hierarchies, call sites, DI registrations, and reflection usage.
+A Roslyn-based MCP server that provides 22 semantic code intelligence tools for .NET codebases. Designed for use with Claude Code to understand type hierarchies, call sites, DI registrations, and reflection usage.
 
 ## Features
 

--- a/plugins/roslyn-codelens/README.md
+++ b/plugins/roslyn-codelens/README.md
@@ -1,4 +1,4 @@
-# Roslyn Code Graph Plugin
+# Roslyn CodeLens Plugin
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Update project title from "Roslyn Code Graph" to "Roslyn CodeLens" in README.md, CLAUDE.md, and plugin README.md
- Fix tool count from 21 to 22 (rebuild_solution was added but docs weren't updated)

## Test plan
- [ ] Verify README, CLAUDE.md, and plugin README reflect correct naming and tool count

🤖 Generated with [Claude Code](https://claude.com/claude-code)