### PR TITLE
ci: skip PR title validation on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   lint-pr-title:
+    if: github.event_name == 'pull_request'
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add `if: github.event_name == 'pull_request'` condition to the `lint-pr-title` job
- The job fails on push to main since there's no PR title to validate, causing the build badge to show failure

## Test plan
- [ ] Verify CI passes on this PR (lint-pr-title should still run)
- [ ] After merge, confirm the push-to-main workflow skips lint-pr-title and badge shows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)