### PR TITLE
fix: restore test fixtures in release workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         run: dotnet build -c Release -p:Version=${{ needs.release-please.outputs.version }}
 
+      - name: Restore test fixtures
+        run: dotnet restore tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
+
       - name: Test
         run: dotnet test -c Release --no-build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore -c Release -p:Version=${{ steps.version.outputs.version }}
 
+      - name: Restore test fixtures
+        run: dotnet restore tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
+
       - name: Test
         run: dotnet test --no-build -c Release --verbosity normal
 


### PR DESCRIPTION
## Summary
- Added a `dotnet restore` step for the test fixture solution (`TestSolution.slnx`) in both `release-please.yml` and `release.yml` workflows
- This step is placed after the build step and before the test step, matching the existing pattern in `ci.yml`
- Roslyn's MSBuild workspace requires NuGet packages to be physically restored to resolve them during tests

## Test plan
- [ ] Verify `release-please.yml` workflow passes when a release is created
- [ ] Verify `release.yml` workflow passes when a release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)