### PR TITLE
chore: add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
   A Roslyn-based MCP server that gives AI agents deep semantic understanding of .NET codebases — type hierarchies, call graphs, DI registrations, diagnostics, and more.
 </p>
 
+<a href="https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp/badge" alt="roslyn-codelens-mcp MCP server" />
+</a>
+
 <!-- mcp-name: io.github.marcelroozekrans/roslyn-codelens -->
 
 ---


### PR DESCRIPTION
This PR adds a badge for the [roslyn-codelens-mcp](https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp/badge" alt="roslyn-codelens-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.