### PR TITLE
fix: use correct .mcp/server.json schema for NuGet MCP discovery

### DIFF
--- a/src/RoslynCodeLens/.mcp/server.json
+++ b/src/RoslynCodeLens/.mcp/server.json
@@ -2,13 +2,13 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.github.marcelroozekrans/roslyn-codelens",
   "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
-  "version": "1.0.7",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
-      "version": "1.0.7",
+      "version": "0.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/RoslynCodeLens/.mcp/server.json
+++ b/src/RoslynCodeLens/.mcp/server.json
@@ -1,5 +1,19 @@
 {
-  "type": "stdio",
-  "command": "dnx",
-  "args": ["RoslynCodeLens.Mcp", "--yes"]
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.github.marcelroozekrans/roslyn-codelens",
+  "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
+  "version": "1.0.7",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "RoslynCodeLens.Mcp",
+      "version": "1.0.7",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    }
+  ]
 }

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -36,6 +36,26 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Stamp the package version into .mcp/server.json before packing -->
+  <UsingTask TaskName="StampMcpVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FilePath ParameterType="System.String" Required="true" />
+      <PackageVersion ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        var content = File.ReadAllText(FilePath);
+        content = System.Text.RegularExpressions.Regex.Replace(
+            content, @"""version""\s*:\s*""[^""]*""", $@"""version"": ""{PackageVersion}""");
+        File.WriteAllText(FilePath, content);
+      </Code>
+    </Task>
+  </UsingTask>
+  <Target Name="StampMcpServerJsonVersion" BeforeTargets="GenerateNuspec">
+    <StampMcpVersion FilePath="$(MSBuildProjectDirectory)/.mcp/server.json" PackageVersion="$(Version)" />
+  </Target>
+
   <!-- MSBuild.Locator requires these to be excluded from runtime -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />


### PR DESCRIPTION
## Summary
- Fixes the `.mcp/server.json` to use the full MCP registry schema that NuGet expects
- Previous format was a simplified version that NuGet couldn't parse, causing the "missing NuGet entry" warning on the MCP Server tab

## Changes
The `server.json` now matches the format used by `NuGet.Mcp.Server` with:
- `$schema` reference
- `packages` array with `registryType`, `registryBaseUrl`, `identifier`, `version`, and `transport`

## Test plan
- [ ] Publish to NuGet and verify the MCP Server tab generates the VS Code config entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)