### PR TITLE
fix: suppress hosting framework log noise on stderr

### DIFF
--- a/src/RoslynCodeLens/Program.cs
+++ b/src/RoslynCodeLens/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using RoslynCodeLens;
 
@@ -23,6 +24,7 @@ else
 }
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
 builder.Services.AddSingleton(manager);
 
 builder.Services


### PR DESCRIPTION
## Summary
- Clear default logging providers in `Program.cs` to prevent `Microsoft.Extensions.Hosting` info lines from polluting stderr
- VS Code's MCP client was showing "Failed to parse message" warnings for every hosting framework log line

## Test plan
- [x] Builds successfully
- [x] MCP server still starts and discovers 22 tools
- [x] No more `info: Microsoft.Hosting.Lifetime` noise on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)