### PR TITLE
fix: update server.json to match latest NuGet version

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.1.4",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
-      "version": "1.1.0",
+      "version": "1.1.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Updated both `version` fields in `server.json` from `1.1.0` to `1.1.4` to match the latest NuGet package version
- Version 1.1.0 was never published to NuGet; 1.1.4 is the current release

## Test plan
- [ ] Verify `server.json` contains `1.1.4` in both version fields
- [ ] Confirm MCP registry picks up the correct NuGet package version

🤖 Generated with [Claude Code](https://claude.com/claude-code)