### PR TITLE
fix: add mcp-name to README for MCP registry ownership verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Roslyn-based MCP server that gives AI agents deep semantic understanding of .N
   <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp/badge" alt="roslyn-codelens-mcp MCP server" />
 </a>
 
-<!-- mcp-name: io.github.marcelroozekrans/roslyn-codelens -->
+<!-- mcp-name: io.github.MarcelRoozekrans/roslyn-codelens -->
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix casing of `mcp-name` in README.md from `io.github.marcelroozekrans/roslyn-codelens` to `io.github.MarcelRoozekrans/roslyn-codelens` for MCP registry ownership verification

## Test plan
- [ ] Verify the MCP registry correctly picks up the mcp-name from the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)