### PR TITLE
docs(skill): harden roslyn-codelens skill against Grep/build fallback

### DIFF
--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -1,111 +1,151 @@
 ---
 name: roslyn-codelens
-description: Use Roslyn-powered semantic code intelligence when working with .NET codebases. Activates automatically when roslyn-codelens MCP tools are available.
+description: Use when working with any .NET / C# code (.cs/.csproj/.sln files), finding callers/references/implementations, checking compiler errors or warnings, running dotnet build for diagnostics, searching for a type/method/interface by name, inspecting DI registrations, detecting dead code or circular dependencies, inspecting source-generator output, or about to Grep/Glob across a C# codebase — activates when roslyn-codelens MCP tools are available.
 ---
 
-# Roslyn Code Graph Intelligence
+# Roslyn CodeLens — Semantic .NET Intelligence
 
 ## Detection
 
-Check if `find_implementations` is available as an MCP tool. If not, this skill is inert — do nothing.
+If `find_implementations` is not available as an MCP tool, this skill is inert — do nothing, no errors.
 
-## Critical Rules
+If it IS available, every rule below applies. No exceptions.
 
-1. **Never use `dotnet build`, `dotnet msbuild`, or MSBuild output** to find compiler errors, warnings, or code quality issues. Use `get_diagnostics` instead — it returns the same diagnostics (and more, including analyzer results) without a separate build step.
-2. **Never use Grep/Glob** for navigating .NET codebases when these tools are available. They provide semantic accuracy that text search cannot match — finding true callers, implementations, and references rather than string matches.
-3. **Always prefer these MCP tools first** for any .NET code understanding, navigation, or quality task. Only fall back to Grep/Glob for non-.NET files or when searching for string literals/comments.
+## The Iron Law
 
-## When to Use These Tools
+**On a .NET codebase where roslyn-codelens MCP tools are available:**
 
-Use these tools **instead of Grep/Glob and instead of MSBuild** whenever you need to understand .NET code structure, find issues, or navigate the codebase.
+1. **Never** use `Grep`, `Glob`, or Bash `grep`/`rg` to locate C# symbols, types, methods, interfaces, references, callers, implementations, or usages.
+2. **Never** run `dotnet build`, `dotnet msbuild`, `msbuild`, or any build command to surface compiler errors, warnings, or analyzer diagnostics.
+3. **Never** manually read a `.cs` file to "grep in my head" for who uses a symbol, or to check if code compiles.
+
+The semantic tools (`find_callers`, `find_references`, `find_implementations`, `search_symbols`, `get_diagnostics`, `go_to_definition`, etc.) are **always** more accurate than text search and **always** faster than a build. There is no tradeoff to weigh.
+
+**Violating the letter of these rules is violating the spirit.** If you're about to run a command or tool that *substitutes* for one of these semantic tools, stop.
+
+## Red Flags — STOP and Use the MCP Tool
+
+If any of these thoughts cross your mind, stop and switch to the MCP tool:
+
+| Thought / Action | STOP — Use instead |
+|---|---|
+| "Let me `Grep` for `class Foo`" | `search_symbols` or `go_to_definition` |
+| "Let me `Grep` for `Foo\\.Bar\\(`" (finding callers) | `find_callers` |
+| "Let me `Grep` for `: IFoo`" (finding implementations) | `find_implementations` |
+| "Let me `Grep` for `new Foo(`" | `find_references` |
+| "Let me `Grep` for `[Authorize]`" | `find_attribute_usages` |
+| "I'll run `dotnet build` to see errors" | `get_diagnostics` |
+| "I'll run `dotnet build -warnaserror` to find warnings" | `get_diagnostics` |
+| "Let me `Read` the .cs file to see what's defined" | `get_file_overview` or `get_type_overview` |
+| "Let me `Glob` for `**/*Service.cs`" | `search_symbols` with a partial name |
+| "Let me `Grep` for `Activator.CreateInstance`" | `find_reflection_usage` |
+| "I'll check if this method is used by reading files" | `find_callers` / `find_unused_symbols` |
+| "I'll eyeball complexity by reading the method" | `get_complexity_metrics` |
+
+**All of these mean: the MCP tool is the correct tool. Use it.**
+
+## Rationalizations — and why they're wrong
+
+| Excuse | Reality |
+|---|---|
+| "Just a quick Grep — it's faster." | It isn't. One `find_references` beats iterating Grep + reading matches + deduping false positives. |
+| "Grep as a sanity check on top of the MCP tool." | Redundant and misleading. Grep finds comments, strings, partial matches. If Roslyn says there are N references, there are N references. |
+| "This is just a string/literal search, so Grep is fine." | If the target is a C# symbol, it's not "just a string" — it has a definition, scope, and binding. Use `find_references`. String literal searches in comments/docstrings are the *only* legitimate Grep case. |
+| "`dotnet build` is how everyone checks errors." | Not here. `get_diagnostics` returns compiler errors + analyzer results, structured, without rebuilding. A build is minutes; the tool is milliseconds. |
+| "The MCP server might be slow / might fail." | If it fails, report that and ask. Do not silently fall back to Grep — that produces wrong answers that look right. |
+| "I need to see the file contents anyway." | `get_file_overview`, `get_type_overview`, and `analyze_method` give you structure without a `Read`. Use `Read` only after you know which lines matter. |
+| "The user asked me to Grep." | If the user asked for *a grep* specifically, ask if they actually want semantic results. If they asked for *information about the code* and suggested grep, use the semantic tool and tell them why. |
+| "I'm just looking for TODO comments / string literals." | Fine — Grep is legitimate for comments, string literals, and non-C# files. That's the only free pass. |
+
+## Pre-Action Checklist
+
+**Before calling `Grep` or `Glob` on `.cs` / `.csproj` / `.sln` / `.cshtml` files:**
+1. Is the target a C# symbol (type/member/namespace)? → Use `search_symbols` or `find_references`.
+2. Is the target an attribute? → Use `find_attribute_usages`.
+3. Is the target a reflection pattern? → Use `find_reflection_usage`.
+4. Is it *genuinely* a string literal, comment, or non-semantic text? → Grep is OK. State why.
+
+**Before running `dotnet build` / `msbuild` via Bash:**
+1. Am I looking for errors, warnings, or analyzer diagnostics? → Use `get_diagnostics`. Stop.
+2. Am I actually trying to produce a binary / run tests / package? → Build is OK. State why.
+
+**Before `Read`ing a `.cs` file:**
+1. Do I just need structure (what's in it, what's defined)? → `get_file_overview` / `get_type_overview`.
+2. Do I need a specific method's shape? → `analyze_method`.
+3. Do I need the actual source lines to edit? → `Read` is OK.
+
+## When to Use Each Tool
 
 ### Understanding a Codebase
+- `get_project_dependencies` — solution architecture, how projects relate.
+- `get_symbol_context` — full context for a type (namespace, base, interfaces, DI deps, public members).
+- `get_type_hierarchy` — inheritance chains and extension points.
+- `get_type_overview` — one-shot: context + hierarchy + diagnostics (replaces 3 calls).
+- `get_file_overview` — types defined in a file + diagnostics, without reading it.
+- `analyze_method` — signature + callers + outgoing calls, all in one.
 
-- Call `get_project_dependencies` to understand solution architecture and how projects relate
-- Call `get_symbol_context` on types mentioned in the user's request for a full context dump (namespace, base class, interfaces, DI dependencies, public members)
-- Call `get_type_hierarchy` to understand inheritance chains and extension points
-- Call `get_type_overview` for a one-shot view of a type: context + hierarchy + file diagnostics (replaces 3 separate calls)
-- Call `get_file_overview` to see which types are defined in a file and any diagnostics — without reading the file
-- Call `analyze_method` to get signature, callers, and outgoing calls for a method in one call
-
-### Navigating Code
-
-**Do NOT use Grep/Glob to find .NET types, methods, or usages.** Text search gives false positives (comments, strings, partial matches). These tools understand the actual code:
-
-- Use `go_to_definition` to jump to where a type or member is defined — replaces Grep/Glob file search
-- Use `search_symbols` to fuzzy-find types, methods, properties, and fields by name — replaces `Grep` for symbol lookup
-- Use `find_references` to find every reference to a symbol across the entire solution — replaces `Grep` for usage search
+### Navigating Code (**instead of Grep/Glob**)
+- `go_to_definition` — jump to the definition.
+- `search_symbols` — fuzzy symbol lookup.
+- `find_references` — every reference across the solution.
 
 ### Finding Dependencies and Usage
+- `find_callers` — every call site for a method.
+- `find_implementations` — all implementors of an interface / extenders of a class.
+- `get_di_registrations` — DI wiring and lifetimes.
+- `find_reflection_usage` — hidden/dynamic coupling (`Activator.CreateInstance`, `MethodInfo.Invoke`, assembly scanning).
+- `get_nuget_dependencies` — NuGet packages and versions.
+- `find_attribute_usages` — members decorated with a given attribute.
 
-- Use `find_callers` to find every call site for a method — more accurate than text search
-- Use `find_implementations` to find all classes implementing an interface or extending a class
-- Use `get_di_registrations` to see how types are wired in the DI container and their lifetimes
-- Use `find_reflection_usage` to detect hidden/dynamic coupling that text search misses (Type.GetType, Activator.CreateInstance, MethodInfo.Invoke, assembly scanning)
-- Use `get_nuget_dependencies` to see what NuGet packages a project uses and their versions
-- Use `find_attribute_usages` to find all types/members decorated with a specific attribute (e.g., Obsolete, Authorize, Serializable)
+### Diagnostics (**instead of `dotnet build`**)
+- `get_diagnostics` — compiler errors, warnings, analyzer diagnostics. Replaces `dotnet build` output.
+- `get_code_fixes` — structured edits for a diagnostic.
+- `get_code_actions` — all refactorings/fixes at a position (with optional range).
+- `apply_code_action` — execute a refactoring by title. Preview mode by default.
+- `analyze_data_flow` — variable lifecycle over a statement range (declared/read/written/captured/flows-in/out).
+- `analyze_control_flow` — reachability, returns, unreachable paths.
 
-### Diagnosing Issues
-
-**Do NOT run `dotnet build` or `dotnet msbuild` to check for errors/warnings.** These MCP tools provide the same diagnostics plus analyzer results, structured as data you can act on:
-
-- Use `get_diagnostics` to list compiler errors, warnings, and Roslyn analyzer diagnostics across the solution — this replaces `dotnet build` output entirely
-- Use `get_code_fixes` to get structured text edits for fixing a specific diagnostic — review and apply via Edit tool (replaces manually interpreting build warnings)
-- Use `get_code_actions` to discover all available refactorings and fixes at a specific position (e.g., extract method, rename, inline variable). Optionally select a range with endLine/endColumn for extract-style operations
-- Use `apply_code_action` to execute a refactoring by its title (from `get_code_actions`). Defaults to preview mode — returns a diff without writing. Set preview=false to apply to disk
-- Use `analyze_data_flow` on a statement range to understand variable lifecycle (declared, read, written, captured, flows in/out) — useful before extracting code
-- Use `analyze_control_flow` on a statement range to check reachability, return statements, and unreachable code paths
-
-**Code generation via `apply_code_action`** — do NOT look for dedicated generation tools. These common tasks are all built-in Roslyn code actions; use `get_code_actions` to find the title, then `apply_code_action`:
-- Implement missing interface/abstract members → position on the class, look for "Implement abstract members" or "Implement interface"
-- Generate constructor from fields → position on the class, look for "Generate constructor"
-- Add null checks → position on a method, look for "Add null checks for all parameters"
-- Generate `Equals`/`GetHashCode` → position on the class, look for "Generate Equals and GetHashCode"
-- Encapsulate field → position on a field, look for "Encapsulate field"
-- Extract method → select statements, look for "Extract method"
-- Inline variable → position on variable, look for "Inline variable"
+**Code generation is in `apply_code_action`** — do NOT look for dedicated generation tools. Use `get_code_actions` to find the title, then `apply_code_action`:
+- Implement missing interface/abstract members → *"Implement abstract members"* / *"Implement interface"*
+- Generate constructor from fields → *"Generate constructor"*
+- Add null checks → *"Add null checks for all parameters"*
+- Generate `Equals`/`GetHashCode` → *"Generate Equals and GetHashCode"*
+- Encapsulate field → *"Encapsulate field"*
+- Extract method → *"Extract method"*
+- Inline variable → *"Inline variable"*
 
 ### Code Quality Analysis
-
-**Do NOT rely on MSBuild warnings or manual code inspection for quality checks.** Use these purpose-built tools:
-
-- Use `find_unused_symbols` to detect dead code — types/members with no references
-- Use `get_complexity_metrics` to find overly complex methods (cyclomatic complexity above threshold)
-- Use `find_naming_violations` to check .NET naming convention compliance (PascalCase, camelCase, I-prefix, _ prefix)
-- Use `find_large_classes` to identify types that may need refactoring (too many members or lines)
-- Use `find_circular_dependencies` to detect project or namespace dependency cycles
+- `find_unused_symbols` — dead code (reference-based).
+- `get_complexity_metrics` — cyclomatic complexity per method.
+- `find_naming_violations` — .NET naming conventions.
+- `find_large_classes` — oversized types.
+- `find_circular_dependencies` — project/namespace cycles.
 
 ### Source Generators
-
-- Use `get_source_generators` to list source generators and their output per project (optional project filter)
-- Use `get_generated_code` to inspect generated source code from source generators (filter by generator name or file path)
+- `get_source_generators` — list generators and their outputs.
+- `get_generated_code` — inspect generated source (filter by generator or file path).
 
 ### Solution Management
+- `list_solutions` — loaded solutions, which is active.
+- `set_active_solution` — switch active solution by partial name.
+- `load_solution` — load a `.sln`/`.slnx` at runtime.
+- `unload_solution` — free memory.
+- `rebuild_solution` — full reload (after `Directory.Build.props` changes, new analyzers/packages, or stale diagnostics).
 
-- Use `list_solutions` to see all loaded solutions, which one is active, how many projects each has, and their status.
-- Use `set_active_solution` to switch the active solution by partial name (e.g. `set_active_solution("ProjectB")`). Call this at the start of a session when multiple solutions are loaded.
-- Use `load_solution` to load a `.sln`/`.slnx` file at runtime and make it active (~3s for a new solution, instant if already loaded). Use this when the server was started empty or you need to switch to a codebase that isn't loaded yet.
-- Use `unload_solution` to remove a solution by partial name and free its memory. The next loaded solution becomes active, or none if it was the last. Use this when done with a codebase in a long-running session.
-- Use `rebuild_solution` to force a full reload of the analyzed solution — re-opens the `.sln`, recompiles all projects, and rebuilds all indexes. Use after changing `Directory.Build.props`, adding/removing NuGet packages or analyzers, or when diagnostics seem stale.
+### Planning a Change — standard order
+1. `get_type_overview` — context + hierarchy + diagnostics.
+2. `analyze_change_impact` — blast radius (files, projects, call sites).
+3. `find_references` / `find_callers` / `find_implementations` — detailed dependency breakdown.
+4. `get_project_dependencies` — architectural position.
+5. `get_di_registrations` — wiring.
+6. `find_reflection_usage` — dynamic coupling.
+7. `find_attribute_usages` — attribute-driven behavior.
+8. `get_diagnostics` — existing issues.
+9. `get_code_fixes` / `get_code_actions` → `apply_code_action` — auto-fixes and refactorings.
+10. `find_unused_symbols` — dead code to delete instead of refactor.
+11. `get_complexity_metrics` — complexity hotspots.
 
-### Planning Changes
-
-Before modifying code, use these tools to understand the impact:
-
-1. `get_type_overview` — one-shot: context + hierarchy + diagnostics for the type
-2. `analyze_change_impact` — blast radius: all files, projects, and call sites affected by changing a symbol
-3. `find_references` + `find_callers` + `find_implementations` — detailed dependency breakdown if needed
-4. `get_project_dependencies` — where does it sit in the architecture?
-5. `get_di_registrations` — how is it wired up?
-6. `find_reflection_usage` — is it used dynamically?
-7. `find_attribute_usages` — are there attribute-driven behaviors (authorization, serialization, etc.)?
-8. `get_diagnostics` — are there existing compiler/analyzer warnings to address?
-9. `get_code_fixes` — can any warnings be auto-fixed?
-9b. `get_code_actions` → `apply_code_action` — discover and apply refactorings (extract method, rename, inline, etc.)
-10. `find_unused_symbols` — is there dead code to clean up?
-11. `get_complexity_metrics` — are there overly complex methods?
-
-Reference concrete types, interfaces, and call sites in your analysis. Example: "These 3 classes implement IUserService: UserService, CachedUserService, AdminUserService."
+Reference concrete types, interfaces, and call sites in your analysis. Not *"the services that implement this"* but *"These 3 classes implement `IUserService`: `UserService`, `CachedUserService`, `AdminUserService`."*
 
 ## Tool Quick Reference
 
@@ -116,32 +156,46 @@ Reference concrete types, interfaces, and call sites in your analysis. Example: 
 | `find_references` | "Where is this symbol used?" / "Show all references" |
 | `go_to_definition` | "Where is this defined?" / "Jump to source" |
 | `search_symbols` | "Find types/methods matching this name" |
-| `get_type_hierarchy` | "What's the inheritance chain?" / "What are the extension points?" |
-| `get_symbol_context` | "Give me everything about this type" (one-shot) |
+| `get_type_hierarchy` | "What's the inheritance chain?" |
+| `get_symbol_context` | "Give me everything about this type" |
 | `get_di_registrations` | "How is this wired up?" / "What's the DI lifetime?" |
-| `get_project_dependencies` | "How do projects relate?" / "What's the dependency graph?" |
+| `get_project_dependencies` | "How do projects relate?" |
 | `get_nuget_dependencies` | "What packages does this project use?" |
-| `find_reflection_usage` | "Is this used dynamically?" / "Are there hidden dependencies?" |
+| `find_reflection_usage` | "Is this used dynamically?" |
 | `find_attribute_usages` | "What's marked [Obsolete]?" / "Find all [Authorize] controllers" |
-| `get_diagnostics` | "Any compiler errors?" / "Show warnings for this project" |
-| `get_code_fixes` | "How do I fix this warning?" / "Get auto-fix suggestions" |
-| `get_code_actions` | "What refactorings are available here?" / "Can I extract this method?" |
-| `apply_code_action` | "Apply this refactoring" / "Extract method" / "Inline variable" |
-| `find_unused_symbols` | "Any dead code?" / "What's not being used?" |
+| `get_diagnostics` | "Any compiler errors?" / "Show warnings" |
+| `get_code_fixes` | "How do I fix this warning?" |
+| `get_code_actions` | "What refactorings are available here?" |
+| `apply_code_action` | "Apply this refactoring" / "Extract method" |
+| `find_unused_symbols` | "Any dead code?" |
 | `get_complexity_metrics` | "Which methods are too complex?" |
 | `find_naming_violations` | "Check naming conventions" |
 | `find_large_classes` | "Find classes that need splitting" |
 | `find_circular_dependencies` | "Any circular dependencies?" |
-| `get_source_generators` | "What source generators are active?" / "List generators for this project" |
-| `get_generated_code` | "Show generated code" / "What did this generator produce?" |
-| `list_solutions` | "What solutions are loaded?" / "Which solution is active?" |
-| `load_solution` | "Load this .sln at runtime" / "Switch to a codebase not yet loaded" |
-| `unload_solution` | "Free memory for this solution" / "Remove a loaded codebase" |
-| `set_active_solution` | "Switch to project B" / "Use the other solution" |
-| `rebuild_solution` | "Reload the solution" / "Pick up new analyzers" / "Diagnostics are stale" |
-| `analyze_data_flow` | "What variables are read/written here?" / "What flows out of this block?" |
-| `analyze_control_flow` | "Is this code reachable?" / "Any unreachable statements?" |
-| `analyze_change_impact` | "What breaks if I change this?" / "Show blast radius" |
+| `get_source_generators` | "What source generators are active?" |
+| `get_generated_code` | "Show generated code" |
+| `list_solutions` | "What solutions are loaded?" |
+| `load_solution` | "Load this .sln at runtime" |
+| `unload_solution` | "Free memory for this solution" |
+| `set_active_solution` | "Switch to project B" |
+| `rebuild_solution` | "Reload the solution" / "Diagnostics are stale" |
+| `analyze_data_flow` | "What variables are read/written here?" |
+| `analyze_control_flow` | "Is this code reachable?" |
+| `analyze_change_impact` | "What breaks if I change this?" |
 | `get_type_overview` | "Give me everything about this type in one call" |
-| `analyze_method` | "Show signature, callers, and outgoing calls for this method" |
-| `get_file_overview` | "What types are in this file?" / "Any diagnostics in this file?" |
+| `analyze_method` | "Show signature, callers, and outgoing calls" |
+| `get_file_overview` | "What types are in this file?" |
+
+## Legitimate Grep / Build Exceptions
+
+Grep is the correct tool for:
+- Non-C# files (`.json`, `.yaml`, `.md`, `.razor` template text, shell scripts).
+- String literals and comments inside C# code.
+- Text that isn't a symbol (log messages, error strings, TODOs).
+
+`dotnet build` is the correct command for:
+- Actually producing a binary.
+- Running tests (`dotnet test`) — not covered by this skill.
+- Packaging / publishing.
+
+State the reason when you take the exception. If you're about to type a Grep/Glob/build command and can't state the reason out loud, you're rationalizing — use the MCP tool.


### PR DESCRIPTION
## Summary

Rewrite `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` to make the rules against `Grep`/`Glob` and `dotnet build` unambiguous and rationalization-resistant. The skill previously activated "automatically when tools are available" and relied on a short Critical Rules section — in practice Claude still fell back to Grep and MSBuild on .NET codebases.

## What changed

- **Description rewritten** to start with "Use when…" and front-load symptom-based triggers (`.cs` files, `find callers/references/implementations`, `check compiler errors/warnings`, `dotnet build`, `Grep a method name`, etc.) so the skill matcher fires in the right situations.
- **Iron Law** block at the top stating the three absolute rules, with a "letter vs spirit" clause.
- **Red Flags — STOP table** mapping each common Grep/Read/build thought to the correct MCP tool.
- **Rationalization table** with explicit counters for the excuses Claude reaches for (*"just a quick Grep"*, *"sanity check on top of MCP"*, *"dotnet build is how everyone checks errors"*, etc.).
- **Pre-action checklist** — 2–3 questions to answer *before* calling Grep/Glob, running `dotnet build`, or `Read`ing a `.cs` file.
- **Legitimate exceptions section** — Grep is correct for non-C# files, comments, string literals; build is correct when actually producing binaries. Agent must state the reason.
- Tool reference kept inline at the bottom, unchanged in content.

## Test plan

- [ ] Validate the skill description triggers on plain .NET asks (e.g. "find callers of `Foo.Bar`", "check for compile errors") without the agent needing a hint.
- [ ] Spot-check a session where Claude previously fell back to Grep/Glob on a .cs file — verify it now reaches for the MCP tool.
- [ ] Verify no regressions for legitimate Grep cases (comment / string literal searches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)