### PR TITLE
fix: add missing DI package reference to test fixture TestLib2

### DIFF
--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/TestLib2.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/TestLib2.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/RoslynCodeLens.Tests/Tools/GetNugetDependenciesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetNugetDependenciesToolTests.cs
@@ -23,7 +23,7 @@ public class GetNugetDependenciesToolTests : IAsyncLifetime
 
         Assert.NotNull(result);
         Assert.NotEmpty(result!.Packages);
-        Assert.Contains(result.Packages, p => string.Equals(p.PackageName, "Microsoft.Extensions.DependencyInjection.Abstractions", StringComparison.Ordinal));
+        Assert.Contains(result.Packages, p => string.Equals(p.PackageName, "Microsoft.Extensions.DependencyInjection", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class GetNugetDependenciesToolTests : IAsyncLifetime
         var result = GetNugetDependenciesLogic.Execute(_loaded, null);
 
         Assert.NotNull(result);
-        var diPkg = result!.Packages.First(p => string.Equals(p.PackageName, "Microsoft.Extensions.DependencyInjection.Abstractions", StringComparison.Ordinal));
+        var diPkg = result!.Packages.First(p => string.Equals(p.PackageName, "Microsoft.Extensions.DependencyInjection", StringComparison.Ordinal));
         Assert.False(string.IsNullOrEmpty(diPkg.Version));
     }
 


### PR DESCRIPTION
## Summary
- Replaced `Microsoft.Extensions.DependencyInjection.Abstractions` with `Microsoft.Extensions.DependencyInjection` in TestLib2.csproj, which provides the full DI namespace needed by `DiSetup.cs`
- Updated `GetNugetDependenciesToolTests` assertions to match the new package name

## Test plan
- [x] `dotnet build` succeeds
- [x] All 129 tests pass, including the two previously failing tests:
  - `GetDiagnosticsToolTests.GetDiagnostics_CleanSolution_ReturnsNoErrors`
  - `GetDiRegistrationsToolTests.FindDiRegistrations_ForIGreeter_ReturnsRegistration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)