### PR TITLE
feat: add project icon

### DIFF
--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a40"/>
+      <stop offset="100%" stop-color="#1b1b3a"/>
+    </linearGradient>
+    <linearGradient id="purple-blue" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <linearGradient id="lens-glass" x1="0.2" y1="0" x2="0.8" y2="1">
+      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0.06"/>
+    </linearGradient>
+    <linearGradient id="lens-ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#67e8f9"/>
+    </linearGradient>
+    <linearGradient id="handle" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="node-top" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="node-mid" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="node-bot" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+    <!-- Glow filter for nodes -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="lens-glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect x="16" y="16" width="480" height="480" rx="72" ry="72" fill="url(#bg)"/>
+  <!-- Subtle border -->
+  <rect x="16" y="16" width="480" height="480" rx="72" ry="72" fill="none" stroke="#a78bfa" stroke-opacity="0.15" stroke-width="2"/>
+
+  <!-- === MAGNIFYING GLASS (main element) === -->
+  <!-- Lens glass -->
+  <circle cx="230" cy="230" r="130" fill="url(#lens-glass)" filter="url(#lens-glow)"/>
+  <!-- Lens ring -->
+  <circle cx="230" cy="230" r="130" fill="none" stroke="url(#lens-ring)" stroke-width="7" stroke-opacity="0.8"/>
+  <!-- Glass shine -->
+  <ellipse cx="185" cy="180" rx="45" ry="28" fill="white" opacity="0.06" transform="rotate(-35 185 180)"/>
+
+  <!-- Handle -->
+  <line x1="322" y1="322" x2="420" y2="420" stroke="#2a2050" stroke-width="28" stroke-linecap="round"/>
+  <line x1="322" y1="322" x2="420" y2="420" stroke="url(#handle)" stroke-width="20" stroke-linecap="round"/>
+  <!-- Handle highlight -->
+  <line x1="325" y1="319" x2="410" y2="404" stroke="#a78bfa" stroke-width="4" stroke-linecap="round" opacity="0.3"/>
+
+  <!-- === CODE GRAPH (inside the lens) === -->
+
+  <!-- Graph edges -->
+  <line x1="230" y1="150" x2="165" y2="230" stroke="#8b5cf6" stroke-width="3" stroke-opacity="0.6"/>
+  <line x1="230" y1="150" x2="295" y2="230" stroke="#8b5cf6" stroke-width="3" stroke-opacity="0.6"/>
+  <line x1="165" y1="230" x2="295" y2="230" stroke="#6366f1" stroke-width="2.5" stroke-opacity="0.4"/>
+  <line x1="165" y1="230" x2="190" y2="310" stroke="#06b6d4" stroke-width="3" stroke-opacity="0.5"/>
+  <line x1="295" y1="230" x2="270" y2="310" stroke="#06b6d4" stroke-width="3" stroke-opacity="0.5"/>
+  <line x1="190" y1="310" x2="270" y2="310" stroke="#22d3ee" stroke-width="2" stroke-opacity="0.35"/>
+
+  <!-- Code brackets inside the lens -->
+  <text x="196" y="268" font-family="'Cascadia Code', 'Fira Code', Consolas, monospace" font-size="90" font-weight="bold" fill="#e0e7ff" text-anchor="middle" opacity="0.25">{</text>
+  <text x="268" y="268" font-family="'Cascadia Code', 'Fira Code', Consolas, monospace" font-size="90" font-weight="bold" fill="#e0e7ff" text-anchor="middle" opacity="0.25">}</text>
+
+  <!-- Graph nodes (glowing) -->
+  <!-- Top -->
+  <circle cx="230" cy="150" r="16" fill="url(#node-top)" filter="url(#glow)"/>
+  <circle cx="230" cy="150" r="6" fill="#ede9fe" opacity="0.9"/>
+  <!-- Mid-left -->
+  <circle cx="165" cy="230" r="13" fill="url(#node-mid)" filter="url(#glow)"/>
+  <circle cx="165" cy="230" r="5" fill="#e0e7ff" opacity="0.8"/>
+  <!-- Mid-right -->
+  <circle cx="295" cy="230" r="13" fill="url(#node-mid)" filter="url(#glow)"/>
+  <circle cx="295" cy="230" r="5" fill="#e0e7ff" opacity="0.8"/>
+  <!-- Bottom-left -->
+  <circle cx="190" cy="310" r="10" fill="url(#node-bot)" filter="url(#glow)"/>
+  <circle cx="190" cy="310" r="4" fill="#ecfeff" opacity="0.9"/>
+  <!-- Bottom-right -->
+  <circle cx="270" cy="310" r="10" fill="url(#node-bot)" filter="url(#glow)"/>
+  <circle cx="270" cy="310" r="4" fill="#ecfeff" opacity="0.9"/>
+</svg>


### PR DESCRIPTION
## Summary
- Adds an SVG project icon featuring a magnifying glass with code graph nodes inside
- Represents the CodeLens concept: inspecting code relationships and structure
- Purple-to-cyan gradient theme on a dark background

## Test plan
- [x] Open `icon.svg` in a browser to verify rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)