### PR TITLE
fix: correct MCP registry name casing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.marcelroozekrans/roslyn-codelens",
+  "name": "io.github.MarcelRoozekrans/roslyn-codelens",
   "title": "Roslyn CodeLens",
   "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
   "repository": {


### PR DESCRIPTION
## Summary
- Corrects the `name` field in `server.json` from `io.github.marcelroozekrans/roslyn-codelens` to `io.github.MarcelRoozekrans/roslyn-codelens`
- The MCP registry requires GitHub username casing to match exactly

## Test plan
- [ ] Verify the registry accepts the corrected casing on next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)