### PR TITLE
feat: add McpServer NuGet package type

### DIFF
--- a/src/RoslynCodeLens/.mcp/server.json
+++ b/src/RoslynCodeLens/.mcp/server.json
@@ -1,0 +1,5 @@
+{
+  "type": "stdio",
+  "command": "dnx",
+  "args": ["RoslynCodeLens.Mcp", "--yes"]
+}

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -15,11 +15,13 @@
     <PackageTags>roslyn;mcp;code-analysis;dotnet-tool</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageType>DotnetTool;McpServer</PackageType>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="/" />
     <None Include="../../icon.png" Pack="true" PackagePath="/" />
+    <None Include=".mcp/server.json" Pack="true" PackagePath=".mcp/" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `McpServer` package type to the csproj so nuget.org surfaces the package in MCP-specific browsing
- Embeds `.mcp/server.json` in the nupkg for VS Code / Visual Studio auto-configuration
- Enables `dnx RoslynCodeLens.Mcp --yes` discovery flow

## Test plan
- [x] Verified `dotnet pack` produces nupkg with `McpServer` packageType and `.mcp/server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)