### PR TITLE
fix: set server.json version to match release-please manifest

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
     "source": "github"
   },
-  "version": "0.0.0",
+  "version": "1.1.6",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
-      "version": "0.0.0",
+      "version": "1.1.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary
- Set server.json versions to `1.1.6` to match release-please manifest
- Release-please finds-and-replaces the current version — `0.0.0` can't be found so it was never updated

## Test plan
- [ ] Merge and verify release-please updates server.json on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)