### PR TITLE
ci: auto-publish to MCP registry after npm release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,28 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-mcp:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xzf mcp-publisher.tar.gz
+          chmod +x mcp-publisher
+
+      - name: Authenticate via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
@@ -51,3 +52,24 @@ jobs:
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ./nupkg/*.nupkg
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: [release-please, publish]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xzf mcp-publisher.tar.gz
+          chmod +x mcp-publisher
+
+      - name: Authenticate via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.marcelroozekrans/roslyn-codelens",
+  "title": "Roslyn CodeLens",
+  "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
+  "repository": {
+    "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
+    "source": "github"
+  },
+  "version": "1.1.0",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "RoslynCodeLens.Mcp",
+      "version": "1.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added `publish-mcp-registry` job to `release-please.yml` that runs after the `publish` job succeeds, automatically publishing to the MCP registry via OIDC authentication
- Added `id-token: write` permission to the release-please workflow for OIDC support
- Created standalone `publish-mcp-registry.yml` workflow for manual ad-hoc re-publishing via `workflow_dispatch`
- Created root `server.json` with the MCP registry schema, matching the existing `.mcp/server.json` in the NuGet package

## Test plan
- [ ] Verify the `release-please.yml` workflow YAML is valid (no syntax errors)
- [ ] Verify `publish-mcp-registry.yml` can be triggered manually from the Actions tab
- [ ] Trigger a release and confirm the `publish-mcp-registry` job runs after `publish` succeeds
- [ ] Confirm OIDC authentication works (repo must be registered with the MCP registry)
- [ ] Verify `server.json` passes MCP registry schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)