### PR TITLE
docs(skill): add .slnx triggers + wire marketplace.json into release-please

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-codelens-mcp",
   "description": "Roslyn-based .NET code graph intelligence for Claude Code",
-  "version": "1.0.0",
+  "version": "1.1.6",
   "owner": {
     "name": "Marcel Roozekrans"
   },
@@ -9,7 +9,7 @@
     {
       "name": "roslyn-codelens",
       "description": "Roslyn-based code graph intelligence for .NET codebases. Provides semantic understanding of type hierarchies, call sites, DI registrations, and reflection usage.",
-      "version": "1.0.0",
+      "version": "1.1.6",
       "author": {
         "name": "Marcel Roozekrans"
       },

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roslyn-codelens
-description: Use when working with any .NET / C# code (.cs/.csproj/.sln files), finding callers/references/implementations, checking compiler errors or warnings, running dotnet build for diagnostics, searching for a type/method/interface by name, inspecting DI registrations, detecting dead code or circular dependencies, inspecting source-generator output, or about to Grep/Glob across a C# codebase — activates when roslyn-codelens MCP tools are available.
+description: Use when working with any .NET / C# code (.cs/.csproj/.sln/.slnx files), finding callers/references/implementations, checking compiler errors or warnings, running dotnet build for diagnostics, searching for a type/method/interface by name, inspecting DI registrations, detecting dead code or circular dependencies, inspecting source-generator output, or about to Grep/Glob across a C# codebase — activates when roslyn-codelens MCP tools are available.
 ---
 
 # Roslyn CodeLens — Semantic .NET Intelligence
@@ -59,7 +59,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 
 ## Pre-Action Checklist
 
-**Before calling `Grep` or `Glob` on `.cs` / `.csproj` / `.sln` / `.cshtml` files:**
+**Before calling `Grep` or `Glob` on `.cs` / `.csproj` / `.sln` / `.slnx` / `.cshtml` files:**
 1. Is the target a C# symbol (type/member/namespace)? → Use `search_symbols` or `find_references`.
 2. Is the target an attribute? → Use `find_attribute_usages`.
 3. Is the target a reflection pattern? → Use `find_reflection_usage`.
@@ -175,7 +175,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `get_source_generators` | "What source generators are active?" |
 | `get_generated_code` | "Show generated code" |
 | `list_solutions` | "What solutions are loaded?" |
-| `load_solution` | "Load this .sln at runtime" |
+| `load_solution` | "Load this .sln / .slnx at runtime" |
 | `unload_solution` | "Free memory for this solution" |
 | `set_active_solution` | "Switch to project B" |
 | `rebuild_solution` | "Reload the solution" / "Diagnostics are stale" |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,16 @@
           "type": "json",
           "path": "server.json",
           "jsonpath": "$.packages[0].version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".claude-plugin/marketplace.json",
+          "jsonpath": "$.plugins[0].version"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Follow-up to #93 — those two commits were pushed to the branch after the PR was already merged, so they never landed on \`main\`. This PR brings them in:

1. **\`.slnx\` triggers** added to the skill description, the pre-action Grep/Glob checklist, and the \`load_solution\` quick-reference row, so the skill fires on \`.slnx\` solutions as well as \`.sln\`.
2. **\`marketplace.json\` catch-up bump** from the stale \`1.0.0\` to \`1.1.6\` so it matches the current release tag.
3. **Wire \`.claude-plugin/marketplace.json\` into \`release-please-config.json\` \`extra-files\`** (top-level \`version\` and \`plugins[0].version\`) so future releases auto-bump the marketplace manifest, which is what Claude Code polls to detect plugin updates.

The \`fix:\` commit type also signals release-please to cut a patch release on merge.

## Test plan

- [ ] Verify the skill description matches on \`.slnx\` files in addition to \`.sln\`.
- [ ] Confirm release-please opens a release PR after merge that bumps both \`server.json\` and \`marketplace.json\` versions in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)