### PR TITLE
feat: multi-solution support + new analysis tools (Phases 1-4)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,5 +20,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ZeroAlloc.Analyzers" Version="1.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A Roslyn-based MCP server that gives AI agents deep semantic understanding of .N
 - **get_generated_code** — Inspect generated source code from source generators
 - **get_code_actions** — Discover available refactorings and fixes at any position (extract method, rename, inline variable, and more)
 - **apply_code_action** — Execute any Roslyn refactoring by title, with preview mode (returns a diff before writing to disk)
+- **list_solutions** — List all loaded solutions and which one is currently active
+- **set_active_solution** — Switch the active solution by partial name (all subsequent tools operate on it)
 - **rebuild_solution** — Force a full reload of the analyzed solution
 - **analyze_data_flow** — Variable read/write/capture analysis within a statement range (declared, read, written, always assigned, captured, flows in/out)
 - **analyze_control_flow** — Branch/loop reachability analysis within a statement range (start/end reachability, return statements, exit points)

--- a/README.md
+++ b/README.md
@@ -108,38 +108,38 @@ When multiple solutions are loaded, use `list_solutions` to see what's available
 
 ## Performance
 
-All type lookups use pre-built reverse inheritance maps, member indexes, and attribute indexes for O(1) access. Benchmarked on an i9-12900HK with .NET 10.0.3:
+All type lookups use pre-built reverse inheritance maps, member indexes, and attribute indexes for O(1) access. Benchmarked on an i9-12900HK with .NET 10.0.4:
 
 | Tool | Latency | Memory |
 |------|--------:|-------:|
-| `find_circular_dependencies` | 648 ns | 1.2 KB |
-| `go_to_definition` | 757 ns | 568 B |
-| `get_project_dependencies` | 839 ns | 1.3 KB |
-| `get_type_hierarchy` | 1.4 µs | 856 B |
-| `find_implementations` | 1.7 µs | 704 B |
-| `get_symbol_context` | 2.3 µs | 960 B |
-| `get_source_generators` | 4.0 µs | 7.1 KB |
-| `analyze_data_flow` | 4.4 µs | 880 B |
-| `find_attribute_usages` | 13 µs | 312 B |
-| `get_generated_code` | 19 µs | 7.8 KB |
-| `analyze_control_flow` | 53 µs | 13 KB |
-| `get_diagnostics` | 87 µs | 22 KB |
-| `get_complexity_metrics` | 90 µs | 5.6 KB |
-| `get_nuget_dependencies` | 114 µs | 15 KB |
-| `find_large_classes` | 116 µs | 888 B |
-| `get_di_registrations` | 140 µs | 13 KB |
-| `get_type_overview` | 151 µs | 24 KB |
-| `get_file_overview` | 153 µs | 24 KB |
-| `find_reflection_usage` | 182 µs | 15 KB |
-| `find_callers` | 468 µs | 37 KB |
-| `analyze_method` | 504 µs | 38 KB |
-| `get_code_actions` | 853 µs | 49 KB |
-| `search_symbols` | 883 µs | 2.4 KB |
-| `find_unused_symbols` | 2.0 ms | 206 KB |
-| `find_references` | 2.3 ms | 203 KB |
-| `analyze_change_impact` | 3.0 ms | 243 KB |
-| `find_naming_violations` | 8.1 ms | 654 KB |
-| Solution loading (one-time) | ~2.7 s | 8.1 MB |
+| `find_circular_dependencies` | 892 ns | 1.2 KB |
+| `get_project_dependencies` | 987 ns | 1.3 KB |
+| `go_to_definition` | 1.3 µs | 608 B |
+| `get_type_hierarchy` | 1.8 µs | 856 B |
+| `find_implementations` | 2.0 µs | 704 B |
+| `get_symbol_context` | 3.0 µs | 960 B |
+| `get_source_generators` | 4.9 µs | 7.1 KB |
+| `analyze_data_flow` | 7.4 µs | 880 B |
+| `find_attribute_usages` | 20 µs | 312 B |
+| `get_generated_code` | 30 µs | 7.8 KB |
+| `analyze_control_flow` | 96 µs | 13 KB |
+| `get_diagnostics` | 98 µs | 22 KB |
+| `get_complexity_metrics` | 127 µs | 5.6 KB |
+| `get_type_overview` | 138 µs | 24 KB |
+| `find_large_classes` | 148 µs | 888 B |
+| `get_file_overview` | 162 µs | 24 KB |
+| `get_di_registrations` | 172 µs | 13 KB |
+| `get_nuget_dependencies` | 202 µs | 15 KB |
+| `find_reflection_usage` | 235 µs | 15 KB |
+| `find_callers` | 406 µs | 37 KB |
+| `analyze_method` | 619 µs | 38 KB |
+| `get_code_actions` | 765 µs | 49 KB |
+| `search_symbols` | 1.3 ms | 2.5 KB |
+| `find_unused_symbols` | 3.8 ms | 207 KB |
+| `find_references` | 3.9 ms | 204 KB |
+| `analyze_change_impact` | 4.2 ms | 243 KB |
+| `find_naming_violations` | 10.7 ms | 654 KB |
+| Solution loading (one-time) | ~3.0 s | 8.2 MB |
 
 ## Hot Reload
 

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -41,12 +41,12 @@ public class CodeGraphBenchmarks
         _loaded = await new SolutionLoader().LoadAsync(FixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
         _greeterPath = _loaded.Solution.Projects
-            .First(p => p.Name == "TestLib")
-            .Documents.First(d => d.Name == "Greeter.cs")
+            .First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal))
+            .Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal))
             .FilePath!;
         _diSetupPath = _loaded.Solution.Projects
-            .First(p => p.Name == "TestLib2")
-            .Documents.First(d => d.Name == "DiSetup.cs")
+            .First(p => string.Equals(p.Name, "TestLib2", StringComparison.Ordinal))
+            .Documents.First(d => string.Equals(d.Name, "DiSetup.cs", StringComparison.Ordinal))
             .FilePath!;
     }
 

--- a/src/RoslynCodeLens/CodeActionRunner.cs
+++ b/src/RoslynCodeLens/CodeActionRunner.cs
@@ -1,3 +1,8 @@
+// EPC12: Reflection-based provider loading — intentionally catches all exceptions and reports ex.Message to stderr
+// EPS06: ImmutableArray.Where — acceptable allocation in non-hot-path diagnostic filtering
+// HLQ012: foreach on List<Assembly> — CollectionsMarshal.AsSpan not applicable (async context / conditional break)
+// MA0051: CollectRawActionsAsync and provider-loader methods naturally exceed 60 lines; splitting would obscure the algorithm
+#pragma warning disable EPC12, EPS06, HLQ012, MA0051
 using System.Collections.Immutable;
 using System.Reflection;
 using Microsoft.CodeAnalysis;

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -76,11 +76,12 @@ public sealed class MultiSolutionManager : IDisposable
                 {
                     status = "error";
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Console.Error.WriteLine($"[roslyn-codelens] Error reading solution status ({kvp.Key}): {ex}");
                     status = "unknown";
                 }
-                return new SolutionInfo(kvp.Key, kvp.Key == activeKey, projectCount, status);
+                return new SolutionInfo(kvp.Key, string.Equals(kvp.Key, activeKey, StringComparison.Ordinal), projectCount, status);
             })
             .ToList();
     }

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -32,10 +32,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.14.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
-    <PackageReference Include="ZeroAlloc.Analyzers" Version="1.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <!-- Stamp the package version into .mcp/server.json before packing -->

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 
@@ -28,6 +29,7 @@ public class SolutionLoader
         var totalProjects = levels.Sum(l => l.Count);
         var compiled = 0;
 
+#pragma warning disable HLQ012, ZA0601 // async method — cannot use CollectionsMarshal.AsSpan across await; Select in loop is required for parallel task projection
         foreach (var level in levels)
         {
             var tasks = level.Select(async project =>
@@ -45,6 +47,7 @@ public class SolutionLoader
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
+#pragma warning restore HLQ012, ZA0601
 
         return compilations;
     }
@@ -91,7 +94,7 @@ public class SolutionLoader
     /// Returns projects grouped by dependency level (leaves first).
     /// Level 0 = no project dependencies, Level 1 = depends only on level 0, etc.
     /// </summary>
-    public static List<List<Project>> GetCompilationLevels(Solution solution)
+    public static IReadOnlyList<IReadOnlyList<Project>> GetCompilationLevels(Solution solution)
     {
         var projects = solution.Projects.ToList();
         var projectIds = new HashSet<ProjectId>(projects.Select(p => p.Id));
@@ -122,7 +125,7 @@ public class SolutionLoader
             return level;
         }
 
-        foreach (var project in projects)
+        foreach (ref readonly var project in CollectionsMarshal.AsSpan(projects))
             GetLevel(project);
 
         if (assigned.Count == 0)
@@ -133,7 +136,7 @@ public class SolutionLoader
         for (var i = 0; i <= maxLevel; i++)
             levels.Add(new List<Project>());
 
-        foreach (var project in projects)
+        foreach (ref readonly var project in CollectionsMarshal.AsSpan(projects))
             levels[assigned[project.Id]].Add(project);
 
         return levels;

--- a/src/RoslynCodeLens/Tools/AnalyzeChangeImpactLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeChangeImpactLogic.cs
@@ -21,14 +21,14 @@ public static class AnalyzeChangeImpactLogic
             .Concat(callers.Select(c => c.File))
             .Where(f => !string.IsNullOrEmpty(f))
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Order()
+            .Order(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var affectedProjects = references.Select(r => r.Project)
             .Concat(callers.Select(c => c.Project))
             .Where(p => !string.IsNullOrEmpty(p))
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Order()
+            .Order(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         return new ChangeImpact(

--- a/src/RoslynCodeLens/Tools/AnalyzeControlFlowLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeControlFlowLogic.cs
@@ -9,24 +9,7 @@ public static class AnalyzeControlFlowLogic
     public static async Task<ControlFlowInfo?> ExecuteAsync(
         LoadedSolution loaded, string filePath, int startLine, int endLine, CancellationToken ct)
     {
-        var normalizedPath = Path.GetFullPath(filePath);
-        Document? targetDocument = null;
-        Compilation? compilation = null;
-
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var doc in project.Documents)
-            {
-                if (doc.FilePath != null &&
-                    doc.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetDocument = doc;
-                    loaded.Compilations.TryGetValue(project.Id, out compilation);
-                    break;
-                }
-            }
-            if (targetDocument != null) break;
-        }
+        var (targetDocument, compilation) = FlowAnalysisHelpers.FindDocument(loaded, filePath);
 
         if (targetDocument == null || compilation == null)
             return null;

--- a/src/RoslynCodeLens/Tools/AnalyzeDataFlowLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeDataFlowLogic.cs
@@ -10,24 +10,7 @@ public static class AnalyzeDataFlowLogic
     public static async Task<DataFlowInfo?> ExecuteAsync(
         LoadedSolution loaded, string filePath, int startLine, int endLine, CancellationToken ct)
     {
-        var normalizedPath = Path.GetFullPath(filePath);
-        Document? targetDocument = null;
-        Compilation? compilation = null;
-
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var doc in project.Documents)
-            {
-                if (doc.FilePath != null &&
-                    doc.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetDocument = doc;
-                    loaded.Compilations.TryGetValue(project.Id, out compilation);
-                    break;
-                }
-            }
-            if (targetDocument != null) break;
-        }
+        var (targetDocument, compilation) = FlowAnalysisHelpers.FindDocument(loaded, filePath);
 
         if (targetDocument == null || compilation == null)
             return null;

--- a/src/RoslynCodeLens/Tools/FindNamingViolationsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindNamingViolationsLogic.cs
@@ -43,7 +43,7 @@ public static class FindNamingViolationsLogic
                     var (file, line) = resolver.GetFileAndLine(type);
                     if (!string.IsNullOrEmpty(file))
                     {
-                        var suggestion = char.ToUpper(type.Name[0], CultureInfo.InvariantCulture) + type.Name.Substring(1);
+                        var suggestion = char.ToUpper(type.Name[0], CultureInfo.InvariantCulture).ToString() + type.Name[1..];
                         results.Add(new NamingViolation(
                             type.Name, "Type", "Types must be PascalCase",
                             suggestion, file, line, projectName));
@@ -80,7 +80,7 @@ public static class FindNamingViolationsLogic
                         var (pf, pl) = resolver.GetFileAndLine(property);
                         if (!string.IsNullOrEmpty(pf))
                         {
-                            var suggestion = char.ToUpper(property.Name[0], CultureInfo.InvariantCulture) + property.Name.Substring(1);
+                            var suggestion = char.ToUpper(property.Name[0], CultureInfo.InvariantCulture).ToString() + property.Name[1..];
                             results.Add(new NamingViolation(
                                 property.Name, "Property", "Properties must be PascalCase",
                                 suggestion, pf, pl, projectName));
@@ -111,7 +111,7 @@ public static class FindNamingViolationsLogic
             var (mf, ml) = resolver.GetFileAndLine(method);
             if (!string.IsNullOrEmpty(mf))
             {
-                var suggestion = char.ToUpper(method.Name[0], CultureInfo.InvariantCulture) + method.Name.Substring(1);
+                var suggestion = char.ToUpper(method.Name[0], CultureInfo.InvariantCulture).ToString() + method.Name[1..];
                 results.Add(new NamingViolation(
                     method.Name, "Method", "Methods must be PascalCase",
                     suggestion, mf, ml, projectName));
@@ -132,7 +132,7 @@ public static class FindNamingViolationsLogic
                 var (pf, pl) = resolver.GetFileAndLine(method);
                 if (!string.IsNullOrEmpty(pf))
                 {
-                    var paramSuggestion = char.ToLower(param.Name[0], CultureInfo.InvariantCulture) + param.Name.Substring(1);
+                    var paramSuggestion = char.ToLower(param.Name[0], CultureInfo.InvariantCulture).ToString() + param.Name[1..];
                     results.Add(new NamingViolation(
                         param.Name, "Parameter", "Parameters should be camelCase",
                         paramSuggestion, pf, pl, projectName));

--- a/src/RoslynCodeLens/Tools/FlowAnalysisHelpers.cs
+++ b/src/RoslynCodeLens/Tools/FlowAnalysisHelpers.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Tools;
+
+internal static class FlowAnalysisHelpers
+{
+    internal static (Document? Document, Compilation? Compilation) FindDocument(LoadedSolution loaded, string filePath)
+    {
+        var normalizedPath = Path.GetFullPath(filePath);
+
+        foreach (var project in loaded.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath != null &&
+                    doc.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    loaded.Compilations.TryGetValue(project.Id, out var compilation);
+                    return (doc, compilation);
+                }
+            }
+        }
+
+        return (null, null);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
@@ -44,7 +44,7 @@ public class ApplyCodeActionLogicTests : IAsyncLifetime
         }
 
         Assert.NotNull(result);
-        Assert.True(result.Success, $"No action succeeded. Last error: {result?.ErrorMessage}");
+        Assert.True(result.Success, $"No action succeeded. Last error: {result.ErrorMessage}");
         Assert.NotEmpty(result.Title);
     }
 

--- a/tests/RoslynCodeLens.Tests/CodeActionRunnerTests.cs
+++ b/tests/RoslynCodeLens.Tests/CodeActionRunnerTests.cs
@@ -22,7 +22,7 @@ public class CodeActionRunnerTests : IAsyncLifetime
     {
         // Greeter.cs line 8: public virtual string Greet(string name) => ...
         var project = _loaded.Solution.Projects.First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal));
-        var doc = project.Documents.First(d => d.Name == "Greeter.cs");
+        var doc = project.Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal));
         var compilation = _loaded.Compilations[project.Id];
 
         var actions = await CodeActionRunner.GetActionsAsync(
@@ -39,7 +39,7 @@ public class CodeActionRunnerTests : IAsyncLifetime
         // Greeter.cs line 8: select the expression body "=> $"Hello, {name}!";"
         // This should trigger refactorings like "Use block body" that don't need workspace services
         var project = _loaded.Solution.Projects.First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal));
-        var doc = project.Documents.First(d => d.Name == "Greeter.cs");
+        var doc = project.Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal));
         var compilation = _loaded.Compilations[project.Id];
 
         // Select the range covering the expression body on line 8

--- a/tests/RoslynCodeLens.Tests/GlobalSuppressions.cs
+++ b/tests/RoslynCodeLens.Tests/GlobalSuppressions.cs
@@ -1,0 +1,6 @@
+// HLQ005: Assert.Single() is the correct xUnit assertion for "exactly one element" — not a performance concern in test code
+// EPS06: ImmutableArray LINQ in test code — allocations irrelevant in test context
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("NetFabric.Hyperlinq", "HLQ005:AvoidSingleAnalyzer", Justification = "Assert.Single() is the correct xUnit assertion for exactly-one-element checks")]
+[assembly: SuppressMessage("ErrorProne.NET", "EPS06:HiddenStructCopy", Justification = "ImmutableArray LINQ allocations are acceptable in test code")]

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
@@ -84,4 +84,15 @@ public class MultiSolutionManagerTests : IAsyncLifetime
         Assert.Throws<InvalidOperationException>(() => multi.SetActiveSolution("DoesNotExist"));
         multi.Dispose();
     }
+
+    [Fact]
+    public async Task ForceReloadAsync_ReturnsPositiveProjectCount()
+    {
+        var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
+        await multi.WaitForWarmupAsync();
+        var (projectCount, elapsed) = await multi.ForceReloadAsync();
+        Assert.True(projectCount > 0);
+        Assert.True(elapsed > TimeSpan.Zero);
+        multi.Dispose();
+    }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
@@ -36,7 +36,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
 
         Assert.NotNull(result);
         // Greet is called from GreeterConsumer.SayHello
-        Assert.True(result.Callers.Count > 0 || result.OutgoingCalls.Count >= 0);
+        Assert.True(result.Callers.Count > 0 || result.OutgoingCalls.Count > 0);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/TopologicalSortTests.cs
+++ b/tests/RoslynCodeLens.Tests/TopologicalSortTests.cs
@@ -47,8 +47,8 @@ public class TopologicalSortTests
         // Level 0: B and C (both leaves), Level 1: A
         Assert.Equal(2, levels.Count);
         Assert.Equal(2, levels[0].Count);
-        Assert.Contains(levels[0], p => p.Name == "B");
-        Assert.Contains(levels[0], p => p.Name == "C");
+        Assert.Contains(levels[0], p => string.Equals(p.Name, "B", StringComparison.Ordinal));
+        Assert.Contains(levels[0], p => string.Equals(p.Name, "C", StringComparison.Ordinal));
         Assert.Single(levels[1]);
         Assert.Equal("A", levels[1][0].Name);
     }


### PR DESCRIPTION
## Summary

- **Multi-solution support**: load multiple `.sln`/`.slnx` files at startup; `list_solutions` and `set_active_solution` to switch context at runtime
- **New analysis tools**: `analyze_data_flow`, `analyze_control_flow`, `analyze_change_impact`, `get_code_actions`, `apply_code_action`, `get_type_overview`, `analyze_method`, `get_file_overview` (8 new tools)
- **Code quality**: added ZeroAlloc.Analyzers 1.3.1 across all projects and resolved all resulting warnings (zero warnings, zero errors)
- **Benchmarks**: re-ran full BenchmarkDotNet suite on .NET 10.0.4 and updated README performance table
- **Docs**: added sharplens-mcp feature comparison matrix (`docs/features.md`); updated SKILL.md and README for all new tools
- **Tests**: 113 tests passing; added `ForceReloadAsync` coverage

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors across all 3 projects
- [x] `dotnet test` — 113/113 passing
- [x] Benchmarks re-run and README updated with new results

🤖 Generated with [Claude Code](https://claude.com/claude-code)