### PR TITLE
feat: multi-solution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,17 @@ Then add to your MCP client config:
 
 ## Usage
 
-The server automatically discovers `.sln` files by walking up from the current directory. You can also pass a solution path directly:
+The server automatically discovers `.sln` files by walking up from the current directory. You can also pass one or more solution paths directly:
 
 ```bash
+# Single solution
 roslyn-codelens-mcp /path/to/MySolution.sln
+
+# Multiple solutions — switch between them with set_active_solution
+roslyn-codelens-mcp /path/to/A.sln /path/to/B.sln
 ```
+
+When multiple solutions are loaded, use `list_solutions` to see what's available and `set_active_solution("B")` to switch context. The first path is active by default.
 
 ## Performance
 

--- a/docs/plans/2026-03-13-multi-solution-design.md
+++ b/docs/plans/2026-03-13-multi-solution-design.md
@@ -1,0 +1,79 @@
+# Multi-Solution Support
+
+## Problem
+
+When the MCP server is installed as a global dotnet tool, a single process is shared across all VS Code windows. That process is started with one hardcoded solution path, so any second workspace ends up analysing the wrong solution.
+
+## Goal
+
+Allow the server to load N solutions at startup and expose two tools so Claude can select the right solution at the start of each session. All 22 existing tools remain unchanged.
+
+## Architecture
+
+### `MultiSolutionManager`
+
+New class that owns a `Dictionary<string, SolutionManager>` keyed by normalised solution path and tracks the currently active key.
+
+Exposes the same public API as `SolutionManager`:
+
+- `EnsureLoaded()`
+- `GetLoadedSolution()`
+- `GetResolver()`
+- `WaitForWarmupAsync()`
+- `ForceReloadAsync()`
+
+Each method delegates to the active `SolutionManager`. All 22 existing tools change only the injected parameter type from `SolutionManager` → `MultiSolutionManager`.
+
+### Startup (`Program.cs`)
+
+- Accept 0..N solution paths as CLI args (unchanged single-path and auto-discovery behaviour preserved when 0 or 1 arg is given).
+- Create one `SolutionManager` per path (warm-up runs in parallel as today).
+- Register `MultiSolutionManager` as the DI singleton.
+- Default active solution: first arg (or auto-discovered path).
+
+### DI
+
+`builder.Services.AddSingleton(multiManager)` — identical to today, just a different type.
+
+## New Tools
+
+### `list_solutions`
+
+Returns a list of all loaded solutions:
+
+```json
+[
+  { "path": "C:/A/A.sln", "isActive": true,  "projectCount": 5, "status": "ready"   },
+  { "path": "C:/B/B.sln", "isActive": false, "projectCount": 3, "status": "loading" }
+]
+```
+
+### `set_active_solution`
+
+Parameter: `name` (partial, case-insensitive match against the solution file name or full path).
+
+- Exact match preferred; fails with a clear error if ambiguous or not found.
+- Returns the full path of the newly active solution.
+
+## Configuration Example
+
+```json
+{
+  "mcpServers": {
+    "roslyn-codelens": {
+      "type": "stdio",
+      "command": "roslyn-codelens-mcp",
+      "args": [
+        "C:/Projects/ProjectA/A.sln",
+        "C:/Projects/ProjectB/B.sln"
+      ]
+    }
+  }
+}
+```
+
+## Backward Compatibility
+
+- Zero args → auto-discovery (unchanged).
+- One arg → single solution loaded, `MultiSolutionManager` wraps it (unchanged behaviour).
+- Multiple args → new multi-solution behaviour.

--- a/docs/plans/2026-03-13-multi-solution-implementation.md
+++ b/docs/plans/2026-03-13-multi-solution-implementation.md
@@ -1,0 +1,503 @@
+# Multi-Solution Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow the MCP server to load N solutions at startup and switch between them with `list_solutions` / `set_active_solution` tools.
+
+**Architecture:** Introduce `MultiSolutionManager` that owns a `Dictionary<string, SolutionManager>` and delegates all existing API calls to the active entry. Register it in DI; rename the injected parameter in all 22 tool files. Add two new tool files.
+
+**Tech Stack:** C# / xUnit / ModelContextProtocol SDK / MSBuild Roslyn workspace
+
+---
+
+### Task 1: Create `MultiSolutionManager` — single-solution wrapper
+
+**Files:**
+- Create: `src/RoslynCodeLens/MultiSolutionManager.cs`
+- Create: `tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs`
+
+**Step 1: Write the failing tests**
+
+Create `tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs`:
+
+```csharp
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class MultiSolutionManagerTests : IAsyncLifetime
+{
+    private string _solutionPath = null!;
+
+    public Task InitializeAsync()
+    {
+        _solutionPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateAsync_SinglePath_DelegatesEnsureLoaded()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        multi.EnsureLoaded(); // must not throw
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task GetLoadedSolution_ReturnsSolution()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        await multi.WaitForWarmupAsync();
+        Assert.False(multi.GetLoadedSolution().IsEmpty);
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task GetResolver_ReturnsResolver()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        await multi.WaitForWarmupAsync();
+        Assert.NotNull(multi.GetResolver());
+        multi.Dispose();
+    }
+
+    [Fact]
+    public void CreateEmpty_EnsureLoaded_Throws()
+    {
+        var multi = MultiSolutionManager.CreateEmpty();
+        Assert.Throws<InvalidOperationException>(() => multi.EnsureLoaded());
+        multi.Dispose();
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```
+dotnet test tests/RoslynCodeLens.Tests --filter "MultiSolutionManagerTests"
+```
+
+Expected: FAIL — `MultiSolutionManager` does not exist yet.
+
+**Step 3: Implement `MultiSolutionManager`**
+
+Create `src/RoslynCodeLens/MultiSolutionManager.cs`:
+
+```csharp
+namespace RoslynCodeLens;
+
+public sealed class MultiSolutionManager : IDisposable
+{
+    private readonly Dictionary<string, SolutionManager> _managers;
+    private string? _activeKey;
+
+    private MultiSolutionManager(Dictionary<string, SolutionManager> managers, string? activeKey)
+    {
+        _managers = managers;
+        _activeKey = activeKey;
+    }
+
+    public static async Task<MultiSolutionManager> CreateAsync(IReadOnlyList<string> solutionPaths)
+    {
+        if (solutionPaths.Count == 0)
+            return CreateEmpty();
+
+        var managers = new Dictionary<string, SolutionManager>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in solutionPaths)
+        {
+            var normalised = Path.GetFullPath(path);
+            managers[normalised] = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+        }
+
+        var firstKey = Path.GetFullPath(solutionPaths[0]);
+        return new MultiSolutionManager(managers, firstKey);
+    }
+
+    public static MultiSolutionManager CreateEmpty() =>
+        new([], null);
+
+    private SolutionManager Active =>
+        _activeKey != null && _managers.TryGetValue(_activeKey, out var m)
+            ? m
+            : SolutionManager.CreateEmpty();
+
+    public void EnsureLoaded() => Active.EnsureLoaded();
+    public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
+    public SymbolResolver GetResolver() => Active.GetResolver();
+    public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
+    public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
+
+    public void Dispose()
+    {
+        foreach (var m in _managers.Values)
+            m.Dispose();
+    }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+```
+dotnet test tests/RoslynCodeLens.Tests --filter "MultiSolutionManagerTests"
+```
+
+Expected: PASS (4 tests).
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/MultiSolutionManager.cs tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+git commit -m "feat: add MultiSolutionManager wrapping single solution"
+```
+
+---
+
+### Task 2: Add multi-solution capability — list and switch
+
+**Files:**
+- Modify: `src/RoslynCodeLens/MultiSolutionManager.cs`
+- Modify: `tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs`
+- Create: `src/RoslynCodeLens/Models/SolutionInfo.cs`
+
+**Step 1: Add `SolutionInfo` model**
+
+Create `src/RoslynCodeLens/Models/SolutionInfo.cs`:
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public sealed record SolutionInfo(
+    string Path,
+    bool IsActive,
+    int ProjectCount,
+    string Status);
+```
+
+**Step 2: Write failing tests**
+
+Add to `tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs`:
+
+```csharp
+[Fact]
+public async Task ListSolutions_ReturnsBothPaths_FirstIsActive()
+{
+    var multi = await MultiSolutionManager.CreateAsync([_solutionPath, _solutionPath]);
+    var list = multi.ListSolutions();
+    Assert.Equal(2, list.Count);
+    Assert.True(list[0].IsActive);
+    Assert.False(list[1].IsActive);
+    multi.Dispose();
+}
+
+[Fact]
+public async Task SetActiveSolution_ByPartialName_SwitchesActive()
+{
+    var multi = await MultiSolutionManager.CreateAsync([_solutionPath, _solutionPath]);
+    var switched = multi.SetActiveSolution("TestSolution");
+    Assert.Contains("TestSolution", switched, StringComparison.OrdinalIgnoreCase);
+    multi.Dispose();
+}
+
+[Fact]
+public async Task SetActiveSolution_UnknownName_Throws()
+{
+    var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+    Assert.Throws<InvalidOperationException>(() => multi.SetActiveSolution("DoesNotExist"));
+    multi.Dispose();
+}
+
+[Fact]
+public async Task SetActiveSolution_AmbiguousName_Throws()
+{
+    // Two paths that both contain "TestSolution"
+    var multi = await MultiSolutionManager.CreateAsync([_solutionPath, _solutionPath]);
+    // Both keys are the same normalised path so there's only one entry — use a path that differs
+    // This test verifies the ambiguity message is thrown when >1 key matches.
+    // We test indirectly: two identical paths dedup to one key, no ambiguity.
+    var switched = multi.SetActiveSolution("TestSolution"); // should succeed (only 1 unique key)
+    Assert.NotNull(switched);
+    multi.Dispose();
+}
+```
+
+**Step 3: Run tests to verify they fail**
+
+```
+dotnet test tests/RoslynCodeLens.Tests --filter "MultiSolutionManagerTests"
+```
+
+Expected: FAIL — `ListSolutions` and `SetActiveSolution` do not exist yet.
+
+**Step 4: Implement `ListSolutions` and `SetActiveSolution`**
+
+Add to `MultiSolutionManager.cs` (inside the class, before `Dispose`):
+
+```csharp
+public IReadOnlyList<SolutionInfo> ListSolutions()
+{
+    return _managers
+        .Select(kvp =>
+        {
+            var m = kvp.Value;
+            int projectCount = 0;
+            string status;
+            try
+            {
+                var loaded = m.GetLoadedSolution();
+                projectCount = loaded.Compilations.Count;
+                status = loaded.IsEmpty ? "empty" : "ready";
+            }
+            catch
+            {
+                status = "loading";
+            }
+            return new SolutionInfo(kvp.Key, kvp.Key == _activeKey, projectCount, status);
+        })
+        .ToList();
+}
+
+public string SetActiveSolution(string name)
+{
+    var matches = _managers.Keys
+        .Where(k => k.Contains(name, StringComparison.OrdinalIgnoreCase))
+        .ToList();
+
+    if (matches.Count == 0)
+        throw new InvalidOperationException(
+            $"No solution matching '{name}'. Available: {string.Join(", ", _managers.Keys.Select(Path.GetFileName))}");
+
+    if (matches.Count > 1)
+        throw new InvalidOperationException(
+            $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}");
+
+    _activeKey = matches[0];
+    return _activeKey;
+}
+```
+
+Also add `using RoslynCodeLens.Models;` at the top of `MultiSolutionManager.cs`.
+
+**Step 5: Run tests to verify they pass**
+
+```
+dotnet test tests/RoslynCodeLens.Tests --filter "MultiSolutionManagerTests"
+```
+
+Expected: PASS (all tests in the class).
+
+**Step 6: Commit**
+
+```bash
+git add src/RoslynCodeLens/MultiSolutionManager.cs src/RoslynCodeLens/Models/SolutionInfo.cs tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+git commit -m "feat: add ListSolutions and SetActiveSolution to MultiSolutionManager"
+```
+
+---
+
+### Task 3: Wire up `Program.cs` and rename parameter type in all 22 tools
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Program.cs`
+- Modify: all 22 `src/RoslynCodeLens/Tools/*Tool.cs` files (type rename only)
+
+**Step 1: Update `Program.cs`**
+
+Replace the entire content of `src/RoslynCodeLens/Program.cs`:
+
+```csharp
+using Microsoft.Build.Locator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using RoslynCodeLens;
+
+MSBuildLocator.RegisterDefaults();
+
+MultiSolutionManager multiManager;
+
+var solutionPaths = args.Length > 0
+    ? args.ToList()
+    : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory()) is { } found
+        ? [found]
+        : [];
+
+if (solutionPaths.Count > 0)
+{
+    multiManager = await MultiSolutionManager.CreateAsync(solutionPaths).ConfigureAwait(false);
+}
+else
+{
+    await Console.Error.WriteLineAsync("[roslyn-codelens] No .sln file found. Tools will return errors.").ConfigureAwait(false);
+    multiManager = MultiSolutionManager.CreateEmpty();
+}
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
+builder.Services.AddSingleton(multiManager);
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync().ConfigureAwait(false);
+```
+
+**Step 2: Rename `SolutionManager` → `MultiSolutionManager` in all tool files**
+
+Run this from the repo root in bash:
+
+```bash
+sed -i 's/SolutionManager manager/MultiSolutionManager manager/g' src/RoslynCodeLens/Tools/*.cs
+```
+
+**Step 3: Build to verify**
+
+```
+dotnet build src/RoslynCodeLens/RoslynCodeLens.csproj
+```
+
+Expected: Build succeeded, 0 errors.
+
+**Step 4: Run full test suite**
+
+```
+dotnet test
+```
+
+Expected: all existing tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Program.cs src/RoslynCodeLens/Tools/
+git commit -m "feat: wire MultiSolutionManager into DI and tools"
+```
+
+---
+
+### Task 4: Add `list_solutions` tool
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/ListSolutionsTool.cs`
+
+No new test file needed — tool is a thin wrapper over `MultiSolutionManager.ListSolutions()` which is already tested.
+
+**Step 1: Implement the tool**
+
+Create `src/RoslynCodeLens/Tools/ListSolutionsTool.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class ListSolutionsTool
+{
+    [McpServerTool(Name = "list_solutions"),
+     Description("List all solutions loaded by this server, showing which one is currently active.")]
+    public static IReadOnlyList<SolutionInfo> Execute(MultiSolutionManager manager)
+    {
+        return manager.ListSolutions();
+    }
+}
+```
+
+**Step 2: Build**
+
+```
+dotnet build src/RoslynCodeLens/RoslynCodeLens.csproj
+```
+
+Expected: Build succeeded.
+
+**Step 3: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/ListSolutionsTool.cs
+git commit -m "feat: add list_solutions tool"
+```
+
+---
+
+### Task 5: Add `set_active_solution` tool
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/SetActiveSolutionTool.cs`
+
+**Step 1: Implement the tool**
+
+Create `src/RoslynCodeLens/Tools/SetActiveSolutionTool.cs`:
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class SetActiveSolutionTool
+{
+    [McpServerTool(Name = "set_active_solution"),
+     Description("Switch the active solution. All subsequent tool calls will operate on the selected solution. " +
+                 "Use a partial, case-insensitive name (e.g. 'MyProject' matches 'C:/code/MyProject/MyProject.sln'). " +
+                 "Returns the full path of the newly active solution.")]
+    public static string Execute(
+        MultiSolutionManager manager,
+        [Description("Partial or full solution name/path to match")] string name)
+    {
+        return manager.SetActiveSolution(name);
+    }
+}
+```
+
+**Step 2: Build and run full test suite**
+
+```
+dotnet build
+dotnet test
+```
+
+Expected: Build succeeded, all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/SetActiveSolutionTool.cs
+git commit -m "feat: add set_active_solution tool"
+```
+
+---
+
+### Task 6: Manual smoke test
+
+**Step 1: Start the server with two solution paths**
+
+```bash
+dotnet run --project src/RoslynCodeLens/RoslynCodeLens.csproj -- RoslynCodeLens.slnx RoslynCodeLens.slnx
+```
+
+Expected: stderr shows `[roslyn-codelens] Background compilation starting...` twice (once per manager).
+
+**Step 2: Verify backward compat — single path still works**
+
+```bash
+dotnet run --project src/RoslynCodeLens/RoslynCodeLens.csproj -- RoslynCodeLens.slnx
+```
+
+Expected: starts normally, one solution loaded.
+
+**Step 3: Verify backward compat — no args / auto-discovery**
+
+```bash
+dotnet run --project src/RoslynCodeLens/RoslynCodeLens.csproj
+```
+
+Expected: auto-discovers `RoslynCodeLens.slnx`, one solution loaded.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -66,6 +66,8 @@ Use these tools **instead of Grep/Glob and instead of MSBuild** whenever you nee
 
 ### Solution Management
 
+- Use `list_solutions` to see all loaded solutions, which one is active, how many projects each has, and their status.
+- Use `set_active_solution` to switch the active solution by partial name (e.g. `set_active_solution("ProjectB")`). Call this at the start of a session when multiple solutions are loaded.
 - Use `rebuild_solution` to force a full reload of the analyzed solution — re-opens the `.sln`, recompiles all projects, and rebuilds all indexes. Use after changing `Directory.Build.props`, adding/removing NuGet packages or analyzers, or when diagnostics seem stale.
 
 ### Planning Changes
@@ -110,4 +112,6 @@ Reference concrete types, interfaces, and call sites in your analysis. Example: 
 | `find_circular_dependencies` | "Any circular dependencies?" |
 | `get_source_generators` | "What source generators are active?" / "List generators for this project" |
 | `get_generated_code` | "Show generated code" / "What did this generator produce?" |
+| `list_solutions` | "What solutions are loaded?" / "Which solution is active?" |
+| `set_active_solution` | "Switch to project B" / "Use the other solution" |
 | `rebuild_solution` | "Reload the solution" / "Pick up new analyzers" / "Diagnostics are stale" |

--- a/src/RoslynCodeLens/Models/SolutionInfo.cs
+++ b/src/RoslynCodeLens/Models/SolutionInfo.cs
@@ -1,0 +1,7 @@
+namespace RoslynCodeLens.Models;
+
+public sealed record SolutionInfo(
+    string Path,
+    bool IsActive,
+    int ProjectCount,
+    string Status);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -20,7 +20,8 @@ public sealed class MultiSolutionManager : IDisposable
         foreach (var path in solutionPaths)
         {
             var normalised = Path.GetFullPath(path);
-            managers[normalised] = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+            if (!managers.ContainsKey(normalised))
+                managers[normalised] = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
         }
 
         var firstKey = Path.GetFullPath(solutionPaths[0]);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -78,7 +78,7 @@ public sealed class MultiSolutionManager : IDisposable
                 }
                 catch
                 {
-                    status = "loading";
+                    status = "unknown";
                 }
                 return new SolutionInfo(kvp.Key, kvp.Key == activeKey, projectCount, status);
             })

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -6,6 +6,7 @@ public sealed class MultiSolutionManager : IDisposable
 {
     private readonly Dictionary<string, SolutionManager> _managers;
     private string? _activeKey;
+    private readonly Lock _lock = new();
 
     private MultiSolutionManager(Dictionary<string, SolutionManager> managers, string? activeKey)
     {
@@ -33,10 +34,20 @@ public sealed class MultiSolutionManager : IDisposable
     public static MultiSolutionManager CreateEmpty() =>
         new([], null);
 
-    private SolutionManager Active =>
-        _activeKey != null && _managers.TryGetValue(_activeKey, out var m)
-            ? m
-            : SolutionManager.CreateEmpty();
+    private SolutionManager Active
+    {
+        get
+        {
+            string? key;
+            lock (_lock) { key = _activeKey; }
+            if (key == null || !_managers.TryGetValue(key, out var m))
+                throw new InvalidOperationException(
+                    key == null
+                        ? "No solution loaded. Pass a .sln/.slnx path as argument."
+                        : $"Active solution key '{key}' not found in loaded solutions.");
+            return m;
+        }
+    }
 
     public void EnsureLoaded() => Active.EnsureLoaded();
     public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
@@ -46,6 +57,9 @@ public sealed class MultiSolutionManager : IDisposable
 
     public IReadOnlyList<SolutionInfo> ListSolutions()
     {
+        string? activeKey;
+        lock (_lock) { activeKey = _activeKey; }
+
         return _managers
             .Select(kvp =>
             {
@@ -58,11 +72,15 @@ public sealed class MultiSolutionManager : IDisposable
                     projectCount = loaded.Compilations.Count;
                     status = loaded.IsEmpty ? "empty" : "ready";
                 }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("warmup failed", StringComparison.OrdinalIgnoreCase))
+                {
+                    status = "error";
+                }
                 catch
                 {
                     status = "loading";
                 }
-                return new SolutionInfo(kvp.Key, kvp.Key == _activeKey, projectCount, status);
+                return new SolutionInfo(kvp.Key, kvp.Key == activeKey, projectCount, status);
             })
             .ToList();
     }
@@ -81,8 +99,8 @@ public sealed class MultiSolutionManager : IDisposable
             throw new InvalidOperationException(
                 $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}");
 
-        _activeKey = matches[0];
-        return _activeKey;
+        lock (_lock) { _activeKey = matches[0]; }
+        return matches[0];
     }
 
     public void Dispose()

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -1,0 +1,49 @@
+namespace RoslynCodeLens;
+
+public sealed class MultiSolutionManager : IDisposable
+{
+    private readonly Dictionary<string, SolutionManager> _managers;
+    private string? _activeKey;
+
+    private MultiSolutionManager(Dictionary<string, SolutionManager> managers, string? activeKey)
+    {
+        _managers = managers;
+        _activeKey = activeKey;
+    }
+
+    public static async Task<MultiSolutionManager> CreateAsync(IReadOnlyList<string> solutionPaths)
+    {
+        if (solutionPaths.Count == 0)
+            return CreateEmpty();
+
+        var managers = new Dictionary<string, SolutionManager>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in solutionPaths)
+        {
+            var normalised = Path.GetFullPath(path);
+            managers[normalised] = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+        }
+
+        var firstKey = Path.GetFullPath(solutionPaths[0]);
+        return new MultiSolutionManager(managers, firstKey);
+    }
+
+    public static MultiSolutionManager CreateEmpty() =>
+        new([], null);
+
+    private SolutionManager Active =>
+        _activeKey != null && _managers.TryGetValue(_activeKey, out var m)
+            ? m
+            : SolutionManager.CreateEmpty();
+
+    public void EnsureLoaded() => Active.EnsureLoaded();
+    public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
+    public SymbolResolver GetResolver() => Active.GetResolver();
+    public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
+    public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
+
+    public void Dispose()
+    {
+        foreach (var m in _managers.Values)
+            m.Dispose();
+    }
+}

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -1,3 +1,5 @@
+using RoslynCodeLens.Models;
+
 namespace RoslynCodeLens;
 
 public sealed class MultiSolutionManager : IDisposable
@@ -41,6 +43,47 @@ public sealed class MultiSolutionManager : IDisposable
     public SymbolResolver GetResolver() => Active.GetResolver();
     public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
     public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
+
+    public IReadOnlyList<SolutionInfo> ListSolutions()
+    {
+        return _managers
+            .Select(kvp =>
+            {
+                var m = kvp.Value;
+                int projectCount = 0;
+                string status;
+                try
+                {
+                    var loaded = m.GetLoadedSolution();
+                    projectCount = loaded.Compilations.Count;
+                    status = loaded.IsEmpty ? "empty" : "ready";
+                }
+                catch
+                {
+                    status = "loading";
+                }
+                return new SolutionInfo(kvp.Key, kvp.Key == _activeKey, projectCount, status);
+            })
+            .ToList();
+    }
+
+    public string SetActiveSolution(string name)
+    {
+        var matches = _managers.Keys
+            .Where(k => k.Contains(name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 0)
+            throw new InvalidOperationException(
+                $"No solution matching '{name}'. Available: {string.Join(", ", _managers.Keys.Select(Path.GetFileName))}");
+
+        if (matches.Count > 1)
+            throw new InvalidOperationException(
+                $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}");
+
+        _activeKey = matches[0];
+        return _activeKey;
+    }
 
     public void Dispose()
     {

--- a/src/RoslynCodeLens/Program.cs
+++ b/src/RoslynCodeLens/Program.cs
@@ -7,25 +7,27 @@ using RoslynCodeLens;
 
 MSBuildLocator.RegisterDefaults();
 
-var solutionPath = args.Length > 0
-    ? args[0]
-    : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory());
+MultiSolutionManager multiManager;
 
-SolutionManager manager;
+var solutionPaths = args.Length > 0
+    ? args.ToList()
+    : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory()) is { } found
+        ? [found]
+        : [];
 
-if (solutionPath != null)
+if (solutionPaths.Count > 0)
 {
-    manager = await SolutionManager.CreateAsync(solutionPath).ConfigureAwait(false);
+    multiManager = await MultiSolutionManager.CreateAsync(solutionPaths).ConfigureAwait(false);
 }
 else
 {
     await Console.Error.WriteLineAsync("[roslyn-codelens] No .sln file found. Tools will return errors.").ConfigureAwait(false);
-    manager = SolutionManager.CreateEmpty();
+    multiManager = MultiSolutionManager.CreateEmpty();
 }
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.Logging.ClearProviders();
-builder.Services.AddSingleton(manager);
+builder.Services.AddSingleton(multiManager);
 
 builder.Services
     .AddMcpServer()

--- a/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
@@ -10,7 +10,7 @@ public static class FindAttributeUsagesTool
     [McpServerTool(Name = "find_attribute_usages"),
      Description("Find all types and members decorated with a specific attribute (e.g., Obsolete, Authorize, Serializable)")]
     public static IReadOnlyList<AttributeUsageInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Attribute name to search for (with or without 'Attribute' suffix)")] string attribute)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindCallersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersTool.cs
@@ -10,7 +10,7 @@ public static class FindCallersTool
     [McpServerTool(Name = "find_callers"),
      Description("Find every call site for a method")]
     public static IReadOnlyList<CallerInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Method name as Type.Method (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
@@ -10,7 +10,7 @@ public static class FindCircularDependenciesTool
     [McpServerTool(Name = "find_circular_dependencies"),
      Description("Detect circular dependencies in the project reference graph or namespace dependency graph")]
     public static IReadOnlyList<CircularDependency> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Level: 'project' or 'namespace' (default: project)")] string level = "project")
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
@@ -10,7 +10,7 @@ public static class FindImplementationsTool
     [McpServerTool(Name = "find_implementations"),
      Description("Find all classes/structs implementing an interface or extending a class")]
     public static IReadOnlyList<SymbolLocation> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
@@ -10,7 +10,7 @@ public static class FindLargeClassesTool
     [McpServerTool(Name = "find_large_classes"),
      Description("Find classes and structs that exceed member count or line count thresholds")]
     public static IReadOnlyList<LargeClassInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Maximum members before flagging (default: 20)")] int maxMembers = 20,
         [Description("Maximum lines before flagging (default: 500)")] int maxLines = 500)

--- a/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
@@ -10,7 +10,7 @@ public static class FindNamingViolationsTool
     [McpServerTool(Name = "find_naming_violations"),
      Description("Check .NET naming convention compliance: PascalCase types/methods/properties, camelCase parameters, I-prefix interfaces, _ prefix private fields")]
     public static IReadOnlyList<NamingViolation> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindReferencesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesTool.cs
@@ -10,7 +10,7 @@ public static class FindReferencesTool
     [McpServerTool(Name = "find_references"),
      Description("Find all references to a symbol (type, method, property, field, or event) across the solution")]
     public static IReadOnlyList<SymbolReference> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyProperty)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
@@ -10,7 +10,7 @@ public static class FindReflectionUsageTool
     [McpServerTool(Name = "find_reflection_usage"),
      Description("Detect dynamic/reflection-based usage like Type.GetType, Activator.CreateInstance, MethodInfo.Invoke")]
     public static IReadOnlyList<ReflectionUsage> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional type name to filter results (omit to scan entire solution)")] string? symbol = null)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
@@ -10,7 +10,7 @@ public static class FindUnusedSymbolsTool
     [McpServerTool(Name = "find_unused_symbols"),
      Description("Find potentially unused types and members (dead code detection). Checks public symbols for references across the solution.")]
     public static IReadOnlyList<UnusedSymbolInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Include internal symbols (default: false)")] bool includeInternal = false)
     {

--- a/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
@@ -10,7 +10,7 @@ public static class GetCodeFixesTool
     [McpServerTool(Name = "get_code_fixes"),
      Description("Get available code fixes for a specific diagnostic at a file location. Returns structured text edits that can be reviewed and applied.")]
     public static async Task<IReadOnlyList<CodeFixSuggestion>> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Diagnostic ID (e.g., 'CA1822', 'CS0168')")] string diagnosticId,
         [Description("Full path to the source file")] string filePath,
         [Description("Line number where the diagnostic occurs")] int line,

--- a/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
@@ -10,7 +10,7 @@ public static class GetComplexityMetricsTool
     [McpServerTool(Name = "get_complexity_metrics"),
      Description("Calculate cyclomatic complexity for methods. Returns methods exceeding the threshold, sorted by complexity.")]
     public static IReadOnlyList<ComplexityMetric> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Minimum complexity threshold (default: 10)")] int threshold = 10)
     {

--- a/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
@@ -10,7 +10,7 @@ public static class GetDiRegistrationsTool
     [McpServerTool(Name = "get_di_registrations"),
      Description("Scan IServiceCollection extension methods for DI registrations of a type")]
     public static IReadOnlyList<DiRegistration> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Type name to search for (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
@@ -10,7 +10,7 @@ public static class GetDiagnosticsTool
     [McpServerTool(Name = "get_diagnostics"),
      Description("List compiler errors and warnings across the solution, optionally including analyzer diagnostics")]
     public static async Task<IReadOnlyList<DiagnosticInfo>> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Minimum severity: 'error' or 'warning' (default: warning)")] string? severity = null,
         [Description("Include analyzer diagnostics (default: true)")] bool includeAnalyzers = true,

--- a/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
+++ b/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
@@ -10,7 +10,7 @@ public static class GetGeneratedCodeTool
     [McpServerTool(Name = "get_generated_code"),
      Description("Inspect generated source code from source generators")]
     public static IReadOnlyList<GeneratedFileInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Generator name to filter by")] string? generator = null,
         [Description("File path (or partial match) to filter by")] string? file = null)
     {

--- a/src/RoslynCodeLens/Tools/GetNugetDependenciesTool.cs
+++ b/src/RoslynCodeLens/Tools/GetNugetDependenciesTool.cs
@@ -10,7 +10,7 @@ public static class GetNugetDependenciesTool
     [McpServerTool(Name = "get_nuget_dependencies"),
      Description("List NuGet package references for projects in the solution")]
     public static NugetDependencyGraph? Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter (omit to list all)")] string? project = null)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetProjectDependenciesTool.cs
+++ b/src/RoslynCodeLens/Tools/GetProjectDependenciesTool.cs
@@ -10,7 +10,7 @@ public static class GetProjectDependenciesTool
     [McpServerTool(Name = "get_project_dependencies"),
      Description("Return the project reference graph (direct and transitive dependencies)")]
     public static ProjectDependencyGraph? Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Project name or .csproj filename")] string project)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
@@ -10,7 +10,7 @@ public static class GetSourceGeneratorsTool
     [McpServerTool(Name = "get_source_generators"),
      Description("List source generators and their output per project")]
     public static IReadOnlyList<SourceGeneratorInfo> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
@@ -10,7 +10,7 @@ public static class GetSymbolContextTool
     [McpServerTool(Name = "get_symbol_context"),
      Description("One-shot context dump for a type: namespace, base class, interfaces, injected dependencies, public members")]
     public static SymbolContext? Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
@@ -10,7 +10,7 @@ public static class GetTypeHierarchyTool
     [McpServerTool(Name = "get_type_hierarchy"),
      Description("Walk up (base classes, interfaces) and down (derived types) from a type")]
     public static TypeHierarchy? Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
+++ b/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
@@ -10,7 +10,7 @@ public static class GoToDefinitionTool
     [McpServerTool(Name = "go_to_definition"),
      Description("Find the source file and line where a symbol is defined")]
     public static IReadOnlyList<SymbolLocation> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.DoWork)")] string symbol)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class ListSolutionsTool
+{
+    [McpServerTool(Name = "list_solutions"),
+     Description("List all solutions loaded by this server, showing which one is currently active.")]
+    public static IReadOnlyList<SolutionInfo> Execute(MultiSolutionManager manager)
+    {
+        return manager.ListSolutions();
+    }
+}

--- a/src/RoslynCodeLens/Tools/RebuildSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/RebuildSolutionTool.cs
@@ -8,7 +8,7 @@ public static class RebuildSolutionTool
 {
     [McpServerTool(Name = "rebuild_solution"),
      Description("Force a full reload of the analyzed solution — re-opens the .sln, recompiles all projects, and rebuilds all indexes. Use after changing Directory.Build.props, adding/removing NuGet packages, or when diagnostics seem stale.")]
-    public static async Task<string> Execute(SolutionManager manager)
+    public static async Task<string> Execute(MultiSolutionManager manager)
     {
         manager.EnsureLoaded();
         var (projectCount, elapsed) = await manager.ForceReloadAsync().ConfigureAwait(false);

--- a/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
@@ -10,7 +10,7 @@ public static class SearchSymbolsTool
     [McpServerTool(Name = "search_symbols"),
      Description("Search for types, methods, properties, and fields by name (case-insensitive substring match, max 50 results)")]
     public static IReadOnlyList<SymbolLocation> Execute(
-        SolutionManager manager,
+        MultiSolutionManager manager,
         [Description("Search query (substring match against symbol names)")] string query)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/SetActiveSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/SetActiveSolutionTool.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class SetActiveSolutionTool
+{
+    [McpServerTool(Name = "set_active_solution"),
+     Description("Switch the active solution. All subsequent tool calls will operate on the selected solution. " +
+                 "Use a partial, case-insensitive name (e.g. 'MyProject' matches 'C:/code/MyProject/MyProject.sln'). " +
+                 "Returns the full path of the newly active solution.")]
+    public static string Execute(
+        MultiSolutionManager manager,
+        [Description("Partial or full solution name/path to match")] string name)
+    {
+        return manager.SetActiveSolution(name);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
@@ -48,4 +48,12 @@ public class MultiSolutionManagerTests : IAsyncLifetime
         Assert.Throws<InvalidOperationException>((Action)(() => multi.EnsureLoaded()));
         multi.Dispose();
     }
+
+    [Fact]
+    public async Task CreateAsync_DuplicatePaths_DoesNotThrow()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath, _solutionPath]);
+        multi.EnsureLoaded();
+        multi.Dispose();
+    }
 }

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
@@ -56,4 +56,32 @@ public class MultiSolutionManagerTests : IAsyncLifetime
         multi.EnsureLoaded();
         multi.Dispose();
     }
+
+    [Fact]
+    public async Task ListSolutions_SinglePath_ReturnsSingleActiveEntry()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        var list = multi.ListSolutions();
+        Assert.Single(list);
+        Assert.True(list[0].IsActive);
+        Assert.Equal(Path.GetFullPath(_solutionPath), list[0].Path, StringComparer.OrdinalIgnoreCase);
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task SetActiveSolution_ByPartialName_SwitchesActive()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        var switched = multi.SetActiveSolution("TestSolution");
+        Assert.Contains("TestSolution", switched, StringComparison.OrdinalIgnoreCase);
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task SetActiveSolution_UnknownName_Throws()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        Assert.Throws<InvalidOperationException>(() => multi.SetActiveSolution("DoesNotExist"));
+        multi.Dispose();
+    }
 }

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
@@ -1,0 +1,51 @@
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class MultiSolutionManagerTests : IAsyncLifetime
+{
+    private string _solutionPath = null!;
+
+    public Task InitializeAsync()
+    {
+        _solutionPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task CreateAsync_SinglePath_DelegatesEnsureLoaded()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        multi.EnsureLoaded(); // must not throw
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task GetLoadedSolution_ReturnsSolution()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        await multi.WaitForWarmupAsync();
+        Assert.False(multi.GetLoadedSolution().IsEmpty);
+        multi.Dispose();
+    }
+
+    [Fact]
+    public async Task GetResolver_ReturnsResolver()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        await multi.WaitForWarmupAsync();
+        Assert.NotNull(multi.GetResolver());
+        multi.Dispose();
+    }
+
+    [Fact]
+    public void CreateEmpty_EnsureLoaded_Throws()
+    {
+        var multi = MultiSolutionManager.CreateEmpty();
+        Assert.Throws<InvalidOperationException>((Action)(() => multi.EnsureLoaded()));
+        multi.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `MultiSolutionManager` that loads N solutions at startup and delegates all existing tool calls to the active one
- New `list_solutions` tool shows all loaded solutions with active flag, project count, and status
- New `set_active_solution` tool switches the active solution by partial name match (case-insensitive)
- All 22 existing tools work unchanged — only the injected parameter type was renamed

## Usage

Configure multiple solutions in your global MCP config:

```json
{
  "mcpServers": {
    "roslyn-codelens": {
      "command": "roslyn-codelens-mcp",
      "args": ["C:/Projects/A/A.sln", "C:/Projects/B/B.sln"]
    }
  }
}
```

Then call `set_active_solution("ProjectB")` at the start of a session to switch context. Single-path and auto-discovery (no args) remain fully backward-compatible.

## Test Plan

- [x] 90 tests passing
- [x] Smoke tested: multi-path, single-path, and no-args (auto-discovery) all start correctly
- [x] Thread-safe active key (Lock field protecting reads/writes)
- [x] Resource-safe: duplicate paths are deduplicated, no leaked SolutionManager instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)