### PR TITLE
feat: external-assembly analysis — Phase 1 (Tier 1 + inspect_external_assembly)

### DIFF
--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -122,7 +122,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "search_symbols: Greet")]
     public object SearchSymbols()
     {
-        return SearchSymbolsLogic.Execute(_resolver, "Greet");
+        return SearchSymbolsLogic.Execute(_resolver, _metadata, "Greet");
     }
 
     [Benchmark(Description = "get_nuget_dependencies: all")]

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -92,7 +92,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "get_symbol_context: GreeterConsumer")]
     public object GetSymbolContext()
     {
-        return GetSymbolContextLogic.Execute(_loaded, _resolver, "GreeterConsumer")!;
+        return GetSymbolContextLogic.Execute(_loaded, _resolver, _metadata, "GreeterConsumer")!;
     }
 
     [Benchmark(Description = "find_reflection_usage: all")]

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -74,7 +74,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "get_type_hierarchy: Greeter")]
     public object GetTypeHierarchy()
     {
-        return GetTypeHierarchyLogic.Execute(_loaded, _resolver, "Greeter")!;
+        return GetTypeHierarchyLogic.Execute(_resolver, _metadata, "Greeter")!;
     }
 
     [Benchmark(Description = "get_di_registrations: IGreeter")]

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -134,7 +134,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "find_attribute_usages: Obsolete")]
     public object FindAttributeUsages()
     {
-        return FindAttributeUsagesLogic.Execute(_loaded, _resolver, "Obsolete");
+        return FindAttributeUsagesLogic.Execute(_loaded, _resolver, _metadata, "Obsolete");
     }
 
     [Benchmark(Description = "find_circular_dependencies: project")]

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using Microsoft.Build.Locator;
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Benchmarks;
@@ -12,6 +13,7 @@ public class CodeGraphBenchmarks
     private static readonly string FixturePath;
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
     private string _greeterPath = null!;
     private string _diSetupPath = null!;
 
@@ -40,6 +42,7 @@ public class CodeGraphBenchmarks
     {
         _loaded = await new SolutionLoader().LoadAsync(FixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
         _greeterPath = _loaded.Solution.Projects
             .First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal))
             .Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal))
@@ -107,7 +110,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "go_to_definition: Greeter")]
     public object GoToDefinition()
     {
-        return GoToDefinitionLogic.Execute(_resolver, "Greeter");
+        return GoToDefinitionLogic.Execute(_resolver, _metadata, "Greeter");
     }
 
     [Benchmark(Description = "get_diagnostics: all")]

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -200,7 +200,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "get_type_overview: Greeter")]
     public object? GetTypeOverview()
     {
-        return GetTypeOverviewLogic.Execute(_loaded, _resolver, "Greeter");
+        return GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "Greeter");
     }
 
     [Benchmark(Description = "analyze_method: Greeter.Greet")]

--- a/docs/plans/2026-04-24-closed-source-assemblies-design.md
+++ b/docs/plans/2026-04-24-closed-source-assemblies-design.md
@@ -1,0 +1,167 @@
+# Closed-Source Assembly Analysis — Design
+
+> Addresses [#95](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/95). Brainstormed and approved 2026-04-24.
+
+## Goal
+
+Enable semantic analysis of assemblies for which source is not available — third-party NuGet packages and internal company binaries referenced by the active solution. Developers should be able to inspect API surface, read XML docs, find where their code uses external symbols, and when needed peek the IL of a specific method.
+
+## Scope
+
+**In scope**
+
+- API surface of metadata symbols: types, members, signatures, attributes, inheritance, generic parameters.
+- XML documentation loaded from sidecar `.xml` files.
+- Source-to-metadata reference queries (who in my code calls this external method, implements this external interface).
+- Raw IL disassembly for individual methods in closed-source assemblies.
+
+**Out of scope (explicit non-goals)**
+
+- No C# decompilation. IL only.
+- No arbitrary DLL paths. Analysis is scoped to assemblies referenced by the active solution. The skill teaches a "add a temp `ProjectReference`, reload" workaround for the rare case where browsing a not-yet-referenced DLL is needed.
+- No NuGet-cache browsing without a solution loaded.
+- No extension of method-body or project-scoped analyses (Tier 3 below).
+- No metadata symbol-name index — resolution uses Roslyn's built-in lookups.
+- `peek_il` does not return structured instruction arrays — only ilasm text.
+
+## Tool surface
+
+### New tools
+
+#### `inspect_external_assembly`
+
+| Field | Value |
+|---|---|
+| Input | `assemblyName: string`, `mode: "summary" \| "namespace" = "summary"`, `namespace?: string` (required when `mode === "namespace"`) |
+| Summary output | `{ name, version, targetFramework, publicKeyToken, namespaceTree: [{ namespace, typeCount, publicTypeNames: string[] }] }` — no members, no docs, bounded regardless of DLL size |
+| Namespace output | For each public type in the namespace: kind, signature, modifiers, base/interfaces, members with signatures and XML-doc summaries, attributes. No IL. |
+| Errors | Assembly not referenced by any project in the active solution (hints at `get_nuget_dependencies`). Unknown namespace. |
+
+Chosen shape (summary + namespace drill-down) handles size variance from ~30 types (`Microsoft.Extensions.DependencyInjection.Abstractions`) to ~5000 types (`System.Private.CoreLib`) without blowing token budget. Mirrors how `get_file_overview` → `get_type_overview` compose in this project.
+
+#### `peek_il`
+
+| Field | Value |
+|---|---|
+| Input | `methodSymbol: string` — fully qualified with parameter types, e.g. `"Newtonsoft.Json.JsonConvert.SerializeObject(object, Newtonsoft.Json.Formatting)"` |
+| Output | ilasm-style text: method signature, `.locals init (...)`, labeled IL instructions, `.try`/`handler` regions. Produced by `ICSharpCode.Decompiler.Disassembler.ReflectionDisassembler`. |
+| Errors | Symbol resolves to source (directs caller to `go_to_definition`). Symbol resolves to abstract/interface member or property with no body. Symbol not found. |
+
+Method-only input avoids accidental context blowup from dumping every overload. ilasm text is the format LLMs recognize as IL from training data — structured JSON would be a novelty.
+
+### Extended existing tools
+
+All extended tools gain an origin block in their output when the resolved symbol is metadata:
+
+```
+origin: "metadata"
+assemblyName: "Newtonsoft.Json"
+assemblyVersion: "13.0.3"
+docId: "M:Newtonsoft.Json.JsonConvert.SerializeObject(System.Object)"
+```
+
+`sourceLocation` is omitted rather than faked.
+
+**Tier 1 — semantic queries on metadata symbols.** Roslyn's underlying calls already return `ISymbol` instances for metadata; tools just drop their source-only guard and add the origin block.
+
+- `get_symbol_context`
+- `get_type_overview`
+- `get_type_hierarchy` (derived types remain source-scanned — we cannot enumerate derivations across the whole ecosystem)
+- `search_symbols`
+- `find_attribute_usages`
+- `go_to_definition`
+
+**Tier 2 — source-to-metadata references.** Uses `SymbolFinder.FindReferencesAsync` / `SymbolFinder.FindImplementationsAsync`, which operate on metadata symbols natively. Highest-value piece of the feature: "who in my code depends on this external method/interface."
+
+- `find_references`
+- `find_callers`
+- `find_implementations`
+
+**Tier 3 — explicitly not extended.** Either require method bodies we do not have, or are project-scoped analyses that would produce noise when fanned out across transitive dependencies.
+
+- `analyze_data_flow`, `analyze_control_flow`
+- `analyze_change_impact`
+- `get_code_actions`, `apply_code_action`, `get_code_fixes`
+- `find_unused_symbols`, `find_large_classes`, `find_naming_violations`, `get_complexity_metrics`, `find_reflection_usage`, `get_di_registrations`
+
+## Architecture
+
+### Symbol resolution layer
+
+New component: `MetadataSymbolResolver`. Given a symbol name string, returns `ISymbol + origin`:
+
+1. Query the existing source `SymbolIndex`. If it resolves, return `origin: "source"`.
+2. Otherwise call `Compilation.GetTypeByMetadataName(name)` on the active solution's compilations. For member lookups, parse `TypeName.MemberName(paramTypes)` and call `ITypeSymbol.GetMembers()` filtered by signature.
+3. If nothing matches, error.
+
+Ambiguity (same name in source and metadata) resolves to source — matching how the compilation itself binds. No separate metadata index is built.
+
+### Assembly discovery
+
+`Compilation.GetReferencedAssemblySymbols()` already contains every direct and transitive assembly the compilation binds against. MSBuild flattens package references so we do not walk `IAssemblySymbol.Modules[0].ReferencedAssemblySymbols` ourselves. When multiple projects reference the same assembly at different versions, symbols are unioned across projects.
+
+### IL peek pipeline
+
+`IMethodSymbol` carries `ContainingAssembly.MetadataName` and a `DocumentationCommentId`. From the matching `PortableExecutableReference` we get the DLL path → open `PEReader` via `System.Reflection.Metadata` → hand to `ICSharpCode.Decompiler.Disassembler.ReflectionDisassembler` keyed by the method's metadata token. Output is ilasm text.
+
+### XML docs
+
+Roslyn loads XML docs via a `DocumentationProvider` attached to a `PortableExecutableReference`. For NuGet-restored assemblies the `.xml` sidecar sits next to the DLL and `MSBuildWorkspace` wires `XmlDocumentationProvider.CreateFromFile` automatically. Audit item: verify this actually happens in the current metadata-reference construction path; attach a provider explicitly if missing. We consume docs via `ISymbol.GetDocumentationCommentXml()` — no new format parsing.
+
+### Caching and hot reload
+
+Two caches, both keyed by `(assemblyPath, fileTimestamp)`:
+
+- `AssemblySummaryCache` — `inspect_external_assembly summary` results (namespace tree + type counts per namespace).
+- `PEFileCache` — open `PEFile` and `ReflectionDisassembler` instances for repeated `peek_il` calls on the same DLL.
+
+Both hook `FileChangeTracker`. Source-file changes leave both caches untouched; referenced-assembly file changes (NuGet restore, rebuild of an internal dep) invalidate the matching entries.
+
+### New components inventory
+
+- `src/RoslynCodeLens/Symbols/MetadataSymbolResolver.cs`
+- `src/RoslynCodeLens/Tools/InspectExternalAssemblyTool.cs` + `Logic/InspectExternalAssemblyLogic.cs`
+- `src/RoslynCodeLens/Tools/PeekIlTool.cs` + `Logic/PeekIlLogic.cs`
+- `src/RoslynCodeLens/Metadata/AssemblySummaryCache.cs`
+- `src/RoslynCodeLens/Metadata/PEFileCache.cs`
+- `src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs` — thin wrapper so tool code never references `ICSharpCode.Decompiler` types directly.
+
+Changes to existing files are small — each extended tool drops its source-only guard and adds the origin block to its output DTO. Most of the diff in extended-tool work lives in tests.
+
+### New dependency
+
+`ICSharpCode.Decompiler` NuGet package (LGPL-2.1). Only the disassembler (`Disassembler.ReflectionDisassembler`) is used — no decompiler types are referenced. Attribution added to `NOTICE` and `README`.
+
+## SKILL.md updates
+
+First-class deliverable. Updates to `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`:
+
+- New **Working with external assemblies** section: what counts as external, how symbols are addressed, the `origin: "metadata"` marker.
+- **Per-tool metadata behavior table** — one row per existing tool: *works / does not work / caveats*. The Tier 3 list is surfaced explicitly so Claude does not waste calls on tools that will reject metadata input.
+- Documentation for both new tools with worked examples — summary → namespace drill-down for exploration; `find_callers` → `peek_il` for "what does this method actually do."
+- **Scope-limitation workarounds**: arbitrary DLL path → add a temp `ProjectReference` / `<Reference>` to a throwaway project, reload. Same pattern for browsing NuGet-cache entries not referenced by any project. These are documented SKILL patterns, not server features.
+- Decision tree at the top: *symbol in my source → existing tools. External symbol with a name → same existing tools (Tier 1+2). Explore a package → `inspect_external_assembly`. See what a method actually does → `peek_il`.*
+
+## Testing
+
+xUnit pattern per existing code:
+
+- `MetadataSymbolResolverTests` — fixture referencing a small known public NuGet. Covers type, member, overload ambiguity, source-shadows-metadata, not-found.
+- `InspectExternalAssemblyLogicTests` — summary shape, namespace mode, error on unreferenced assembly, error on unknown namespace.
+- `PeekIlLogicTests` — known-method IL output contains expected opcodes, error on abstract/interface member, error on source symbol.
+- Extended-tool tests — one test per extended tool asserting metadata input yields the expected origin block, and for Tier 2 that source-to-metadata references are discovered. Most can extend existing fixtures by targeting a NuGet symbol instead of a source one.
+- Benchmarks — `inspect_external_assembly` (summary + namespace) and `peek_il` added to the BenchmarkDotNet suite. `MetadataSymbolResolver` gets its own micro-benchmark to guard against naive-enumeration regressions.
+
+## Phased rollout
+
+Three independently shippable phases, each a PR:
+
+1. **Phase 1 — foundations + Tier 1.** `MetadataSymbolResolver`, origin-field plumbing on output DTOs, the six Tier 1 extended tools, `inspect_external_assembly`, SKILL.md updates for Phase 1 scope, `AssemblySummaryCache`. No new library dependency yet.
+2. **Phase 2 — Tier 2 references.** `find_references` / `find_callers` / `find_implementations` accept metadata input. Small phase — mostly guard removal + tests — but isolated because it delivers the highest-value user-facing capability and deserves its own review.
+3. **Phase 3 — `peek_il`.** Adds the `ICSharpCode.Decompiler` dependency (attribution, NOTICE update), `PeekIlTool`, `PEFileCache`, `IlDisassemblerAdapter`, SKILL.md updates, benchmarks. Isolated so the dependency addition can be reverted cleanly if license or binary-size concerns surface.
+
+## Open questions for implementation
+
+- Verify `XmlDocumentationProvider` is attached to `PortableExecutableReference` in the current MSBuildWorkspace-loading path. If not, wire it up in Phase 1.
+- Confirm `Compilation.GetTypeByMetadataName` behavior for generic types in our Roslyn 4.14 — should accept both `List\`1` metadata-name form and `List<T>` display form consistently. Document the accepted input form in the tool docs and in SKILL.md.
+- Decide whether `inspect_external_assembly summary` should sort namespaces alphabetically or by type count — pick one for determinism in Phase 1, document.

--- a/docs/plans/2026-04-24-closed-source-assemblies-phase-1.md
+++ b/docs/plans/2026-04-24-closed-source-assemblies-phase-1.md
@@ -1,0 +1,887 @@
+# Phase 1 — Foundations + Tier 1 + inspect_external_assembly
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Tier-1 read-only tools (`get_symbol_context`, `get_type_overview`, `get_type_hierarchy`, `search_symbols`, `find_attribute_usages`, `go_to_definition`) accept metadata symbols, and add the new `inspect_external_assembly` tool.
+
+**Architecture:** Introduce `MetadataSymbolResolver` as a thin layer that extends `SymbolResolver.FindSymbols` with a metadata fallback via `Compilation.GetTypeByMetadataName`. Extend each Tier-1 `*Logic.cs` to surface metadata symbols in addition to source. New `inspect_external_assembly` tool walks `Compilation.GetReferencedAssemblySymbols()` to produce summary / namespace-mode output.
+
+**Tech Stack:** C# 13 / .NET 10, Roslyn 4.14, xUnit, ModelContextProtocol SDK. No new NuGet dependencies in this phase.
+
+**Fixture:** Existing `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx` — `TestLib2` already references `Microsoft.Extensions.DependencyInjection`, which supplies stable metadata symbols like `Microsoft.Extensions.DependencyInjection.IServiceCollection` and `ServiceDescriptor`. No fixture changes required.
+
+**Design reference:** [docs/plans/2026-04-24-closed-source-assemblies-design.md](./2026-04-24-closed-source-assemblies-design.md)
+
+---
+
+## Task 1: Add the origin block to SymbolLocation and SymbolContext models
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Models/SymbolLocation.cs](../../src/RoslynCodeLens/Models/SymbolLocation.cs)
+- Modify: [src/RoslynCodeLens/Models/SymbolContext.cs](../../src/RoslynCodeLens/Models/SymbolContext.cs)
+- Create: [src/RoslynCodeLens/Models/SymbolOrigin.cs](../../src/RoslynCodeLens/Models/SymbolOrigin.cs)
+
+**Step 1: Create the shared origin record.**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record SymbolOrigin(
+    string Kind,                 // "source" | "metadata"
+    string? AssemblyName,        // null when Kind=="source"
+    string? AssemblyVersion,     // null when Kind=="source"
+    string? DocId);              // null when Kind=="source"; set for metadata symbols
+```
+
+**Step 2: Extend `SymbolLocation` with an optional `Origin` field.**
+
+Add a nullable `SymbolOrigin? Origin = null` parameter at the end of the record. Records-with-defaults keep existing call sites compiling unchanged. No test failures expected yet.
+
+**Step 3: Extend `SymbolContext` the same way.**
+
+Add `SymbolOrigin? Origin = null` at the end.
+
+**Step 4: Build to confirm nothing broke.**
+
+Run: `dotnet build`
+Expected: Build succeeds with zero warnings.
+
+**Step 5: Commit.**
+
+```
+git add src/RoslynCodeLens/Models/SymbolOrigin.cs src/RoslynCodeLens/Models/SymbolLocation.cs src/RoslynCodeLens/Models/SymbolContext.cs
+git commit -m "feat: add SymbolOrigin model for metadata symbol provenance"
+```
+
+---
+
+## Task 2: Write failing test for MetadataSymbolResolver type lookup
+
+**Files:**
+- Test: `tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs` (new)
+
+**Step 1: Write the failing test.**
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Tests.Symbols;
+
+public class MetadataSymbolResolverTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _sourceResolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _sourceResolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _sourceResolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Resolve_MetadataType_ReturnsMetadataSymbol()
+    {
+        var result = _metadata.Resolve(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result.Origin.Kind);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.Origin.AssemblyName);
+        Assert.False(string.IsNullOrEmpty(result.Origin.AssemblyVersion));
+        Assert.True(result.Symbol is INamedTypeSymbol { TypeKind: TypeKind.Interface });
+    }
+
+    [Fact]
+    public void Resolve_SourceTypeTakesPrecedence()
+    {
+        var result = _metadata.Resolve("IGreeter");
+
+        Assert.NotNull(result);
+        Assert.Equal("source", result.Origin.Kind);
+    }
+
+    [Fact]
+    public void Resolve_UnknownSymbol_ReturnsNull()
+    {
+        Assert.Null(_metadata.Resolve("Nothing.Here.AtAll"));
+    }
+
+    [Fact]
+    public void Resolve_MetadataMember_ReturnsMethodSymbol()
+    {
+        var result = _metadata.Resolve(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection.Add");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result.Origin.Kind);
+        Assert.IsAssignableFrom<IMethodSymbol>(result.Symbol);
+    }
+}
+```
+
+**Step 2: Run to verify it fails.**
+
+Run: `dotnet test --filter "FullyQualifiedName~MetadataSymbolResolverTests"`
+Expected: FAIL — `MetadataSymbolResolver` / namespace `RoslynCodeLens.Symbols` does not exist.
+
+---
+
+## Task 3: Implement MetadataSymbolResolver
+
+**Files:**
+- Create: `src/RoslynCodeLens/Symbols/MetadataSymbolResolver.cs`
+
+**Step 1: Implement the class.**
+
+```csharp
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Symbols;
+
+public sealed record ResolvedSymbol(ISymbol Symbol, SymbolOrigin Origin);
+
+public sealed class MetadataSymbolResolver
+{
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _source;
+
+    public MetadataSymbolResolver(LoadedSolution loaded, SymbolResolver source)
+    {
+        _loaded = loaded;
+        _source = source;
+    }
+
+    public ResolvedSymbol? Resolve(string name)
+    {
+        // 1. Source first — matches how the compilation binds.
+        var sourceMatches = _source.FindSymbols(name);
+        if (sourceMatches.Count > 0)
+        {
+            return new ResolvedSymbol(sourceMatches[0], SourceOrigin);
+        }
+
+        // 2. Metadata fallback.
+        foreach (var compilation in _loaded.Compilations.Values)
+        {
+            var type = compilation.GetTypeByMetadataName(name);
+            if (type != null && type.Locations.All(l => !l.IsInSource))
+                return new ResolvedSymbol(type, ToOrigin(type));
+
+            // Try Type.Member split.
+            var lastDot = name.LastIndexOf('.');
+            if (lastDot <= 0)
+                continue;
+
+            var typeName = name[..lastDot];
+            var memberName = name[(lastDot + 1)..];
+            var container = compilation.GetTypeByMetadataName(typeName);
+            if (container == null || container.Locations.Any(l => l.IsInSource))
+                continue;
+
+            var member = container.GetMembers(memberName).FirstOrDefault();
+            if (member != null)
+                return new ResolvedSymbol(member, ToOrigin(member));
+        }
+
+        return null;
+    }
+
+    public IEnumerable<IAssemblySymbol> EnumerateMetadataAssemblies()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var compilation in _loaded.Compilations.Values)
+        {
+            foreach (var asm in compilation.GetReferencedAssemblySymbols())
+            {
+                if (seen.Add(asm.Identity.GetDisplayName()))
+                    yield return asm;
+            }
+        }
+    }
+
+    public IAssemblySymbol? FindAssembly(string assemblyName)
+    {
+        foreach (var asm in EnumerateMetadataAssemblies())
+        {
+            if (string.Equals(asm.Identity.Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                return asm;
+        }
+        return null;
+    }
+
+    public static SymbolOrigin ToOrigin(ISymbol symbol)
+    {
+        if (symbol.Locations.Any(l => l.IsInSource))
+            return SourceOrigin;
+
+        var asm = symbol.ContainingAssembly;
+        return new SymbolOrigin(
+            "metadata",
+            asm?.Identity.Name,
+            asm?.Identity.Version.ToString(),
+            symbol.GetDocumentationCommentId());
+    }
+
+    public static SymbolOrigin SourceOrigin { get; } = new("source", null, null, null);
+}
+```
+
+**Step 2: Run tests to verify they pass.**
+
+Run: `dotnet test --filter "FullyQualifiedName~MetadataSymbolResolverTests"`
+Expected: PASS (4 tests).
+
+**Step 3: Commit.**
+
+```
+git add src/RoslynCodeLens/Symbols/MetadataSymbolResolver.cs tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs
+git commit -m "feat: MetadataSymbolResolver resolves source + metadata symbols by name"
+```
+
+---
+
+## Task 4: Wire MetadataSymbolResolver into SolutionManager
+
+**Files:**
+- Modify: [src/RoslynCodeLens/SolutionManager.cs](../../src/RoslynCodeLens/SolutionManager.cs)
+
+Currently `SolutionManager` exposes `GetResolver()` returning the source `SymbolResolver`. We add a parallel `GetMetadataResolver()` so tools don't need to instantiate it per-call.
+
+**Step 1: Add a private field and build it alongside `_resolver`.**
+
+In the constructor and in `WarmupAsync` / `RebuildStaleProjects` / `ForceReloadAsync`, wherever `new SymbolResolver(...)` is called, also build `new MetadataSymbolResolver(newLoaded, newResolver)` and assign to a new field `_metadataResolver`.
+
+**Step 2: Add public accessor.**
+
+```csharp
+public MetadataSymbolResolver GetMetadataResolver()
+{
+    _warmupTask?.GetAwaiter().GetResult();
+    if (_warmupException != null)
+        throw new InvalidOperationException("Solution warmup failed.", _warmupException);
+    RebuildIfStale();
+    return _metadataResolver;
+}
+```
+
+**Step 3: Also surface through `MultiSolutionManager`.**
+
+Add `public MetadataSymbolResolver GetMetadataResolver()` to `MultiSolutionManager` delegating to the active `SolutionManager` (follow the existing `GetResolver()` pattern).
+
+**Step 4: Build.**
+
+Run: `dotnet build`
+Expected: succeeds.
+
+**Step 5: Commit.**
+
+```
+git add src/RoslynCodeLens/SolutionManager.cs src/RoslynCodeLens/MultiSolutionManager.cs
+git commit -m "feat: expose MetadataSymbolResolver through SolutionManager"
+```
+
+---
+
+## Task 5: Extend `go_to_definition` to surface metadata symbols
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/GoToDefinitionLogic.cs](../../src/RoslynCodeLens/Tools/GoToDefinitionLogic.cs)
+- Modify: [src/RoslynCodeLens/Tools/GoToDefinitionTool.cs](../../src/RoslynCodeLens/Tools/GoToDefinitionTool.cs)
+- Test: `tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs`
+
+**Step 1: Write failing test.**
+
+Add to the existing test file:
+
+```csharp
+[Fact]
+public void GoToDefinition_MetadataType_ReturnsMetadataOrigin()
+{
+    var result = GoToDefinitionLogic.Execute(
+        _resolver, _metadata, "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+    var single = Assert.Single(result);
+    Assert.NotNull(single.Origin);
+    Assert.Equal("metadata", single.Origin!.Kind);
+    Assert.Equal("", single.File);
+    Assert.Equal(0, single.Line);
+}
+```
+
+Also add `_metadata = new MetadataSymbolResolver(_loaded, _resolver);` to `InitializeAsync`. The test compiles once Step 2 changes the `Execute` signature.
+
+**Step 2: Run — expected to fail with compile error.**
+
+Run: `dotnet test --filter "FullyQualifiedName~GoToDefinitionToolTests"`
+Expected: FAIL — Logic signature still takes only `SymbolResolver`.
+
+**Step 3: Update `GoToDefinitionLogic.Execute` signature and body.**
+
+```csharp
+public static IReadOnlyList<SymbolLocation> Execute(
+    SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+{
+    var sourceHits = source.FindSymbols(symbol);
+    if (sourceHits.Count > 0)
+    {
+        return BuildSourceResults(source, sourceHits);
+    }
+
+    var resolved = metadata.Resolve(symbol);
+    if (resolved == null)
+        return [];
+
+    return
+    [
+        new SymbolLocation(
+            KindOf(resolved.Symbol),
+            resolved.Symbol.ToDisplayString(),
+            File: "",
+            Line: 0,
+            Project: "",
+            IsGenerated: false,
+            Origin: resolved.Origin)
+    ];
+}
+
+private static IReadOnlyList<SymbolLocation> BuildSourceResults(
+    SymbolResolver source, IReadOnlyList<ISymbol> symbols) { /* move current loop here, pass Origin: MetadataSymbolResolver.SourceOrigin */ }
+
+private static string KindOf(ISymbol s) => /* existing switch extracted */;
+```
+
+**Step 4: Update the Tool wrapper** to pass `manager.GetMetadataResolver()` as the second argument.
+
+**Step 5: Run test to verify pass.**
+
+Run: `dotnet test --filter "FullyQualifiedName~GoToDefinitionToolTests"`
+Expected: PASS (all pre-existing tests + new metadata test).
+
+**Step 6: Commit.**
+
+```
+git add src/RoslynCodeLens/Tools/GoToDefinitionLogic.cs src/RoslynCodeLens/Tools/GoToDefinitionTool.cs tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
+git commit -m "feat: go_to_definition surfaces metadata symbols with origin block"
+```
+
+---
+
+## Task 6: Extend `get_symbol_context` to accept metadata types
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs](../../src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs)
+- Modify: [src/RoslynCodeLens/Tools/GetSymbolContextTool.cs](../../src/RoslynCodeLens/Tools/GetSymbolContextTool.cs)
+- Test: `tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs`
+
+**Step 1: Failing test.**
+
+```csharp
+[Fact]
+public void GetContext_MetadataInterface_ReturnsMembersAndOrigin()
+{
+    var result = GetSymbolContextLogic.Execute(
+        _loaded, _resolver, _metadata, "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+    Assert.NotNull(result);
+    Assert.Equal("metadata", result.Origin!.Kind);
+    Assert.Equal("Microsoft.Extensions.DependencyInjection", result.Namespace);
+    Assert.Empty(result.InjectedDependencies);
+    Assert.NotEmpty(result.PublicMembers);
+    Assert.Equal("", result.File);
+    Assert.Equal(0, result.Line);
+}
+```
+
+Wire `_metadata` in `InitializeAsync` as in Task 5.
+
+**Step 2: Run — fail.**
+
+**Step 3: Update `GetSymbolContextLogic.Execute`.**
+
+Accept `MetadataSymbolResolver` parameter. If `resolver.FindNamedTypes(symbol)` is empty, call `metadata.Resolve(symbol)`; if it returns a type, build a `SymbolContext` from it with:
+- `File = ""`, `Line = 0`, `Project = ""`
+- `BaseClass` / `Interfaces` / `PublicMembers` from the `INamedTypeSymbol` as before
+- `InjectedDependencies = []` (metadata-interface constructors are not meaningful in this feature)
+- `Origin = resolved.Origin`
+
+For source-origin results, set `Origin = MetadataSymbolResolver.SourceOrigin` so consumers can always read the field.
+
+**Step 4: Update Tool wrapper to pass metadata resolver.**
+
+**Step 5: Test passes.**
+
+**Step 6: Commit.**
+
+```
+git commit -m "feat: get_symbol_context accepts metadata types"
+```
+
+---
+
+## Task 7: Extend `get_type_overview` and `get_type_hierarchy` to metadata types
+
+Repeat the Task-5/6 pattern for:
+
+- [src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs](../../src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs)
+- [src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs](../../src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs)
+
+For `get_type_hierarchy` specifically: derived types stay source-only — the logic is "base chain from any type (source or metadata), derived types from source index only" because we cannot enumerate all derivations across the ecosystem. Document this in an XML-doc comment on `Execute`.
+
+**Each tool gets one TDD cycle:**
+1. Failing test using `Microsoft.Extensions.DependencyInjection.IServiceCollection` (has base `IEnumerable<ServiceDescriptor>`, useful inheritance)
+2. Run → fail
+3. Update Logic signature and body
+4. Update Tool wrapper
+5. Run → pass
+6. Commit per tool: `feat: get_type_overview accepts metadata types`, `feat: get_type_hierarchy accepts metadata types`
+
+---
+
+## Task 8: Extend `find_attribute_usages` to look up metadata attribute types
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/FindAttributeUsagesLogic.cs](../../src/RoslynCodeLens/Tools/FindAttributeUsagesLogic.cs)
+- Test: `tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs`
+
+Already works on attribute **usages** in source — the task is to let the *attribute type itself* be a metadata symbol. E.g. `find_attribute_usages("System.ObsoleteAttribute")` should resolve the metadata attribute and then scan source usage.
+
+**Step 1: Failing test** — look up usages of `System.Diagnostics.CodeAnalysis.SuppressMessageAttribute` (present in `GlobalSuppressions.cs`).
+
+**Step 2: Fail → update Logic to accept `MetadataSymbolResolver` and use it when the source resolver finds nothing → pass → commit.**
+
+---
+
+## Task 9: Extend `search_symbols` to include metadata types
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs](../../src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs)
+- Test: `tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs`
+
+Search currently walks `resolver.TypesBySimpleName` / `MembersBySimpleName`. We add a second pass that enumerates metadata assemblies from `MetadataSymbolResolver.EnumerateMetadataAssemblies()`, walks the `GlobalNamespace`, and emits `SymbolLocation` with `File=""`, `Line=0`, and `Origin` set to metadata.
+
+**Step 1: Failing test.**
+
+```csharp
+[Fact]
+public void Search_MatchesMetadataSymbol()
+{
+    var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "IServiceCollection");
+    Assert.Contains(results, r => r.Origin?.Kind == "metadata"
+        && r.FullName == "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+}
+```
+
+**Step 2: Run → fail.**
+
+**Step 3: Implement.**
+
+Add a pass: `foreach assembly in metadata.EnumerateMetadataAssemblies()` → `SymbolResolver.GetAllTypes(assembly.GlobalNamespace)` → filter by `type.Name.Contains(query, OrdinalIgnoreCase)` → add to results with metadata origin. Respect the existing `MaxResults = 50` cap (source results take precedence).
+
+Budget: to avoid walking all of `System.Private.CoreLib` on every search, skip assemblies where `IsImplicitlyDeclared` is true OR `Identity.Name` starts with `System.` / `Microsoft.` unless the source pass returned zero metadata hits *and* the query is ≥ 3 characters. Document the heuristic with a comment citing token-budget concern.
+
+**Step 4: Run → pass.**
+
+**Step 5: Commit.**
+
+```
+git commit -m "feat: search_symbols includes metadata types with budget heuristics"
+```
+
+---
+
+## Task 10: Add `InspectExternalAssembly` model
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/ExternalAssemblyOverview.cs`
+- Create: `src/RoslynCodeLens/Models/ExternalNamespaceOverview.cs`
+
+**Step 1: Define records.**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record ExternalAssemblyOverview(
+    string Mode,                                             // "summary" | "namespace"
+    string Name,
+    string Version,
+    string? TargetFramework,
+    string? PublicKeyToken,
+    IReadOnlyList<ExternalNamespaceSummary> NamespaceTree,   // non-empty for mode=="summary"
+    IReadOnlyList<ExternalTypeInfo> Types);                  // non-empty for mode=="namespace"
+
+public record ExternalNamespaceSummary(
+    string Namespace,
+    int TypeCount,
+    IReadOnlyList<string> PublicTypeNames);
+
+public record ExternalTypeInfo(
+    string Kind,                   // "class" | "interface" | "struct" | "enum" | "delegate"
+    string FullName,
+    IReadOnlyList<string> Modifiers,
+    string? BaseType,
+    IReadOnlyList<string> Interfaces,
+    IReadOnlyList<ExternalMemberInfo> Members,
+    IReadOnlyList<string> Attributes,
+    string? XmlDocSummary);
+
+public record ExternalMemberInfo(
+    string Kind,                   // "method" | "property" | "field" | "event" | "constructor"
+    string Signature,
+    string? XmlDocSummary);
+```
+
+**Step 2: Build.**
+
+Run: `dotnet build`
+
+**Step 3: Commit.**
+
+```
+git commit -m "feat: add ExternalAssemblyOverview models"
+```
+
+---
+
+## Task 11: Write failing test for `inspect_external_assembly` summary mode
+
+**Files:**
+- Test: `tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs` (new)
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class InspectExternalAssemblyToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _metadata = new MetadataSymbolResolver(_loaded, new SymbolResolver(_loaded));
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Summary_ListsNamespacesAndCounts()
+    {
+        var result = InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "summary", namespaceFilter: null);
+
+        Assert.NotNull(result);
+        Assert.Equal("summary", result!.Mode);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.Name);
+        Assert.NotEmpty(result.NamespaceTree);
+        Assert.Contains(result.NamespaceTree,
+            n => n.Namespace == "Microsoft.Extensions.DependencyInjection"
+              && n.PublicTypeNames.Contains("IServiceCollection"));
+        Assert.Empty(result.Types);
+    }
+
+    [Fact]
+    public void Namespace_ReturnsTypesWithMembers()
+    {
+        var result = InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "namespace", namespaceFilter: "Microsoft.Extensions.DependencyInjection");
+
+        Assert.NotNull(result);
+        Assert.Equal("namespace", result!.Mode);
+        Assert.Contains(result.Types, t => t.FullName.EndsWith("IServiceCollection", StringComparison.Ordinal));
+        var svc = result.Types.First(t => t.FullName.EndsWith("IServiceCollection", StringComparison.Ordinal));
+        Assert.Equal("interface", svc.Kind);
+        Assert.NotEmpty(svc.Members);
+    }
+
+    [Fact]
+    public void UnreferencedAssembly_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+            _metadata, "Some.NotReferenced.Library", mode: "summary", namespaceFilter: null));
+    }
+
+    [Fact]
+    public void NamespaceMode_UnknownNamespace_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "namespace", namespaceFilter: "NoSuch.Namespace"));
+    }
+}
+```
+
+**Step 2: Run → fail** (logic class does not exist).
+
+---
+
+## Task 12: Implement `InspectExternalAssemblyLogic`
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs`
+
+```csharp
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class InspectExternalAssemblyLogic
+{
+    public static ExternalAssemblyOverview Execute(
+        MetadataSymbolResolver metadata,
+        string assemblyName,
+        string mode,
+        string? namespaceFilter)
+    {
+        var assembly = metadata.FindAssembly(assemblyName)
+            ?? throw new ArgumentException(
+                $"Assembly '{assemblyName}' is not referenced by any project in the active solution. " +
+                "Use get_nuget_dependencies to list referenced assemblies.");
+
+        var identity = assembly.Identity;
+        return mode switch
+        {
+            "summary" => BuildSummary(assembly),
+            "namespace" => BuildNamespace(assembly, namespaceFilter
+                ?? throw new ArgumentException("'namespace' is required when mode='namespace'.")),
+            _ => throw new ArgumentException($"Unknown mode '{mode}'. Expected 'summary' or 'namespace'.")
+        };
+    }
+
+    private static ExternalAssemblyOverview BuildSummary(IAssemblySymbol assembly)
+    {
+        var byNamespace = new SortedDictionary<string, List<INamedTypeSymbol>>(StringComparer.Ordinal);
+        foreach (var type in SymbolResolver.GetAllTypes(assembly.GlobalNamespace))
+        {
+            if (type.DeclaredAccessibility != Accessibility.Public || type.ContainingType != null)
+                continue;
+            var ns = type.ContainingNamespace.ToDisplayString();
+            if (!byNamespace.TryGetValue(ns, out var list))
+                byNamespace[ns] = list = new List<INamedTypeSymbol>();
+            list.Add(type);
+        }
+
+        var tree = byNamespace.Select(kv => new ExternalNamespaceSummary(
+            kv.Key, kv.Value.Count,
+            kv.Value.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToList()))
+            .ToList();
+
+        var id = assembly.Identity;
+        return new ExternalAssemblyOverview(
+            "summary", id.Name, id.Version.ToString(),
+            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            NamespaceTree: tree, Types: []);
+    }
+
+    private static ExternalAssemblyOverview BuildNamespace(IAssemblySymbol assembly, string ns)
+    {
+        var types = new List<INamedTypeSymbol>();
+        foreach (var t in SymbolResolver.GetAllTypes(assembly.GlobalNamespace))
+        {
+            if (t.DeclaredAccessibility != Accessibility.Public || t.ContainingType != null)
+                continue;
+            if (!string.Equals(t.ContainingNamespace.ToDisplayString(), ns, StringComparison.Ordinal))
+                continue;
+            types.Add(t);
+        }
+
+        if (types.Count == 0)
+            throw new ArgumentException(
+                $"Namespace '{ns}' not found (or contains no public types) in assembly '{assembly.Identity.Name}'.");
+
+        var typeInfos = types.OrderBy(t => t.Name, StringComparer.Ordinal).Select(ToTypeInfo).ToList();
+
+        var id = assembly.Identity;
+        return new ExternalAssemblyOverview(
+            "namespace", id.Name, id.Version.ToString(),
+            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            NamespaceTree: [], Types: typeInfos);
+    }
+
+    private static ExternalTypeInfo ToTypeInfo(INamedTypeSymbol t)
+    {
+        var kind = t.TypeKind switch
+        {
+            TypeKind.Interface => "interface",
+            TypeKind.Struct => "struct",
+            TypeKind.Enum => "enum",
+            TypeKind.Delegate => "delegate",
+            _ => "class"
+        };
+        var modifiers = new List<string>();
+        if (t.IsAbstract && t.TypeKind != TypeKind.Interface) modifiers.Add("abstract");
+        if (t.IsSealed) modifiers.Add("sealed");
+        if (t.IsStatic) modifiers.Add("static");
+
+        var baseType = t.BaseType is { SpecialType: not SpecialType.System_Object }
+            ? t.BaseType.ToDisplayString() : null;
+        var interfaces = t.Interfaces.Select(i => i.ToDisplayString()).ToList();
+
+        var members = new List<ExternalMemberInfo>();
+        foreach (var m in t.GetMembers())
+        {
+            if (m.DeclaredAccessibility != Accessibility.Public || m.IsImplicitlyDeclared)
+                continue;
+            if (m is IMethodSymbol { MethodKind:
+                MethodKind.PropertyGet or MethodKind.PropertySet or
+                MethodKind.EventAdd or MethodKind.EventRemove })
+                continue;
+            members.Add(new ExternalMemberInfo(
+                MemberKind(m),
+                m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                SummaryFromXmlDoc(m)));
+        }
+
+        var attributes = t.GetAttributes()
+            .Select(a => a.AttributeClass?.Name ?? "Attribute")
+            .ToList();
+
+        return new ExternalTypeInfo(kind, t.ToDisplayString(), modifiers, baseType,
+            interfaces, members, attributes, SummaryFromXmlDoc(t));
+    }
+
+    private static string MemberKind(ISymbol s) => s switch
+    {
+        IMethodSymbol { MethodKind: MethodKind.Constructor } => "constructor",
+        IMethodSymbol => "method",
+        IPropertySymbol => "property",
+        IFieldSymbol => "field",
+        IEventSymbol => "event",
+        _ => "symbol"
+    };
+
+    private static string? SummaryFromXmlDoc(ISymbol s)
+    {
+        var xml = s.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml))
+            return null;
+        var start = xml.IndexOf("<summary>", StringComparison.Ordinal);
+        var end = xml.IndexOf("</summary>", StringComparison.Ordinal);
+        if (start < 0 || end <= start)
+            return null;
+        return xml.Substring(start + "<summary>".Length, end - start - "<summary>".Length).Trim();
+    }
+
+    private static string? FormatPublicKey(System.Collections.Immutable.ImmutableArray<byte> key)
+        => key.IsDefaultOrEmpty ? null : string.Concat(key.Select(b => b.ToString("x2")));
+}
+```
+
+**Step 2: Run tests.**
+
+Run: `dotnet test --filter "FullyQualifiedName~InspectExternalAssemblyToolTests"`
+Expected: PASS.
+
+**Step 3: Commit.**
+
+```
+git commit -m "feat: inspect_external_assembly logic with summary + namespace modes"
+```
+
+---
+
+## Task 13: Wire `inspect_external_assembly` as an MCP tool
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/InspectExternalAssemblyTool.cs`
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class InspectExternalAssemblyTool
+{
+    [McpServerTool(Name = "inspect_external_assembly"),
+     Description("Inspect a referenced closed-source assembly. mode='summary' returns namespaces + type counts; mode='namespace' returns public types and members for the given namespace.")]
+    public static ExternalAssemblyOverview Execute(
+        MultiSolutionManager manager,
+        [Description("Assembly name, e.g. 'Newtonsoft.Json' or 'Microsoft.Extensions.DependencyInjection.Abstractions'")] string assemblyName,
+        [Description("'summary' (default) or 'namespace'")] string mode = "summary",
+        [Description("Required when mode='namespace'")] string? namespaceFilter = null)
+    {
+        manager.EnsureLoaded();
+        return InspectExternalAssemblyLogic.Execute(
+            manager.GetMetadataResolver(), assemblyName, mode, namespaceFilter);
+    }
+}
+```
+
+**Step 1: Manual smoke test** — run the server against a small solution and call the tool via `dotnet tool run roslyn-codelens-mcp` behind the MCP client. Can be skipped if test coverage is sufficient; reviewers will exercise in Claude Code.
+
+**Step 2: Commit.**
+
+```
+git commit -m "feat: register inspect_external_assembly MCP tool"
+```
+
+---
+
+## Task 14: Update SKILL.md with Phase-1 guidance
+
+**Files:**
+- Modify: [plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md](../../plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md)
+
+**Step 1: Add "Working with external assemblies" section.** Topics:
+- What counts as external (symbol's `origin.kind === "metadata"`).
+- Fully-qualified name addressing.
+- Origin block format (`{ kind, assemblyName, assemblyVersion, docId }`).
+
+**Step 2: Add per-tool metadata behavior table.** One row per tool with three columns: *Works on metadata*, *Caveats*, *Alternative if not supported*. Include **all** existing tools plus the new `inspect_external_assembly`. Mark Tier-3 tools explicitly as *No — source only*.
+
+**Step 3: Document `inspect_external_assembly`** with two worked examples:
+- summary → drill into one namespace
+- summary alone is enough for a "what does this package expose" read
+
+**Step 4: Decision tree at top of the skill.**
+
+```
+Symbol in my source      → existing tools (work unchanged)
+External symbol by name  → existing tools (Tier 1). They return origin="metadata".
+Who in my code uses it?  → deferred to Phase 2
+Browse a package         → inspect_external_assembly
+See a method's IL        → deferred to Phase 3
+Browse arbitrary DLL     → add temp ProjectReference to throwaway project, reload
+```
+
+**Step 5: Commit.**
+
+```
+git commit -m "docs(skill): add external-assembly guidance for Phase 1 tools"
+```
+
+---
+
+## Task 15: Full test + build sweep and PR prep
+
+**Step 1: Run everything.**
+
+Run: `dotnet build && dotnet test`
+Expected: All tests pass, zero warnings.
+
+**Step 2: Confirm `docs/features.md` and `docs/plans/` design doc are consistent.** If any Phase-1 design detail changed during implementation, update [docs/plans/2026-04-24-closed-source-assemblies-design.md](./2026-04-24-closed-source-assemblies-design.md) to match before PR.
+
+**Step 3: Use @superpowers:verification-before-completion before declaring done.** Confirm the tool is actually callable end-to-end via MCP before merge.
+
+**Step 4: Open PR titled `feat: external-assembly analysis — Phase 1 (Tier 1 + inspect_external_assembly)`** linking issue #95 and the design doc.

--- a/docs/plans/2026-04-24-closed-source-assemblies-phase-2.md
+++ b/docs/plans/2026-04-24-closed-source-assemblies-phase-2.md
@@ -1,0 +1,251 @@
+# Phase 2 — Tier 2 references (source-to-metadata)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Allow `find_references`, `find_callers`, and `find_implementations` to accept metadata symbol names as input and find source call/reference/implementation sites that target them.
+
+**Architecture:** Each tool's `*Logic.Execute` currently resolves its target symbol exclusively through the source `SymbolResolver`. We widen each one to fall back on `MetadataSymbolResolver.Resolve` when no source match is found. The downstream scan logic (iterating compilations, calling `GetSymbolInfo`, matching with `SymbolEqualityComparer`) already works for metadata symbols — the `ISymbol` identity comparison is uniform across source and metadata origins.
+
+**Tech Stack:** Same as Phase 1. No new NuGet dependencies.
+
+**Fixture:** `TestLib2` calls `services.AddSingleton<...>()` and similar `Microsoft.Extensions.DependencyInjection` APIs in `DiSetup.cs` / `GreeterConsumer.cs`. Those are real source-to-metadata references suitable for assertions. Verify by `Grep`-ing `AddSingleton`, `AddScoped`, `AddTransient` before writing tests.
+
+**Prerequisite:** Phase 1 merged (`MetadataSymbolResolver`, `GetMetadataResolver()` on `MultiSolutionManager`, extended Tier-1 tools, `SymbolLocation.Origin`).
+
+**Design reference:** [docs/plans/2026-04-24-closed-source-assemblies-design.md](./2026-04-24-closed-source-assemblies-design.md)
+
+---
+
+## Task 1: Confirm fixture has source-to-metadata references
+
+**Step 1: Grep.**
+
+Run: `grep -rn "AddSingleton\|AddScoped\|AddTransient\|IServiceCollection" tests/RoslynCodeLens.Tests/Fixtures/TestSolution`
+Expected: At least one call site in `TestLib2/DiSetup.cs` or `GreeterConsumer.cs`.
+
+**Step 2: If nothing matches,** add the minimum fixture to `TestLib2/DiSetup.cs`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TestLib2;
+
+public static class DiSetup
+{
+    public static IServiceCollection AddGreeters(IServiceCollection services)
+    {
+        services.AddSingleton<TestLib.IGreeter, TestLib.Greeter>();
+        return services;
+    }
+}
+```
+
+Only commit fixture changes if the grep failed. **No commit** otherwise.
+
+---
+
+## Task 2: Extend `find_references` to accept metadata symbols
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/FindReferencesLogic.cs](../../src/RoslynCodeLens/Tools/FindReferencesLogic.cs)
+- Modify: [src/RoslynCodeLens/Tools/FindReferencesTool.cs](../../src/RoslynCodeLens/Tools/FindReferencesTool.cs)
+- Test: [tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs](../../tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs)
+
+**Step 1: Failing test.**
+
+```csharp
+[Fact]
+public void FindReferences_MetadataInterface_FindsSourceUsages()
+{
+    var results = FindReferencesLogic.Execute(
+        _loaded, _resolver, _metadata,
+        "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+    Assert.NotEmpty(results);
+    Assert.All(results, r => Assert.True(!string.IsNullOrEmpty(r.File)));
+}
+```
+
+Wire `_metadata = new MetadataSymbolResolver(_loaded, _resolver);` in `InitializeAsync`.
+
+**Step 2: Run → fail** (signature mismatch: Logic.Execute takes 3 args today).
+
+**Step 3: Update `FindReferencesLogic.Execute` signature and body.**
+
+```csharp
+public static IReadOnlyList<SymbolReference> Execute(
+    LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+{
+    var targets = source.FindSymbols(symbol);
+    if (targets.Count == 0)
+    {
+        var resolved = metadata.Resolve(symbol);
+        if (resolved == null)
+            return [];
+        targets = [resolved.Symbol];
+    }
+
+    var targetSet = BuildTargetSet(targets);
+    return ScanForReferences(loaded, source, targetSet);
+}
+```
+
+No other change to `ScanForReferences` — it already uses `SymbolEqualityComparer` which works equally for metadata symbols.
+
+**Step 4: Update `FindReferencesTool.Execute` to pass `manager.GetMetadataResolver()`.**
+
+**Step 5: Run test → pass.** Verify pre-existing tests still pass.
+
+Run: `dotnet test --filter "FullyQualifiedName~FindReferencesToolTests"`
+
+**Step 6: Commit.**
+
+```
+git commit -m "feat: find_references accepts metadata symbols (source call sites of external symbols)"
+```
+
+---
+
+## Task 3: Extend `find_callers` to accept metadata methods
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/FindCallersLogic.cs](../../src/RoslynCodeLens/Tools/FindCallersLogic.cs)
+- Modify: [src/RoslynCodeLens/Tools/FindCallersTool.cs](../../src/RoslynCodeLens/Tools/FindCallersTool.cs)
+- Test: [tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs](../../tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs)
+
+**Step 1: Failing test.**
+
+```csharp
+[Fact]
+public void FindCallers_MetadataExtensionMethod_FindsSourceInvocations()
+{
+    // ServiceCollectionServiceExtensions.AddSingleton is the extension target.
+    var results = FindCallersLogic.Execute(
+        _loaded, _resolver, _metadata,
+        "Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton");
+
+    Assert.NotEmpty(results);
+}
+```
+
+**Step 2: Fail → update signature.**
+
+The current `Execute` uses `resolver.FindMethods(symbol)`. Widen:
+
+```csharp
+public static IReadOnlyList<CallerInfo> Execute(
+    LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+{
+    var targetMethods = source.FindMethods(symbol);
+    if (targetMethods.Count == 0)
+    {
+        var resolved = metadata.Resolve(symbol);
+        if (resolved?.Symbol is IMethodSymbol m)
+            targetMethods = [m];
+        else
+            return [];
+    }
+
+    // ... rest unchanged
+}
+```
+
+**Step 3: Update Tool wrapper, run tests, commit.**
+
+```
+git commit -m "feat: find_callers accepts metadata methods"
+```
+
+---
+
+## Task 4: Extend `find_implementations` to accept metadata interfaces
+
+**Files:**
+- Modify: [src/RoslynCodeLens/Tools/FindImplementationsLogic.cs](../../src/RoslynCodeLens/Tools/FindImplementationsLogic.cs)
+- Modify: [src/RoslynCodeLens/Tools/FindImplementationsTool.cs](../../src/RoslynCodeLens/Tools/FindImplementationsTool.cs)
+- Test: [tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs](../../tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs)
+
+The current implementation uses `resolver.GetInterfaceImplementors(target)` / `GetDerivedTypes(target)` — both indexed by `INamedTypeSymbol` instance. Source-only lookups. For metadata interfaces, we need a different path because the **implementors live in source** but the key is a metadata symbol.
+
+**Step 1: Failing test.**
+
+```csharp
+[Fact]
+public void FindImplementations_MetadataInterface_FindsSourceImplementors()
+{
+    // Fixture: TestLib/Greeter.cs implements TestLib/IGreeter (source interface).
+    // We want a metadata-interface example. Adjust fixture if needed to reference e.g.
+    // System.IDisposable, or use Microsoft.Extensions.Hosting IHostedService (not in deps).
+    // Simpler: add IDisposable to Greeter in the fixture and assert.
+    var results = FindImplementationsLogic.Execute(
+        _loaded, _resolver, _metadata, "System.IDisposable");
+
+    Assert.Contains(results, r => r.FullName.EndsWith("Greeter", StringComparison.Ordinal));
+}
+```
+
+If the fixture does not implement any metadata interface, **add a tiny fixture change**: make `TestLib/Greeter.cs` implement `IDisposable` with an empty `Dispose()`. That change is in-scope and makes the test deterministic.
+
+**Step 2: Fail → update signature.**
+
+```csharp
+public static IReadOnlyList<SymbolLocation> Execute(
+    LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+{
+    var targets = source.FindNamedTypes(symbol);
+    if (targets.Count == 0)
+    {
+        var resolved = metadata.Resolve(symbol);
+        if (resolved?.Symbol is INamedTypeSymbol nt)
+            targets = [nt];
+        else
+            return [];
+    }
+
+    // rest unchanged — resolver.GetInterfaceImplementors works on any INamedTypeSymbol key
+    // because SymbolEqualityComparer is used, and the source indexer walks type.AllInterfaces
+    // which includes metadata interfaces. No additional work needed.
+}
+```
+
+Verify: the source `SymbolResolver` constructor's `BuildInheritanceMaps` walks `type.AllInterfaces` — this enumerates both source and metadata interfaces, so `_interfaceImplementors` already keys metadata interfaces to source implementors. That's the intended path.
+
+**Step 3: Run test → pass.**
+
+**Step 4: Commit.**
+
+```
+git commit -m "feat: find_implementations accepts metadata interfaces (source implementors)"
+```
+
+---
+
+## Task 5: Update SKILL.md with Tier-2 guidance
+
+**Files:**
+- Modify: [plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md](../../plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md)
+
+**Step 1: Upgrade the per-tool metadata-behavior table rows** for `find_references`, `find_callers`, `find_implementations` from "No (Phase 2)" to "Yes — finds source call/reference/implementation sites for external symbols."
+
+**Step 2: Update the decision tree**: replace the placeholder `"Who in my code uses it? → deferred to Phase 2"` with the real direction: `"Who in my code uses it? → find_references / find_callers / find_implementations with the external symbol's fully qualified name."`
+
+**Step 3: Add a worked example.** "I want to know everything in my code that consumes `Microsoft.Extensions.DependencyInjection.IServiceCollection`" — show `find_references` call, note that returned items all have `origin.kind === "source"` (the references live in source) even though the *target* was a metadata symbol.
+
+**Step 4: Commit.**
+
+```
+git commit -m "docs(skill): update external-assembly guidance for Tier-2 reference tools"
+```
+
+---
+
+## Task 6: Full sweep and PR
+
+**Step 1: Run everything.**
+
+Run: `dotnet build && dotnet test`
+Expected: Pass, zero warnings.
+
+**Step 2: Verification.** Use @superpowers:verification-before-completion — exercise the server via MCP and call `find_references` / `find_callers` / `find_implementations` on known metadata symbols from your own .NET project.
+
+**Step 3: PR titled `feat: external-assembly analysis — Phase 2 (Tier-2 references)`** linking issue #95 and the design doc.

--- a/docs/plans/2026-04-24-closed-source-assemblies-phase-3.md
+++ b/docs/plans/2026-04-24-closed-source-assemblies-phase-3.md
@@ -1,0 +1,518 @@
+# Phase 3 — peek_il (IL disassembly for closed-source methods)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new `peek_il` MCP tool that returns ilasm-style textual IL for a single method in a metadata assembly. This is the only Phase that adds a new library dependency.
+
+**Architecture:** Resolve the input to an `IMethodSymbol` via `MetadataSymbolResolver`. Locate the `PortableExecutableReference` matching the method's containing assembly. Open the DLL via `System.Reflection.Metadata.PEReader` and hand to `ICSharpCode.Decompiler.Disassembler.ReflectionDisassembler`, which emits ilasm-style text. Output is a single string wrapped in a minimal result record. A `PEFileCache` keeps `PEFile` handles open across calls to the same DLL and invalidates on file-timestamp change.
+
+**Tech Stack:** Adds `ICSharpCode.Decompiler` (LGPL-2.1) to [src/RoslynCodeLens/RoslynCodeLens.csproj](../../src/RoslynCodeLens/RoslynCodeLens.csproj). Only the disassembler namespace is consumed; no decompiler types are referenced.
+
+**Prerequisite:** Phase 1 merged (`MetadataSymbolResolver`, `GetMetadataResolver()`).
+
+**Fixture:** `Microsoft.Extensions.DependencyInjection.Abstractions` `ServiceDescriptor` constructor has simple, deterministic IL — good target for assertions.
+
+**Design reference:** [docs/plans/2026-04-24-closed-source-assemblies-design.md](./2026-04-24-closed-source-assemblies-design.md)
+
+---
+
+## Task 1: Add the ICSharpCode.Decompiler dependency
+
+**Files:**
+- Modify: [src/RoslynCodeLens/RoslynCodeLens.csproj](../../src/RoslynCodeLens/RoslynCodeLens.csproj)
+- Modify: `README.md` (add attribution)
+- Create: `NOTICE` (if absent) with LGPL attribution
+
+**Step 1: Add PackageReference.**
+
+Use the latest 10.x release of `ICSharpCode.Decompiler` (as of 2026-04: 10.x line). If CI build fails due to framework mismatch against net10, pin to whichever version targets `netstandard2.0` / `net8.0` (we ship on net10 which consumes both).
+
+```xml
+<PackageReference Include="ICSharpCode.Decompiler" Version="10.x.y" />
+```
+
+**Step 2: Build.**
+
+Run: `dotnet build`
+Expected: succeeds. Warnings from the library itself should be filtered via `<NoWarn>` if necessary, but only for the library's own assemblies.
+
+**Step 3: Add attribution.** In `README.md` under a new "Third-party licenses" heading, add:
+
+> This project uses [ICSharpCode.Decompiler](https://github.com/icsharpcode/ILSpy) for IL disassembly, licensed under the MIT license (from version 10 onwards) — verify current license at the linked repository before merging and adjust this note if needed.
+
+Create `NOTICE` at repo root if not already present, listing the dependency.
+
+**Step 4: Commit.**
+
+```
+git commit -m "chore: add ICSharpCode.Decompiler dependency for peek_il"
+```
+
+---
+
+## Task 2: Add result model
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/IlPeekResult.cs`
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record IlPeekResult(
+    string MethodFullName,
+    string AssemblyName,
+    string AssemblyVersion,
+    string Il);        // ilasm-style text, possibly multi-line
+```
+
+Commit: `git commit -m "feat: add IlPeekResult model"`
+
+---
+
+## Task 3: PEFileCache keyed by (path, lastWriteTime)
+
+**Files:**
+- Create: `src/RoslynCodeLens/Metadata/PEFileCache.cs`
+- Test: `tests/RoslynCodeLens.Tests/Metadata/PEFileCacheTests.cs`
+
+**Step 1: Failing test.**
+
+```csharp
+using ICSharpCode.Decompiler.Metadata;
+using RoslynCodeLens.Metadata;
+
+namespace RoslynCodeLens.Tests.Metadata;
+
+public class PEFileCacheTests
+{
+    [Fact]
+    public void Get_SamePath_ReturnsSameInstance()
+    {
+        var cache = new PEFileCache();
+        var path = typeof(object).Assembly.Location;
+
+        var first = cache.Get(path);
+        var second = cache.Get(path);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Invalidate_DropsEntry()
+    {
+        var cache = new PEFileCache();
+        var path = typeof(object).Assembly.Location;
+
+        var first = cache.Get(path);
+        cache.Invalidate(path);
+        var second = cache.Get(path);
+
+        Assert.NotSame(first, second);
+    }
+}
+```
+
+**Step 2: Fail** — class does not exist.
+
+**Step 3: Implement.**
+
+```csharp
+using System.Collections.Concurrent;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace RoslynCodeLens.Metadata;
+
+public sealed class PEFileCache : IDisposable
+{
+    private readonly ConcurrentDictionary<string, (DateTime Timestamp, PEFile File)> _cache
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public PEFile Get(string path)
+    {
+        var stamp = File.GetLastWriteTimeUtc(path);
+        if (_cache.TryGetValue(path, out var existing) && existing.Timestamp == stamp)
+            return existing.File;
+
+        var pe = new PEFile(path);
+        _cache[path] = (stamp, pe);
+        return pe;
+    }
+
+    public void Invalidate(string path)
+    {
+        if (_cache.TryRemove(path, out var entry))
+            entry.File.Dispose();
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _cache.Values)
+            entry.File.Dispose();
+        _cache.Clear();
+    }
+}
+```
+
+**Step 4: Pass.** Commit: `git commit -m "feat: PEFileCache with timestamp-based invalidation"`.
+
+---
+
+## Task 4: IlDisassemblerAdapter — isolates ICSharpCode.Decompiler types
+
+**Files:**
+- Create: `src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs`
+
+**Step 1: Implement.**
+
+```csharp
+using System.IO;
+using System.Reflection.Metadata.Ecma335;
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace RoslynCodeLens.Metadata;
+
+public sealed class IlDisassemblerAdapter
+{
+    private readonly PEFileCache _cache;
+
+    public IlDisassemblerAdapter(PEFileCache cache) { _cache = cache; }
+
+    public string DisassembleMethod(string assemblyPath, int metadataToken)
+    {
+        var pe = _cache.Get(assemblyPath);
+        using var writer = new StringWriter();
+        var output = new PlainTextOutput(writer);
+        var disasm = new ReflectionDisassembler(output, cancellationToken: default)
+        {
+            DetectControlStructure = true,
+            ShowSequencePoints = false,
+        };
+        var handle = MetadataTokens.EntityHandle(metadataToken);
+        disasm.DisassembleMethod(pe, (System.Reflection.Metadata.MethodDefinitionHandle)handle);
+        return writer.ToString();
+    }
+}
+```
+
+No TDD cycle here — this wrapper is a thin adapter exercised through `PeekIlLogicTests` in Task 6. Verify it at least compiles.
+
+**Step 2: Commit.**
+
+```
+git commit -m "feat: IlDisassemblerAdapter wraps ICSharpCode.Decompiler"
+```
+
+---
+
+## Task 5: Write failing test for PeekIlLogic
+
+**Files:**
+- Test: `tests/RoslynCodeLens.Tests/Tools/PeekIlToolTests.cs`
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Metadata;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class PeekIlToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+    private IlDisassemblerAdapter _adapter = null!;
+    private PEFileCache _peCache = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _peCache = new PEFileCache();
+        _adapter = new IlDisassemblerAdapter(_peCache);
+    }
+
+    public Task DisposeAsync() { _peCache.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public void Peek_MetadataCtor_ReturnsIlText()
+    {
+        // Pick an overload deterministically — ServiceDescriptor has a well-known ctor taking (Type, Type).
+        var result = PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter,
+            "Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)");
+
+        Assert.NotNull(result);
+        Assert.Contains("IL_", result!.Il, StringComparison.Ordinal); // labels like IL_0000
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.AssemblyName);
+    }
+
+    [Fact]
+    public void Peek_SourceSymbol_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter, "Greeter.Greet"));
+    }
+
+    [Fact]
+    public void Peek_AbstractMethod_Throws()
+    {
+        // Interface methods have no bodies.
+        Assert.Throws<ArgumentException>(() => PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter,
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection.Add"));
+    }
+}
+```
+
+Run: `dotnet test --filter "FullyQualifiedName~PeekIlToolTests"`
+Expected: FAIL — `PeekIlLogic` does not exist.
+
+---
+
+## Task 6: Implement PeekIlLogic
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/PeekIlLogic.cs`
+
+```csharp
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Metadata;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class PeekIlLogic
+{
+    public static IlPeekResult Execute(
+        LoadedSolution loaded,
+        MetadataSymbolResolver metadata,
+        IlDisassemblerAdapter disassembler,
+        string methodSymbol)
+    {
+        var resolved = metadata.Resolve(methodSymbol)
+            ?? throw new ArgumentException(
+                $"Symbol '{methodSymbol}' not found.");
+
+        if (resolved.Origin.Kind != "metadata")
+            throw new ArgumentException(
+                $"Symbol '{methodSymbol}' is a source symbol. Use go_to_definition instead.");
+
+        if (resolved.Symbol is not IMethodSymbol method)
+            throw new ArgumentException(
+                $"Symbol '{methodSymbol}' is not a method. peek_il only works on methods.");
+
+        if (method.IsAbstract || method.MethodKind == MethodKind.EventAdd
+            || method.MethodKind == MethodKind.EventRemove
+            || method.ContainingType?.TypeKind == TypeKind.Interface && !method.IsStatic)
+            throw new ArgumentException(
+                $"Method '{methodSymbol}' has no body (abstract, interface instance member, or event accessor).");
+
+        var assembly = method.ContainingAssembly
+            ?? throw new ArgumentException("Could not determine containing assembly.");
+
+        var assemblyPath = FindAssemblyPath(loaded, assembly)
+            ?? throw new ArgumentException(
+                $"Could not locate on-disk path for assembly '{assembly.Identity.Name}'.");
+
+        var token = MetadataTokenOf(method)
+            ?? throw new ArgumentException("Could not determine metadata token for method.");
+
+        var ilText = disassembler.DisassembleMethod(assemblyPath, token);
+
+        return new IlPeekResult(
+            method.ToDisplayString(),
+            assembly.Identity.Name,
+            assembly.Identity.Version.ToString(),
+            ilText);
+    }
+
+    private static string? FindAssemblyPath(LoadedSolution loaded, IAssemblySymbol assembly)
+    {
+        foreach (var compilation in loaded.Compilations.Values)
+        {
+            foreach (var reference in compilation.References)
+            {
+                if (reference is not PortableExecutableReference pe)
+                    continue;
+
+                var refAsm = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
+                if (refAsm != null && SymbolEqualityComparer.Default.Equals(refAsm, assembly))
+                    return pe.FilePath;
+            }
+        }
+        return null;
+    }
+
+    private static int? MetadataTokenOf(IMethodSymbol method)
+    {
+        // Use reflection on the internal Roslyn `MetadataToken` via
+        // `Microsoft.CodeAnalysis.PEMethodSymbol` exposed via `MetadataTokenAttribute`.
+        // Simpler and stable: use SymbolDocumentationCommentId + manual resolution in the PE,
+        // but easiest is using the Roslyn public surface:
+        //   method.GetType().GetProperty("MetadataToken")?.GetValue(method)
+        // which works for PEMethodSymbol in practice.
+        var prop = method.GetType().GetProperty("MetadataToken",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.Instance);
+        if (prop?.GetValue(method) is int token)
+            return token;
+        return null;
+    }
+}
+```
+
+**Note for the implementer:** the reflection hop in `MetadataTokenOf` is fragile. If Roslyn 4.14 exposes this via a public API (e.g. through `ISymbol.MetadataToken` on a future revision), prefer that. If the reflection path returns 0 or null for some symbols, fall back to matching via `DocumentationCommentId` against the metadata reader's method definitions — loop `metadataReader.MethodDefinitions`, find the one whose full name matches. Cover this fallback path only if the happy test fails.
+
+**Step 2: Run tests.**
+
+Run: `dotnet test --filter "FullyQualifiedName~PeekIlToolTests"`
+Expected: PASS.
+
+**Step 3: Commit.**
+
+```
+git commit -m "feat: PeekIlLogic resolves metadata methods and returns ilasm text"
+```
+
+---
+
+## Task 7: Register peek_il as an MCP tool
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/PeekIlTool.cs`
+- Modify: [src/RoslynCodeLens/SolutionManager.cs](../../src/RoslynCodeLens/SolutionManager.cs) — add `PEFileCache` and `IlDisassemblerAdapter` singletons; dispose on `Dispose()`.
+
+**Step 1: Tool wrapper.**
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class PeekIlTool
+{
+    [McpServerTool(Name = "peek_il"),
+     Description("Return ilasm-style IL for a method in a referenced closed-source assembly.")]
+    public static IlPeekResult Execute(
+        MultiSolutionManager manager,
+        [Description("Fully qualified method name with parameter types, e.g. 'Newtonsoft.Json.JsonConvert.SerializeObject(object)'")] string methodSymbol)
+    {
+        manager.EnsureLoaded();
+        return PeekIlLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetMetadataResolver(),
+            manager.GetIlDisassembler(),
+            methodSymbol);
+    }
+}
+```
+
+**Step 2: Add `PEFileCache` / `IlDisassemblerAdapter` to `SolutionManager`.** Create them in the constructor, expose `GetIlDisassembler()`, dispose in `Dispose()`. Also surface `GetIlDisassembler()` on `MultiSolutionManager`.
+
+**Step 3: Wire PEFileCache to FileChangeTracker.** Currently `FileChangeTracker` watches `*.cs / *.csproj / *.props / *.targets`. Add `*.dll` to the watched extensions so that when a NuGet restore or internal-assembly rebuild replaces a DLL, `_peCache.Invalidate(path)` is called.
+
+Update `FileChangeTracker` to accept a callback:
+```csharp
+public Action<string>? OnAssemblyChanged { get; set; }
+```
+
+In the `ProcessPendingChanges` / `OnFileChangedPath` path, if the file is a `.dll`, invoke the callback with the full path (no project marking). Wire the callback in `SolutionManager` to call `_peCache.Invalidate(...)`.
+
+**Step 4: Build + full test run.**
+
+Run: `dotnet build && dotnet test`
+Expected: all green.
+
+**Step 5: Commit.**
+
+```
+git commit -m "feat: register peek_il MCP tool and wire PEFileCache to FileChangeTracker"
+```
+
+---
+
+## Task 8: Add benchmarks for peek_il and inspect_external_assembly
+
+**Files:**
+- Modify: [benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs](../../benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs)
+
+Add three benchmarks following the existing pattern:
+
+```csharp
+[Benchmark(Description = "inspect_external_assembly: summary")]
+public object InspectExternalAssemblySummary() =>
+    InspectExternalAssemblyLogic.Execute(_metadata,
+        "Microsoft.Extensions.DependencyInjection.Abstractions", "summary", null);
+
+[Benchmark(Description = "inspect_external_assembly: namespace")]
+public object InspectExternalAssemblyNamespace() =>
+    InspectExternalAssemblyLogic.Execute(_metadata,
+        "Microsoft.Extensions.DependencyInjection.Abstractions", "namespace",
+        "Microsoft.Extensions.DependencyInjection");
+
+[Benchmark(Description = "peek_il: ServiceDescriptor ctor")]
+public object PeekIlServiceDescriptor() =>
+    PeekIlLogic.Execute(_loaded, _metadata, _ilAdapter,
+        "Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)");
+```
+
+Add `_metadata`, `_ilAdapter`, `_peCache` fields and initialize them in `Setup()`.
+
+**Step 1: Build benchmarks.**
+
+Run: `dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release`
+
+**Step 2: Smoke-run.**
+
+Run: `dotnet run --project benchmarks/RoslynCodeLens.Benchmarks -c Release -- --filter '*inspect_external*' --job short`
+
+Just verify no exceptions. Short-job results are not meaningful — we only want to confirm the benchmark code is wired correctly.
+
+**Step 3: Commit.**
+
+```
+git commit -m "bench: add inspect_external_assembly and peek_il benchmarks"
+```
+
+---
+
+## Task 9: SKILL.md — Phase 3 final pass
+
+**Files:**
+- Modify: [plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md](../../plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md)
+
+**Step 1: Document peek_il.** A section with:
+- Input format (fully qualified method with parameter types)
+- Output is ilasm text — not C#
+- When to use (after `find_callers` identifies a metadata method that's worth reading)
+- Limitations (no abstract/interface instance members, no properties-as-whole — must target accessor)
+
+**Step 2: Update the decision tree**: replace `"See a method's IL → deferred to Phase 3"` with `"See a method's IL → peek_il with the full signature"`.
+
+**Step 3: Commit.**
+
+```
+git commit -m "docs(skill): document peek_il"
+```
+
+---
+
+## Task 10: Final sweep + PR
+
+**Step 1:** `dotnet build && dotnet test` — all green, zero warnings.
+
+**Step 2:** @superpowers:verification-before-completion — call `peek_il` on a real dependency in Claude Code, confirm IL appears and is sensible.
+
+**Step 3:** PR titled `feat: external-assembly analysis — Phase 3 (peek_il)` linking issue #95, design doc, and Phase 1 + Phase 2 PRs. Note in the PR description: new LGPL dependency (`ICSharpCode.Decompiler`), attribution added to `README.md` and `NOTICE`.
+
+**Step 4:** Close issue #95 with a summary of all three phases shipped.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -76,6 +76,23 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 
 ## When to Use Each Tool
 
+### Decision Tree for External Assemblies
+
+```
+I want to...                         Tool / Approach
+─────────────────────────────────────────────────────────────────────
+Work with types in my source code  → existing tools (unchanged)
+Look up an external type by name   → go_to_definition / get_symbol_context /
+                                     get_type_overview / get_type_hierarchy
+                                     (pass fully-qualified name; returns origin="metadata")
+Browse what a package exposes      → inspect_external_assembly
+Who in my code uses an ext. type?  → find_references / find_callers /
+                                     find_implementations (Phase 2 — extended)
+See a method's IL bytecode         → peek_il (Phase 3 — not yet available)
+Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
+                                     project, rebuild_solution, then use normally
+```
+
 ### Understanding a Codebase
 - `get_project_dependencies` — solution architecture, how projects relate.
 - `get_symbol_context` — full context for a type (namespace, base, interfaces, DI deps, public members).
@@ -124,6 +141,27 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 ### Source Generators
 - `get_source_generators` — list generators and their outputs.
 - `get_generated_code` — inspect generated source (filter by generator or file path).
+
+### Working with External Assemblies (Closed-Source / NuGet)
+
+External symbols have `origin.kind = "metadata"` in tool results. Supply fully-qualified names (e.g. `Microsoft.Extensions.DependencyInjection.IServiceCollection`) to the Tier-1 tools below — they fall back to metadata lookup automatically when no source match is found.
+
+- `inspect_external_assembly` — browse a referenced assembly's public API:
+  - `mode="summary"` → namespace tree + type counts (start here to orient yourself)
+  - `mode="namespace"` → full type + member listing for one namespace
+
+**Worked example — drill into a NuGet package:**
+```
+inspect_external_assembly(assemblyName: "Microsoft.Extensions.DependencyInjection.Abstractions", mode: "summary")
+→ shows NamespaceTree with Microsoft.Extensions.DependencyInjection (15 types)
+
+inspect_external_assembly(assemblyName: "Microsoft.Extensions.DependencyInjection.Abstractions",
+    mode: "namespace", namespaceFilter: "Microsoft.Extensions.DependencyInjection")
+→ returns IServiceCollection, ServiceDescriptor, ServiceLifetime, etc. with members and XML doc summaries
+```
+
+**To find where your code uses an external symbol** (Phase 2 — now available):
+Use `find_references` / `find_callers` / `find_implementations` with the fully-qualified external symbol name. Results will be source locations in your codebase.
 
 ### Solution Management
 - `list_solutions` — loaded solutions, which is active.
@@ -174,6 +212,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `find_circular_dependencies` | "Any circular dependencies?" |
 | `get_source_generators` | "What source generators are active?" |
 | `get_generated_code` | "Show generated code" |
+| `inspect_external_assembly` | "What does this NuGet package expose?" / "Show me the API of X assembly" |
 | `list_solutions` | "What solutions are loaded?" |
 | `load_solution` | "Load this .sln / .slnx at runtime" |
 | `unload_solution` | "Free memory for this solution" |
@@ -199,3 +238,42 @@ Grep is the correct tool for:
 - Packaging / publishing.
 
 State the reason when you take the exception. If you're about to type a Grep/Glob/build command and can't state the reason out loud, you're rationalizing — use the MCP tool.
+
+## Metadata Support by Tool
+
+| Tool | Works on metadata symbols | Caveats | Alternative |
+|------|--------------------------|---------|-------------|
+| `go_to_definition` | Yes — returns `File=""`, `Line=0` with `origin` block | No source location; use to confirm identity | |
+| `get_symbol_context` | Yes — members, interfaces, base type | `InjectedDependencies` always empty | |
+| `get_type_overview` | Yes | Diagnostics always empty | |
+| `get_type_hierarchy` | Yes — base chain from metadata; derived types from source only | Cannot enumerate all ecosystem implementors | |
+| `find_attribute_usages` | Yes — resolves metadata attribute type, returns source usages | | |
+| `search_symbols` | Yes — includes metadata types (budget heuristic: BCL skipped when source hits exist) | May miss BCL types if source has matches | Use fully-qualified name with `go_to_definition` |
+| `find_references` | Yes — finds source call/reference sites for external symbols | | |
+| `find_callers` | Yes — finds source invocations of external methods | | |
+| `find_implementations` | Yes — finds source implementors of external interfaces | | |
+| `inspect_external_assembly` | Metadata only — this is its purpose | Assembly must be referenced by a project in the solution | `get_nuget_dependencies` to discover assembly names |
+| `get_diagnostics` | No — source only | | |
+| `get_code_fixes` | No — source only | | |
+| `get_code_actions` | No — source only | | |
+| `apply_code_action` | No — source only | | |
+| `analyze_data_flow` | No — source only | | |
+| `analyze_control_flow` | No — source only | | |
+| `analyze_change_impact` | No — source only | | |
+| `analyze_method` | No — source only | | |
+| `get_file_overview` | No — source only | | |
+| `find_unused_symbols` | No — source only | | |
+| `get_complexity_metrics` | No — source only | | |
+| `find_naming_violations` | No — source only | | |
+| `find_large_classes` | No — source only | | |
+| `find_circular_dependencies` | No — source only | | |
+| `get_source_generators` | No — source only | | |
+| `get_generated_code` | No — source only | | |
+| `get_di_registrations` | No — source only | | |
+| `get_nuget_dependencies` | Partial — lists referenced packages, not assemblies directly | Use `inspect_external_assembly` for assembly API | |
+| `find_reflection_usage` | No — source only | | |
+| `list_solutions` | N/A | | |
+| `set_active_solution` | N/A | | |
+| `load_solution` | N/A | | |
+| `unload_solution` | N/A | | |
+| `rebuild_solution` | N/A | | |

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -160,8 +160,8 @@ inspect_external_assembly(assemblyName: "Microsoft.Extensions.DependencyInjectio
 → returns IServiceCollection, ServiceDescriptor, ServiceLifetime, etc. with members and XML doc summaries
 ```
 
-**To find where your code uses an external symbol** (Phase 2 — now available):
-Use `find_references` / `find_callers` / `find_implementations` with the fully-qualified external symbol name. Results will be source locations in your codebase.
+**To find where your code uses an external symbol** (Phase 2 — not yet available):
+`find_references` / `find_callers` / `find_implementations` do not yet accept external symbol names. Use `inspect_external_assembly` to discover the API surface, then search your source for usages manually.
 
 ### Solution Management
 - `list_solutions` — loaded solutions, which is active.
@@ -249,9 +249,9 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_type_hierarchy` | Yes — base chain from metadata; derived types from source only | Cannot enumerate all ecosystem implementors | |
 | `find_attribute_usages` | Yes — resolves metadata attribute type, returns source usages | | |
 | `search_symbols` | Yes — includes metadata types (budget heuristic: BCL skipped when source hits exist) | May miss BCL types if source has matches | Use fully-qualified name with `go_to_definition` |
-| `find_references` | Yes — finds source call/reference sites for external symbols | | |
-| `find_callers` | Yes — finds source invocations of external methods | | |
-| `find_implementations` | Yes — finds source implementors of external interfaces | | |
+| `find_references` | No — source only (Phase 2) | | |
+| `find_callers` | No — source only (Phase 2) | | |
+| `find_implementations` | No — source only (Phase 2) | | |
 | `inspect_external_assembly` | Metadata only — this is its purpose | Assembly must be referenced by a project in the solution | `get_nuget_dependencies` to discover assembly names |
 | `get_diagnostics` | No — source only | | |
 | `get_code_fixes` | No — source only | | |

--- a/src/RoslynCodeLens/Models/ExternalAssemblyOverview.cs
+++ b/src/RoslynCodeLens/Models/ExternalAssemblyOverview.cs
@@ -1,0 +1,10 @@
+namespace RoslynCodeLens.Models;
+
+public record ExternalAssemblyOverview(
+    string Mode,                                             // "summary" | "namespace"
+    string Name,
+    string Version,
+    string? TargetFramework,
+    string? PublicKeyToken,
+    IReadOnlyList<ExternalNamespaceSummary> NamespaceTree,   // non-empty for mode=="summary"
+    IReadOnlyList<ExternalTypeInfo> Types);                  // non-empty for mode=="namespace"

--- a/src/RoslynCodeLens/Models/ExternalMemberInfo.cs
+++ b/src/RoslynCodeLens/Models/ExternalMemberInfo.cs
@@ -1,0 +1,6 @@
+namespace RoslynCodeLens.Models;
+
+public record ExternalMemberInfo(
+    string Kind,                   // "method" | "property" | "field" | "event" | "constructor"
+    string Signature,
+    string? XmlDocSummary);

--- a/src/RoslynCodeLens/Models/ExternalNamespaceSummary.cs
+++ b/src/RoslynCodeLens/Models/ExternalNamespaceSummary.cs
@@ -1,0 +1,6 @@
+namespace RoslynCodeLens.Models;
+
+public record ExternalNamespaceSummary(
+    string Namespace,
+    int TypeCount,
+    IReadOnlyList<string> PublicTypeNames);

--- a/src/RoslynCodeLens/Models/ExternalTypeInfo.cs
+++ b/src/RoslynCodeLens/Models/ExternalTypeInfo.cs
@@ -1,0 +1,11 @@
+namespace RoslynCodeLens.Models;
+
+public record ExternalTypeInfo(
+    string Kind,                   // "class" | "interface" | "struct" | "enum" | "delegate"
+    string FullName,
+    IReadOnlyList<string> Modifiers,
+    string? BaseType,
+    IReadOnlyList<string> Interfaces,
+    IReadOnlyList<ExternalMemberInfo> Members,
+    IReadOnlyList<string> Attributes,
+    string? XmlDocSummary);

--- a/src/RoslynCodeLens/Models/SymbolContext.cs
+++ b/src/RoslynCodeLens/Models/SymbolContext.cs
@@ -9,4 +9,5 @@ public record SymbolContext(
     string? BaseClass,
     IReadOnlyList<string> Interfaces,
     IReadOnlyList<string> InjectedDependencies,
-    IReadOnlyList<string> PublicMembers);
+    IReadOnlyList<string> PublicMembers,
+    SymbolOrigin? Origin = null);

--- a/src/RoslynCodeLens/Models/SymbolLocation.cs
+++ b/src/RoslynCodeLens/Models/SymbolLocation.cs
@@ -6,4 +6,5 @@ public record SymbolLocation(
     string File,
     int Line,
     string Project,
-    bool IsGenerated = false);
+    bool IsGenerated = false,
+    SymbolOrigin? Origin = null);

--- a/src/RoslynCodeLens/Models/SymbolOrigin.cs
+++ b/src/RoslynCodeLens/Models/SymbolOrigin.cs
@@ -1,0 +1,7 @@
+namespace RoslynCodeLens.Models;
+
+public record SymbolOrigin(
+    string Kind,                 // "source" | "metadata"
+    string? AssemblyName,        // null when Kind=="source"
+    string? AssemblyVersion,     // null when Kind=="source"
+    string? DocId);              // null when Kind=="source"; set for metadata

--- a/src/RoslynCodeLens/Models/TypeHierarchy.cs
+++ b/src/RoslynCodeLens/Models/TypeHierarchy.cs
@@ -3,4 +3,5 @@ namespace RoslynCodeLens.Models;
 public record TypeHierarchy(
     IReadOnlyList<SymbolLocation> Bases,
     IReadOnlyList<SymbolLocation> Interfaces,
-    IReadOnlyList<SymbolLocation> Derived);
+    IReadOnlyList<SymbolLocation> Derived,
+    SymbolOrigin? Origin = null);

--- a/src/RoslynCodeLens/Models/TypeOverview.cs
+++ b/src/RoslynCodeLens/Models/TypeOverview.cs
@@ -3,4 +3,5 @@ namespace RoslynCodeLens.Models;
 public record TypeOverview(
     SymbolContext? Context,
     TypeHierarchy? Hierarchy,
-    IReadOnlyList<DiagnosticInfo> Diagnostics);
+    IReadOnlyList<DiagnosticInfo> Diagnostics,
+    SymbolOrigin? Origin = null);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens;
 
@@ -53,6 +54,7 @@ public sealed class MultiSolutionManager : IDisposable
     public void EnsureLoaded() => Active.EnsureLoaded();
     public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
     public SymbolResolver GetResolver() => Active.GetResolver();
+    public MetadataSymbolResolver GetMetadataResolver() => Active.GetMetadataResolver();
     public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
     public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
 

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens;
 
@@ -8,6 +9,7 @@ public sealed class SolutionManager : IDisposable
 {
     private LoadedSolution _loaded;
     private SymbolResolver _resolver;
+    private MetadataSymbolResolver _metadataResolver;
     private readonly string? _solutionPath;
     private FileChangeTracker? _tracker;
     private readonly Lock _lock = new();
@@ -20,6 +22,7 @@ public sealed class SolutionManager : IDisposable
         _loaded = loaded;
         _solutionPath = solutionPath;
         _resolver = new SymbolResolver(loaded);
+        _metadataResolver = new MetadataSymbolResolver(loaded, _resolver);
     }
 
     public static async Task<SolutionManager> CreateAsync(string solutionPath)
@@ -56,11 +59,13 @@ public sealed class SolutionManager : IDisposable
                 Compilations = compilations
             };
             var newResolver = new SymbolResolver(newLoaded);
+            var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
             lock (_lock)
             {
                 _loaded = newLoaded;
                 _resolver = newResolver;
+                _metadataResolver = newMetadataResolver;
 
                 if (_solutionPath != null)
                 {
@@ -99,6 +104,15 @@ public sealed class SolutionManager : IDisposable
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
         RebuildIfStale();
         return _resolver;
+    }
+
+    public MetadataSymbolResolver GetMetadataResolver()
+    {
+        _warmupTask?.GetAwaiter().GetResult();
+        if (_warmupException != null)
+            throw new InvalidOperationException("Solution warmup failed.", _warmupException);
+        RebuildIfStale();
+        return _metadataResolver;
     }
 
     public void EnsureLoaded()
@@ -175,11 +189,13 @@ public sealed class SolutionManager : IDisposable
             Compilations = compilations
         };
         var newResolver = new SymbolResolver(newLoaded);
+        var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
         lock (_lock)
         {
             _loaded = newLoaded;
             _resolver = newResolver;
+            _metadataResolver = newMetadataResolver;
         }
 
         _tracker!.UpdateMappings(newLoaded);
@@ -204,11 +220,13 @@ public sealed class SolutionManager : IDisposable
             Compilations = compilations
         };
         var newResolver = new SymbolResolver(newLoaded);
+        var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
         lock (_lock)
         {
             _loaded = newLoaded;
             _resolver = newResolver;
+            _metadataResolver = newMetadataResolver;
         }
 
         _tracker?.UpdateMappings(newLoaded);

--- a/src/RoslynCodeLens/Symbols/MetadataSymbolResolver.cs
+++ b/src/RoslynCodeLens/Symbols/MetadataSymbolResolver.cs
@@ -1,0 +1,133 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Symbols;
+
+public sealed class MetadataSymbolResolver
+{
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _source;
+
+    public MetadataSymbolResolver(LoadedSolution loaded, SymbolResolver source)
+    {
+        _loaded = loaded;
+        _source = source;
+    }
+
+    public ResolvedSymbol? Resolve(string name)
+    {
+        // 1. Source first — matches how the compilation binds. The source resolver's
+        //    indexes are built from Compilation.GlobalNamespace, which is a merged view
+        //    including referenced metadata, so a hit here may still be a metadata symbol;
+        //    ToOrigin inspects Locations to classify accurately.
+        var sourceMatches = _source.FindSymbols(name);
+        foreach (var match in sourceMatches)
+        {
+            if (match.Locations.Any(l => l.IsInSource))
+                return new ResolvedSymbol(match, SourceOrigin);
+        }
+
+        if (sourceMatches.Count > 0)
+        {
+            var first = sourceMatches[0];
+            return new ResolvedSymbol(first, ToOrigin(first));
+        }
+
+        // 2. Metadata fallback via Compilation.GetTypeByMetadataName (handles names the
+        //    source index does not reach, e.g. when SymbolResolver's display-string key
+        //    differs from the metadata name).
+        foreach (var compilation in _loaded.Compilations.Values)
+        {
+            var type = compilation.GetTypeByMetadataName(name);
+            if (type != null && type.Locations.All(l => !l.IsInSource))
+                return new ResolvedSymbol(type, ToOrigin(type));
+
+            var lastDot = name.LastIndexOf('.');
+            if (lastDot <= 0)
+                continue;
+
+            var typeName = name[..lastDot];
+            var memberName = name[(lastDot + 1)..];
+            var container = compilation.GetTypeByMetadataName(typeName);
+            if (container == null || container.Locations.Any(l => l.IsInSource))
+                continue;
+
+            var member = FindMemberIncludingInherited(container, memberName);
+            if (member != null)
+                return new ResolvedSymbol(member, ToOrigin(member));
+        }
+
+        return null;
+    }
+
+    private static ISymbol? FindMemberIncludingInherited(INamedTypeSymbol container, string memberName)
+    {
+        var direct = container.GetMembers(memberName);
+        if (direct.Length > 0)
+            return direct[0];
+
+        // For interfaces, search AllInterfaces for the member. For classes/structs,
+        // walk the base chain. Matches how the compiler resolves member-access on
+        // the static type.
+        if (container.TypeKind == TypeKind.Interface)
+        {
+            foreach (var iface in container.AllInterfaces)
+            {
+                var members = iface.GetMembers(memberName);
+                if (members.Length > 0)
+                    return members[0];
+            }
+        }
+        else
+        {
+            var current = container.BaseType;
+            while (current != null)
+            {
+                var members = current.GetMembers(memberName);
+                if (members.Length > 0)
+                    return members[0];
+                current = current.BaseType;
+            }
+        }
+
+        return null;
+    }
+
+    public IEnumerable<IAssemblySymbol> EnumerateMetadataAssemblies()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var compilation in _loaded.Compilations.Values)
+        {
+            foreach (var asm in compilation.SourceModule.ReferencedAssemblySymbols)
+            {
+                if (seen.Add(asm.Identity.GetDisplayName()))
+                    yield return asm;
+            }
+        }
+    }
+
+    public IAssemblySymbol? FindAssembly(string assemblyName)
+    {
+        foreach (var asm in EnumerateMetadataAssemblies())
+        {
+            if (string.Equals(asm.Identity.Name, assemblyName, StringComparison.OrdinalIgnoreCase))
+                return asm;
+        }
+        return null;
+    }
+
+    public static SymbolOrigin ToOrigin(ISymbol symbol)
+    {
+        if (symbol.Locations.Any(l => l.IsInSource))
+            return SourceOrigin;
+
+        var asm = symbol.ContainingAssembly;
+        return new SymbolOrigin(
+            "metadata",
+            asm?.Identity.Name,
+            asm?.Identity.Version.ToString(),
+            symbol.GetDocumentationCommentId());
+    }
+
+    public static SymbolOrigin SourceOrigin { get; } = new("source", null, null, null);
+}

--- a/src/RoslynCodeLens/Symbols/ResolvedSymbol.cs
+++ b/src/RoslynCodeLens/Symbols/ResolvedSymbol.cs
@@ -1,0 +1,6 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Symbols;
+
+public sealed record ResolvedSymbol(ISymbol Symbol, SymbolOrigin Origin);

--- a/src/RoslynCodeLens/Tools/FindAttributeUsagesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindAttributeUsagesLogic.cs
@@ -1,17 +1,52 @@
+using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class FindAttributeUsagesLogic
 {
-    public static IReadOnlyList<AttributeUsageInfo> Execute(LoadedSolution loaded, SymbolResolver resolver, string attribute)
+    public static IReadOnlyList<AttributeUsageInfo> Execute(
+        LoadedSolution loaded,
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        string attribute)
     {
-        // Use pre-built attribute index for O(1) lookup by name
-        if (!resolver.AttributeIndex.TryGetValue(attribute, out var entries))
+        // Fast path: the pre-built attribute index is keyed by simple name
+        // (e.g. "Obsolete", "ObsoleteAttribute"), so matches land here for the
+        // common case of callers typing a short attribute name.
+        if (resolver.AttributeIndex.TryGetValue(attribute, out var entries))
+            return BuildResults(resolver, entries, fallbackAttributeName: attribute);
+
+        // Fallback: the caller may have passed a fully-qualified metadata attribute
+        // (e.g. "System.ObsoleteAttribute") that the simple-name index does not
+        // reach. Resolve the attribute type via the metadata resolver and then
+        // scan the existing index values for usages whose AttributeClass matches.
+        var resolved = metadata.Resolve(attribute);
+        if (resolved?.Symbol is not INamedTypeSymbol attributeType)
             return [];
 
+        var matches = new List<(ISymbol Symbol, AttributeData Attribute)>();
+        foreach (var list in resolver.AttributeIndex.Values)
+        {
+            foreach (ref readonly var entry in CollectionsMarshal.AsSpan(list))
+            {
+                if (SymbolEqualityComparer.Default.Equals(entry.Attribute.AttributeClass, attributeType))
+                    matches.Add(entry);
+            }
+        }
+
+        return BuildResults(resolver, matches, fallbackAttributeName: attributeType.Name);
+    }
+
+    private static IReadOnlyList<AttributeUsageInfo> BuildResults(
+        SymbolResolver resolver,
+        IReadOnlyList<(ISymbol Symbol, AttributeData Attribute)> entries,
+        string fallbackAttributeName)
+    {
         var results = new List<AttributeUsageInfo>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var (symbol, attr) in entries)
         {
@@ -28,22 +63,29 @@ public static class FindAttributeUsagesLogic
                     TypeKind.Interface => "interface",
                     TypeKind.Struct => "struct",
                     TypeKind.Enum => "enum",
-                    _ => "class"
+                    _ => "class",
                 },
                 IMethodSymbol m when m.MethodKind == MethodKind.Constructor => "constructor",
                 IMethodSymbol => "method",
                 IPropertySymbol => "property",
                 IFieldSymbol => "field",
                 IEventSymbol => "event",
-                _ => "member"
+                _ => "member",
             };
 
             var targetName = symbol is INamedTypeSymbol
                 ? symbol.ToDisplayString()
                 : symbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
+            // Deduplicate: the attribute index stores each usage twice (once keyed
+            // by "Obsolete" and once by "ObsoleteAttribute"), and the metadata
+            // fallback concatenates all index lists.
+            var dedupKey = $"{targetName}|{file}|{line}";
+            if (!seen.Add(dedupKey))
+                continue;
+
             results.Add(new AttributeUsageInfo(
-                attr.AttributeClass?.Name ?? attribute,
+                attr.AttributeClass?.Name ?? fallbackAttributeName,
                 targetKind, targetName, file, line, project));
         }
 

--- a/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
@@ -14,6 +14,10 @@ public static class FindAttributeUsagesTool
         [Description("Attribute name to search for (with or without 'Attribute' suffix)")] string attribute)
     {
         manager.EnsureLoaded();
-        return FindAttributeUsagesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), attribute);
+        return FindAttributeUsagesLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            attribute);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs
@@ -1,18 +1,32 @@
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class GetSymbolContextLogic
 {
-    public static SymbolContext? Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static SymbolContext? Execute(
+        LoadedSolution loaded,
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        string symbol)
     {
         var types = resolver.FindNamedTypes(symbol);
-        if (types.Count == 0)
-            return null;
+        var target = types.FirstOrDefault(t => t.Locations.Any(l => l.IsInSource));
+        if (target != null)
+            return BuildContext(resolver, target, MetadataSymbolResolver.SourceOrigin);
 
-        var target = types[0];
+        // No source-defined type with this name — try the metadata fallback.
+        var resolved = metadata.Resolve(symbol);
+        if (resolved?.Symbol is INamedTypeSymbol metadataType)
+            return BuildMetadataContext(metadataType, resolved.Origin);
 
+        return null;
+    }
+
+    private static SymbolContext BuildContext(SymbolResolver resolver, INamedTypeSymbol target, SymbolOrigin origin)
+    {
         var (file, line) = resolver.GetFileAndLine(target);
         var project = resolver.GetProjectName(target);
 
@@ -35,16 +49,7 @@ public static class GetSymbolContextLogic
             .ToList();
 
         // Public members (skip constructors and implicit members)
-        var publicMembers = new List<string>();
-        foreach (var m in target.GetMembers())
-        {
-            if (m.DeclaredAccessibility == Accessibility.Public
-                && !m.IsImplicitlyDeclared
-                && m is not IMethodSymbol { MethodKind: MethodKind.Constructor })
-            {
-                publicMembers.Add(m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
-            }
-        }
+        var publicMembers = BuildPublicMembers(target);
 
         return new SymbolContext(
             target.ToDisplayString(),
@@ -55,6 +60,59 @@ public static class GetSymbolContextLogic
             baseClass,
             interfaces,
             injectedDependencies,
-            publicMembers);
+            publicMembers,
+            Origin: origin);
+    }
+
+    private static SymbolContext BuildMetadataContext(INamedTypeSymbol target, SymbolOrigin origin)
+    {
+        string? baseClass = target.BaseType is { SpecialType: not SpecialType.System_Object }
+            ? target.BaseType.ToDisplayString()
+            : null;
+
+        var interfaces = target.AllInterfaces
+            .Select(i => i.ToDisplayString())
+            .ToList();
+
+        // Metadata types have no meaningful DI story — constructors on a referenced
+        // interface/type aren't "dependencies injected into OUR code". Leave empty.
+        // For metadata interfaces, include inherited members too: consumers calling
+        // get_symbol_context on IServiceCollection expect to see Add/Remove/etc even
+        // though those live on the base IList<T> interface.
+        var publicMembers = BuildPublicMembers(target);
+        if (target.TypeKind == TypeKind.Interface)
+        {
+            foreach (var iface in target.AllInterfaces)
+            {
+                publicMembers.AddRange(BuildPublicMembers(iface));
+            }
+        }
+
+        return new SymbolContext(
+            target.ToDisplayString(),
+            target.ContainingNamespace.ToDisplayString(),
+            Project: "",
+            File: "",
+            Line: 0,
+            baseClass,
+            interfaces,
+            InjectedDependencies: [],
+            publicMembers,
+            Origin: origin);
+    }
+
+    private static List<string> BuildPublicMembers(INamedTypeSymbol target)
+    {
+        var publicMembers = new List<string>();
+        foreach (var m in target.GetMembers())
+        {
+            if (m.DeclaredAccessibility == Accessibility.Public
+                && !m.IsImplicitlyDeclared
+                && m is not IMethodSymbol { MethodKind: MethodKind.Constructor })
+            {
+                publicMembers.Add(m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+            }
+        }
+        return publicMembers;
     }
 }

--- a/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
@@ -14,6 +14,10 @@ public static class GetSymbolContextTool
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
-        return GetSymbolContextLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        return GetSymbolContextLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs
@@ -1,23 +1,44 @@
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class GetTypeHierarchyLogic
 {
-    public static TypeHierarchy? Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    /// <summary>
+    /// Walks base classes, interfaces, and derived types for a named type. Accepts
+    /// both source-defined and metadata types. Derived types are source-only — the
+    /// server cannot enumerate all derivations across the ecosystem, so implementors
+    /// of a metadata interface will only be listed when they live in the loaded
+    /// solution's source.
+    /// </summary>
+    public static TypeHierarchy? Execute(
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
-        var types = resolver.FindNamedTypes(symbol);
-        if (types.Count == 0)
-            return null;
+        INamedTypeSymbol? target = null;
+        SymbolOrigin origin = MetadataSymbolResolver.SourceOrigin;
 
-        var target = types[0];
+        var types = resolver.FindNamedTypes(symbol);
+        target = types.FirstOrDefault(t => t.Locations.Any(l => l.IsInSource));
+        if (target == null)
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved?.Symbol is INamedTypeSymbol metadataType)
+            {
+                target = metadataType;
+                origin = resolved.Origin;
+            }
+        }
+
+        if (target == null)
+            return null;
 
         var bases = CollectBaseTypes(target, resolver);
         var interfaces = CollectInterfaces(target, resolver);
         var derived = CollectDerivedTypes(target, resolver);
 
-        return new TypeHierarchy(bases, interfaces, derived);
+        return new TypeHierarchy(bases, interfaces, derived, Origin: origin);
     }
 
     private static List<SymbolLocation> CollectBaseTypes(INamedTypeSymbol target, SymbolResolver resolver)
@@ -26,10 +47,7 @@ public static class GetTypeHierarchyLogic
         var baseType = target.BaseType;
         while (baseType != null && baseType.SpecialType != SpecialType.System_Object)
         {
-            var (file, line) = resolver.GetFileAndLine(baseType);
-            var project = resolver.GetProjectName(baseType);
-            var kind = GetTypeKindString(baseType);
-            bases.Add(new SymbolLocation(kind, baseType.ToDisplayString(), file, line, project));
+            bases.Add(BuildLocation(baseType, resolver));
             baseType = baseType.BaseType;
         }
         return bases;
@@ -40,9 +58,7 @@ public static class GetTypeHierarchyLogic
         var interfaces = new List<SymbolLocation>();
         foreach (var iface in target.AllInterfaces)
         {
-            var (file, line) = resolver.GetFileAndLine(iface);
-            var project = resolver.GetProjectName(iface);
-            interfaces.Add(new SymbolLocation("interface", iface.ToDisplayString(), file, line, project));
+            interfaces.Add(BuildLocation(iface, resolver));
         }
         return interfaces;
     }
@@ -61,12 +77,20 @@ public static class GetTypeHierarchyLogic
             if (!seen.Add(fullName))
                 continue;
 
-            var (file, line) = resolver.GetFileAndLine(candidate);
-            var project = resolver.GetProjectName(candidate);
-            var kind = GetTypeKindString(candidate);
-            derived.Add(new SymbolLocation(kind, fullName, file, line, project));
+            derived.Add(BuildLocation(candidate, resolver));
         }
         return derived;
+    }
+
+    private static SymbolLocation BuildLocation(INamedTypeSymbol type, SymbolResolver resolver)
+    {
+        var (file, line) = resolver.GetFileAndLine(type);
+        var project = resolver.GetProjectName(type);
+        var kind = GetTypeKindString(type);
+        return new SymbolLocation(
+            kind, type.ToDisplayString(), file, line, project,
+            IsGenerated: false,
+            Origin: MetadataSymbolResolver.ToOrigin(type));
     }
 
     private static string GetTypeKindString(INamedTypeSymbol type)
@@ -75,7 +99,7 @@ public static class GetTypeHierarchyLogic
         {
             TypeKind.Struct => "struct",
             TypeKind.Interface => "interface",
-            _ => "class"
+            _ => "class",
         };
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
@@ -14,6 +14,6 @@ public static class GetTypeHierarchyTool
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
-        return GetTypeHierarchyLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        return GetTypeHierarchyLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
@@ -21,7 +21,7 @@ public static class GetTypeOverviewLogic
         if (context == null)
             return null;
 
-        var hierarchy = GetTypeHierarchyLogic.Execute(loaded, resolver, typeName);
+        var hierarchy = GetTypeHierarchyLogic.Execute(resolver, metadata, typeName);
 
         List<DiagnosticInfo> diagnostics;
         if (string.Equals(context.Origin?.Kind, "metadata", StringComparison.Ordinal))

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
@@ -6,7 +7,8 @@ public static class GetTypeOverviewLogic
 {
     public static TypeOverview? Execute(LoadedSolution loaded, SymbolResolver resolver, string typeName)
     {
-        var context = GetSymbolContextLogic.Execute(loaded, resolver, typeName);
+        var metadata = new MetadataSymbolResolver(loaded, resolver);
+        var context = GetSymbolContextLogic.Execute(loaded, resolver, metadata, typeName);
         if (context == null)
             return null;
 

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
@@ -5,21 +5,40 @@ namespace RoslynCodeLens.Tools;
 
 public static class GetTypeOverviewLogic
 {
-    public static TypeOverview? Execute(LoadedSolution loaded, SymbolResolver resolver, string typeName)
+    /// <summary>
+    /// Returns a combined context + hierarchy + diagnostics view for a type, resolving
+    /// both source-defined and metadata-only types. For metadata types the diagnostics
+    /// list is empty by construction (the compiler does not attach diagnostics to
+    /// closed-source assemblies) and derived types are source-only.
+    /// </summary>
+    public static TypeOverview? Execute(
+        LoadedSolution loaded,
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        string typeName)
     {
-        var metadata = new MetadataSymbolResolver(loaded, resolver);
         var context = GetSymbolContextLogic.Execute(loaded, resolver, metadata, typeName);
         if (context == null)
             return null;
 
         var hierarchy = GetTypeHierarchyLogic.Execute(loaded, resolver, typeName);
 
-        // Diagnostics scoped to the file containing the type
-        var diagnostics = GetDiagnosticsLogic.Execute(loaded, resolver, project: null, severity: null)
-            .Where(d => !string.IsNullOrEmpty(context.File) &&
-                        d.File.Equals(context.File, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        List<DiagnosticInfo> diagnostics;
+        if (string.Equals(context.Origin?.Kind, "metadata", StringComparison.Ordinal))
+        {
+            // No diagnostics apply to closed-source types; File is empty so the
+            // file-scoped diagnostic filter below would be a no-op anyway.
+            diagnostics = [];
+        }
+        else
+        {
+            // Diagnostics scoped to the file containing the type
+            diagnostics = GetDiagnosticsLogic.Execute(loaded, resolver, project: null, severity: null)
+                .Where(d => !string.IsNullOrEmpty(context.File) &&
+                            string.Equals(d.File, context.File, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
 
-        return new TypeOverview(context, hierarchy, diagnostics);
+        return new TypeOverview(context, hierarchy, diagnostics, Origin: context.Origin);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
@@ -18,6 +18,7 @@ public static class GetTypeOverviewTool
         manager.EnsureLoaded();
         var loaded = manager.GetLoadedSolution();
         var resolver = manager.GetResolver();
-        return GetTypeOverviewLogic.Execute(loaded, resolver, typeName);
+        var metadata = manager.GetMetadataResolver();
+        return GetTypeOverviewLogic.Execute(loaded, resolver, metadata, typeName);
     }
 }

--- a/src/RoslynCodeLens/Tools/GoToDefinitionLogic.cs
+++ b/src/RoslynCodeLens/Tools/GoToDefinitionLogic.cs
@@ -1,16 +1,45 @@
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class GoToDefinitionLogic
 {
-    public static IReadOnlyList<SymbolLocation> Execute(SymbolResolver resolver, string symbol)
+    public static IReadOnlyList<SymbolLocation> Execute(
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
         var symbols = resolver.FindSymbols(symbol);
-        if (symbols.Count == 0)
+        if (symbols.Count > 0)
+        {
+            var sourceResults = BuildSourceResults(resolver, symbols);
+            if (sourceResults.Count > 0)
+                return sourceResults;
+        }
+
+        // Either no source match, or the matches were metadata-only (no source locations).
+        // Try the metadata fallback so callers can still locate the symbol
+        // (with File="", Line=0) and see an origin pointing at the assembly.
+        var resolved = metadata.Resolve(symbol);
+        if (resolved == null)
             return [];
 
+        return
+        [
+            new SymbolLocation(
+                KindOf(resolved.Symbol),
+                resolved.Symbol.ToDisplayString(),
+                File: "",
+                Line: 0,
+                Project: "",
+                IsGenerated: false,
+                Origin: resolved.Origin),
+        ];
+    }
+
+    private static IReadOnlyList<SymbolLocation> BuildSourceResults(
+        SymbolResolver resolver, IReadOnlyList<ISymbol> symbols)
+    {
         var results = new List<SymbolLocation>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
@@ -24,27 +53,30 @@ public static class GoToDefinitionLogic
             if (!seen.Add(fullName))
                 continue;
 
-            var kind = s switch
-            {
-                INamedTypeSymbol t => t.TypeKind switch
-                {
-                    TypeKind.Interface => "interface",
-                    TypeKind.Struct => "struct",
-                    TypeKind.Enum => "enum",
-                    TypeKind.Delegate => "delegate",
-                    _ => "class"
-                },
-                IMethodSymbol => "method",
-                IPropertySymbol => "property",
-                IFieldSymbol => "field",
-                IEventSymbol => "event",
-                _ => "symbol"
-            };
-
             var project = resolver.GetProjectName(s);
-            results.Add(new SymbolLocation(kind, fullName, file, line, project, resolver.IsGenerated(file)));
+            results.Add(new SymbolLocation(
+                KindOf(s), fullName, file, line, project,
+                resolver.IsGenerated(file),
+                Origin: MetadataSymbolResolver.SourceOrigin));
         }
 
         return results;
     }
+
+    private static string KindOf(ISymbol s) => s switch
+    {
+        INamedTypeSymbol t => t.TypeKind switch
+        {
+            TypeKind.Interface => "interface",
+            TypeKind.Struct => "struct",
+            TypeKind.Enum => "enum",
+            TypeKind.Delegate => "delegate",
+            _ => "class",
+        },
+        IMethodSymbol => "method",
+        IPropertySymbol => "property",
+        IFieldSymbol => "field",
+        IEventSymbol => "event",
+        _ => "symbol",
+    };
 }

--- a/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
+++ b/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
@@ -14,6 +14,6 @@ public static class GoToDefinitionTool
         [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.DoWork)")] string symbol)
     {
         manager.EnsureLoaded();
-        return GoToDefinitionLogic.Execute(manager.GetResolver(), symbol);
+        return GoToDefinitionLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
+++ b/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
@@ -1,0 +1,161 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class InspectExternalAssemblyLogic
+{
+    public static ExternalAssemblyOverview Execute(
+        MetadataSymbolResolver metadata,
+        string assemblyName,
+        string mode,
+        string? namespaceFilter)
+    {
+        var assembly = metadata.FindAssembly(assemblyName)
+            ?? throw new ArgumentException(
+                $"Assembly '{assemblyName}' is not referenced by any project in the active solution. " +
+                "Use get_nuget_dependencies to list referenced assemblies.");
+
+        return mode switch
+        {
+            "summary" => BuildSummary(assembly),
+            "namespace" => BuildNamespace(assembly, namespaceFilter
+                ?? throw new ArgumentException("'namespaceFilter' is required when mode='namespace'.")),
+            _ => throw new ArgumentException($"Unknown mode '{mode}'. Expected 'summary' or 'namespace'.")
+        };
+    }
+
+    private static ExternalAssemblyOverview BuildSummary(IAssemblySymbol assembly)
+    {
+        var byNamespace = new SortedDictionary<string, List<INamedTypeSymbol>>(StringComparer.Ordinal);
+        foreach (var type in SymbolResolver.GetAllTypes(assembly.GlobalNamespace))
+        {
+            if (type.DeclaredAccessibility != Accessibility.Public || type.ContainingType != null)
+                continue;
+            var ns = type.ContainingNamespace.ToDisplayString();
+            if (!byNamespace.TryGetValue(ns, out var list))
+                byNamespace[ns] = list = [];
+            list.Add(type);
+        }
+
+        var tree = byNamespace.Select(kv => new ExternalNamespaceSummary(
+            kv.Key, kv.Value.Count,
+            kv.Value.Select(t => t.Name).OrderBy(n => n, StringComparer.Ordinal).ToList()))
+            .ToList();
+
+        var id = assembly.Identity;
+        return new ExternalAssemblyOverview(
+            "summary", id.Name, id.Version.ToString(),
+            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            NamespaceTree: tree, Types: []);
+    }
+
+    private static ExternalAssemblyOverview BuildNamespace(IAssemblySymbol assembly, string ns)
+    {
+        var types = new List<INamedTypeSymbol>();
+        foreach (var t in SymbolResolver.GetAllTypes(assembly.GlobalNamespace))
+        {
+            if (t.DeclaredAccessibility != Accessibility.Public || t.ContainingType != null)
+                continue;
+            if (!string.Equals(t.ContainingNamespace.ToDisplayString(), ns, StringComparison.Ordinal))
+                continue;
+            types.Add(t);
+        }
+
+        if (types.Count == 0)
+            throw new ArgumentException(
+                $"Namespace '{ns}' not found (or contains no public types) in assembly '{assembly.Identity.Name}'.");
+
+        var typeInfos = types.OrderBy(t => t.Name, StringComparer.Ordinal).Select(ToTypeInfo).ToList();
+
+        var id = assembly.Identity;
+        return new ExternalAssemblyOverview(
+            "namespace", id.Name, id.Version.ToString(),
+            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            NamespaceTree: [], Types: typeInfos);
+    }
+
+    private static ExternalTypeInfo ToTypeInfo(INamedTypeSymbol t)
+    {
+        var kind = t.TypeKind switch
+        {
+            TypeKind.Interface => "interface",
+            TypeKind.Struct => "struct",
+            TypeKind.Enum => "enum",
+            TypeKind.Delegate => "delegate",
+            _ => "class"
+        };
+        var modifiers = new List<string>();
+        if (t.IsAbstract && t.TypeKind != TypeKind.Interface) modifiers.Add("abstract");
+        if (t.IsSealed) modifiers.Add("sealed");
+        if (t.IsStatic) modifiers.Add("static");
+
+        var baseType = t.BaseType is { SpecialType: not SpecialType.System_Object }
+            ? t.BaseType.ToDisplayString() : null;
+        var interfaces = t.Interfaces.Select(i => i.ToDisplayString()).ToList();
+
+        var isInterface = t.TypeKind == TypeKind.Interface;
+        var members = new List<ExternalMemberInfo>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        // Collect members from the type itself, then from base interfaces (for pure-marker
+        // interfaces like IServiceCollection that define no own members but inherit from
+        // IList<T>, ICollection<T>, etc.).
+        var memberSources = isInterface
+            ? new[] { t }.Concat(t.AllInterfaces.Cast<ITypeSymbol>())
+            : new[] { (ITypeSymbol)t };
+
+        foreach (var source in memberSources)
+        {
+            foreach (var m in source.GetMembers())
+            {
+                // Interface members are implicitly public; DeclaredAccessibility is NotApplicable.
+                var accessible = m.DeclaredAccessibility == Accessibility.Public
+                    || (isInterface && m.DeclaredAccessibility == Accessibility.NotApplicable);
+                if (!accessible || m.IsImplicitlyDeclared)
+                    continue;
+                if (m is IMethodSymbol { MethodKind:
+                    MethodKind.PropertyGet or MethodKind.PropertySet or
+                    MethodKind.EventAdd or MethodKind.EventRemove })
+                    continue;
+                var sig = m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                if (!seen.Add(sig))
+                    continue;
+                members.Add(new ExternalMemberInfo(MemberKind(m), sig, SummaryFromXmlDoc(m)));
+            }
+        }
+
+        var attributes = t.GetAttributes()
+            .Select(a => a.AttributeClass?.Name ?? "Attribute")
+            .ToList();
+
+        return new ExternalTypeInfo(kind, t.ToDisplayString(), modifiers, baseType,
+            interfaces, members, attributes, SummaryFromXmlDoc(t));
+    }
+
+    private static string MemberKind(ISymbol s) => s switch
+    {
+        IMethodSymbol { MethodKind: MethodKind.Constructor } => "constructor",
+        IMethodSymbol => "method",
+        IPropertySymbol => "property",
+        IFieldSymbol => "field",
+        IEventSymbol => "event",
+        _ => "symbol"
+    };
+
+    private static string? SummaryFromXmlDoc(ISymbol s)
+    {
+        var xml = s.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml))
+            return null;
+        var start = xml.IndexOf("<summary>", StringComparison.Ordinal);
+        var end = xml.IndexOf("</summary>", StringComparison.Ordinal);
+        if (start < 0 || end <= start)
+            return null;
+        return xml[(start + "<summary>".Length)..end].Trim();
+    }
+
+    private static string? FormatPublicKey(System.Collections.Immutable.ImmutableArray<byte> key)
+        => key.IsDefaultOrEmpty ? null : string.Concat(key.Select(b => b.ToString("x2")));
+}

--- a/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
+++ b/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
@@ -47,7 +47,7 @@ public static class InspectExternalAssemblyLogic
         var id = assembly.Identity;
         return new ExternalAssemblyOverview(
             "summary", id.Name, id.Version.ToString(),
-            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            TargetFramework: GetTargetFramework(assembly), PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
             NamespaceTree: tree, Types: []);
     }
 
@@ -72,7 +72,7 @@ public static class InspectExternalAssemblyLogic
         var id = assembly.Identity;
         return new ExternalAssemblyOverview(
             "namespace", id.Name, id.Version.ToString(),
-            TargetFramework: null, PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
+            TargetFramework: GetTargetFramework(assembly), PublicKeyToken: FormatPublicKey(id.PublicKeyToken),
             NamespaceTree: [], Types: typeInfos);
     }
 
@@ -154,6 +154,14 @@ public static class InspectExternalAssemblyLogic
         if (start < 0 || end <= start)
             return null;
         return xml[(start + "<summary>".Length)..end].Trim();
+    }
+
+    private static string? GetTargetFramework(IAssemblySymbol assembly)
+    {
+        var attr = assembly.GetAttributes().FirstOrDefault(a =>
+            a.AttributeClass?.ToDisplayString() ==
+            "System.Runtime.Versioning.TargetFrameworkAttribute");
+        return attr?.ConstructorArguments.FirstOrDefault().Value as string;
     }
 
     private static string? FormatPublicKey(System.Collections.Immutable.ImmutableArray<byte> key)

--- a/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
+++ b/src/RoslynCodeLens/Tools/InspectExternalAssemblyLogic.cs
@@ -15,14 +15,15 @@ public static class InspectExternalAssemblyLogic
         var assembly = metadata.FindAssembly(assemblyName)
             ?? throw new ArgumentException(
                 $"Assembly '{assemblyName}' is not referenced by any project in the active solution. " +
-                "Use get_nuget_dependencies to list referenced assemblies.");
+                "Use get_nuget_dependencies to list referenced assemblies.",
+                nameof(assemblyName));
 
         return mode switch
         {
             "summary" => BuildSummary(assembly),
             "namespace" => BuildNamespace(assembly, namespaceFilter
-                ?? throw new ArgumentException("'namespaceFilter' is required when mode='namespace'.")),
-            _ => throw new ArgumentException($"Unknown mode '{mode}'. Expected 'summary' or 'namespace'.")
+                ?? throw new ArgumentException("'namespaceFilter' is required when mode='namespace'.", nameof(namespaceFilter))),
+            _ => throw new ArgumentException($"Unknown mode '{mode}'. Expected 'summary' or 'namespace'.", nameof(mode))
         };
     }
 
@@ -65,7 +66,8 @@ public static class InspectExternalAssemblyLogic
 
         if (types.Count == 0)
             throw new ArgumentException(
-                $"Namespace '{ns}' not found (or contains no public types) in assembly '{assembly.Identity.Name}'.");
+                $"Namespace '{ns}' not found (or contains no public types) in assembly '{assembly.Identity.Name}'.",
+                nameof(ns));
 
         var typeInfos = types.OrderBy(t => t.Name, StringComparer.Ordinal).Select(ToTypeInfo).ToList();
 
@@ -87,8 +89,8 @@ public static class InspectExternalAssemblyLogic
             _ => "class"
         };
         var modifiers = new List<string>();
-        if (t.IsAbstract && t.TypeKind != TypeKind.Interface) modifiers.Add("abstract");
-        if (t.IsSealed) modifiers.Add("sealed");
+        if (t.IsAbstract && !t.IsStatic && t.TypeKind != TypeKind.Interface) modifiers.Add("abstract");
+        if (t.IsSealed && !t.IsStatic) modifiers.Add("sealed");
         if (t.IsStatic) modifiers.Add("static");
 
         var baseType = t.BaseType is { SpecialType: not SpecialType.System_Object }
@@ -117,7 +119,9 @@ public static class InspectExternalAssemblyLogic
                     continue;
                 if (m is IMethodSymbol { MethodKind:
                     MethodKind.PropertyGet or MethodKind.PropertySet or
-                    MethodKind.EventAdd or MethodKind.EventRemove })
+                    MethodKind.EventAdd or MethodKind.EventRemove or
+                    MethodKind.EventRaise or MethodKind.StaticConstructor or
+                    MethodKind.DelegateInvoke })
                     continue;
                 var sig = m.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                 if (!seen.Add(sig))
@@ -126,9 +130,11 @@ public static class InspectExternalAssemblyLogic
             }
         }
 
+#pragma warning disable EPS06 // ImmutableArray<T> is a small struct; copy is intentional and cheap
         var attributes = t.GetAttributes()
             .Select(a => a.AttributeClass?.Name ?? "Attribute")
             .ToList();
+#pragma warning restore EPS06
 
         return new ExternalTypeInfo(kind, t.ToDisplayString(), modifiers, baseType,
             interfaces, members, attributes, SummaryFromXmlDoc(t));
@@ -137,6 +143,8 @@ public static class InspectExternalAssemblyLogic
     private static string MemberKind(ISymbol s) => s switch
     {
         IMethodSymbol { MethodKind: MethodKind.Constructor } => "constructor",
+        IMethodSymbol { MethodKind: MethodKind.Conversion or MethodKind.UserDefinedOperator } => "operator",
+        IMethodSymbol { MethodKind: MethodKind.Destructor } => "destructor",
         IMethodSymbol => "method",
         IPropertySymbol => "property",
         IFieldSymbol => "field",
@@ -156,14 +164,21 @@ public static class InspectExternalAssemblyLogic
         return xml[(start + "<summary>".Length)..end].Trim();
     }
 
+#pragma warning disable EPS06 // ImmutableArray<T> is a small struct; copy is intentional and cheap
     private static string? GetTargetFramework(IAssemblySymbol assembly)
     {
         var attr = assembly.GetAttributes().FirstOrDefault(a =>
-            a.AttributeClass?.ToDisplayString() ==
-            "System.Runtime.Versioning.TargetFrameworkAttribute");
+            a.AttributeClass is { Name: "TargetFrameworkAttribute" } ac &&
+            string.Equals(
+                ac.ContainingNamespace?.ToDisplayString(),
+                "System.Runtime.Versioning",
+                StringComparison.Ordinal));
         return attr?.ConstructorArguments.FirstOrDefault().Value as string;
     }
+#pragma warning restore EPS06
 
+#pragma warning disable EPS06 // ImmutableArray<byte> is a small struct; copy is intentional and cheap
     private static string? FormatPublicKey(System.Collections.Immutable.ImmutableArray<byte> key)
         => key.IsDefaultOrEmpty ? null : string.Concat(key.Select(b => b.ToString("x2")));
+#pragma warning restore EPS06
 }

--- a/src/RoslynCodeLens/Tools/InspectExternalAssemblyTool.cs
+++ b/src/RoslynCodeLens/Tools/InspectExternalAssemblyTool.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class InspectExternalAssemblyTool
+{
+    [McpServerTool(Name = "inspect_external_assembly"),
+     Description("Inspect a referenced closed-source assembly. mode='summary' returns namespaces + type counts; mode='namespace' returns public types and members for the given namespace.")]
+    public static ExternalAssemblyOverview Execute(
+        MultiSolutionManager manager,
+        [Description("Assembly name, e.g. 'Newtonsoft.Json' or 'Microsoft.Extensions.DependencyInjection.Abstractions'")] string assemblyName,
+        [Description("'summary' (default) or 'namespace'")] string mode = "summary",
+        [Description("Required when mode='namespace'")] string? namespaceFilter = null)
+    {
+        manager.EnsureLoaded();
+        return InspectExternalAssemblyLogic.Execute(
+            manager.GetMetadataResolver(), assemblyName, mode, namespaceFilter);
+    }
+}

--- a/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
@@ -1,20 +1,26 @@
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class SearchSymbolsLogic
 {
     private const int MaxResults = 50;
+    private const int MinMetadataQueryLength = 3;
 
-    public static IReadOnlyList<SymbolLocation> Execute(SymbolResolver resolver, string query)
+    public static IReadOnlyList<SymbolLocation> Execute(
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string query)
     {
         var results = new List<SymbolLocation>();
 
         SearchTypes(resolver, query, results);
         if (results.Count < MaxResults)
             SearchMembers(resolver, query, results);
+
+        if (results.Count < MaxResults && query.Length >= MinMetadataQueryLength)
+            SearchMetadata(metadata, query, sourceHitCount: results.Count, results);
 
         return results;
     }
@@ -38,11 +44,14 @@ public static class SearchSymbolsLogic
                     TypeKind.Struct => "struct",
                     TypeKind.Enum => "enum",
                     TypeKind.Delegate => "delegate",
-                    _ => "class"
+                    _ => "class",
                 };
 
                 var project = resolver.GetProjectName(type);
-                results.Add(new SymbolLocation(kind, type.ToDisplayString(), file, line, project));
+                results.Add(new SymbolLocation(
+                    kind, type.ToDisplayString(), file, line, project,
+                    IsGenerated: false,
+                    Origin: MetadataSymbolResolver.SourceOrigin));
 
                 if (results.Count >= MaxResults)
                     return;
@@ -70,14 +79,74 @@ public static class SearchSymbolsLogic
                     IPropertySymbol => "property",
                     IFieldSymbol => "field",
                     IEventSymbol => "event",
-                    _ => null
+                    _ => null,
                 };
 
                 if (kind == null)
                     continue;
 
                 var project = resolver.GetProjectName(member);
-                results.Add(new SymbolLocation(kind, member.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat), file, line, project));
+                results.Add(new SymbolLocation(
+                    kind, member.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                    file, line, project,
+                    IsGenerated: false,
+                    Origin: MetadataSymbolResolver.SourceOrigin));
+
+                if (results.Count >= MaxResults)
+                    return;
+            }
+        }
+    }
+
+    private static void SearchMetadata(
+        MetadataSymbolResolver metadata,
+        string query,
+        int sourceHitCount,
+        List<SymbolLocation> results)
+    {
+        // Budget heuristic (token cost concern): walking every type in
+        // System.Private.CoreLib or the Microsoft.Extensions.* graph is expensive
+        // and usually irrelevant — callers who search for a short query rarely
+        // want hits from mscorlib. Skip System./Microsoft.* assemblies UNLESS the
+        // source pass produced zero hits, in which case the user almost certainly
+        // IS looking for a framework type (e.g. "IServiceCollection" lives in
+        // Microsoft.Extensions.DependencyInjection.Abstractions — see
+        // SearchSymbolsToolTests.Search_MatchesMetadataSymbol for the canonical
+        // example).
+        var includeBcl = sourceHitCount == 0;
+
+        foreach (var assembly in metadata.EnumerateMetadataAssemblies())
+        {
+            var name = assembly.Identity.Name;
+            if (!includeBcl &&
+                (name.StartsWith("System.", StringComparison.Ordinal) ||
+                 name.StartsWith("Microsoft.", StringComparison.Ordinal)))
+            {
+                continue;
+            }
+
+            foreach (var type in SymbolResolver.GetAllTypes(assembly.GlobalNamespace))
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public)
+                    continue;
+
+                if (!type.Name.Contains(query, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var kind = type.TypeKind switch
+                {
+                    TypeKind.Interface => "interface",
+                    TypeKind.Struct => "struct",
+                    TypeKind.Enum => "enum",
+                    TypeKind.Delegate => "delegate",
+                    _ => "class",
+                };
+
+                results.Add(new SymbolLocation(
+                    kind, type.ToDisplayString(),
+                    File: "", Line: 0, Project: "",
+                    IsGenerated: false,
+                    Origin: MetadataSymbolResolver.ToOrigin(type)));
 
                 if (results.Count >= MaxResults)
                     return;

--- a/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
@@ -14,6 +14,6 @@ public static class SearchSymbolsTool
         [Description("Search query (substring match against symbol names)")] string query)
     {
         manager.EnsureLoaded();
-        return SearchSymbolsLogic.Execute(manager.GetResolver(), query);
+        return SearchSymbolsLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), query);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs
+++ b/tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs
@@ -1,0 +1,62 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Tests.Symbols;
+
+public class MetadataSymbolResolverTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _sourceResolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _sourceResolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _sourceResolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Resolve_MetadataType_ReturnsMetadataSymbol()
+    {
+        var result = _metadata.Resolve(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result.Origin.Kind);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.Origin.AssemblyName);
+        Assert.False(string.IsNullOrEmpty(result.Origin.AssemblyVersion));
+        Assert.True(result.Symbol is INamedTypeSymbol { TypeKind: TypeKind.Interface });
+    }
+
+    [Fact]
+    public void Resolve_SourceTypeTakesPrecedence()
+    {
+        var result = _metadata.Resolve("IGreeter");
+
+        Assert.NotNull(result);
+        Assert.Equal("source", result.Origin.Kind);
+    }
+
+    [Fact]
+    public void Resolve_UnknownSymbol_ReturnsNull()
+    {
+        Assert.Null(_metadata.Resolve("Nothing.Here.AtAll"));
+    }
+
+    [Fact]
+    public void Resolve_MetadataMember_ReturnsMethodSymbol()
+    {
+        var result = _metadata.Resolve(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection.Add");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result.Origin.Kind);
+        Assert.IsAssignableFrom<IMethodSymbol>(result.Symbol);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
     [Fact]
     public void FindAttributeUsages_Obsolete_FindsMarkedMember()
     {
-        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, "Obsolete");
+        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, _metadata, "Obsolete");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.TargetName.Contains("OldGreet", StringComparison.Ordinal) && string.Equals(r.TargetKind, "method", StringComparison.Ordinal));
@@ -30,7 +33,7 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
     [Fact]
     public void FindAttributeUsages_Serializable_FindsMarkedType()
     {
-        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, "Serializable");
+        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, _metadata, "Serializable");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.TargetName.Contains("Greeter", StringComparison.Ordinal) && string.Equals(r.TargetKind, "class", StringComparison.Ordinal));
@@ -39,7 +42,7 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
     [Fact]
     public void FindAttributeUsages_WithSuffix_StillMatches()
     {
-        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, "ObsoleteAttribute");
+        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, _metadata, "ObsoleteAttribute");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.TargetName.Contains("OldGreet", StringComparison.Ordinal));
@@ -48,8 +51,21 @@ public class FindAttributeUsagesToolTests : IAsyncLifetime
     [Fact]
     public void FindAttributeUsages_NoMatch_ReturnsEmpty()
     {
-        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, "NonExistentAttribute");
+        var results = FindAttributeUsagesLogic.Execute(_loaded, _resolver, _metadata, "NonExistentAttribute");
 
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void FindAttributeUsages_FullyQualifiedMetadata_FindsUsage()
+    {
+        // When the caller passes the fully qualified name of a metadata attribute
+        // (which is not in the simple-name index), the metadata resolver should
+        // locate the attribute type and a full scan should still surface usages.
+        var results = FindAttributeUsagesLogic.Execute(
+            _loaded, _resolver, _metadata, "System.ObsoleteAttribute");
+
+        Assert.NotEmpty(results);
+        Assert.Contains(results, r => r.TargetName.Contains("OldGreet", StringComparison.Ordinal));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class GetSymbolContextToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class GetSymbolContextToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,11 +24,27 @@ public class GetSymbolContextToolTests : IAsyncLifetime
     [Fact]
     public void GetContext_ForGreeterConsumer_ShowsInjectedDeps()
     {
-        var result = GetSymbolContextLogic.Execute(_loaded, _resolver, "GreeterConsumer");
+        var result = GetSymbolContextLogic.Execute(_loaded, _resolver, _metadata, "GreeterConsumer");
 
         Assert.NotNull(result);
         Assert.Equal("TestLib2", result.Namespace);
         Assert.Contains(result.InjectedDependencies, d => d.Contains("IGreeter", StringComparison.Ordinal));
         Assert.Contains(result.PublicMembers, m => m.Contains("SayHello", StringComparison.Ordinal));
+        Assert.Equal("source", result.Origin?.Kind);
+    }
+
+    [Fact]
+    public void GetContext_MetadataInterface_ReturnsMembersAndOrigin()
+    {
+        var result = GetSymbolContextLogic.Execute(
+            _loaded, _resolver, _metadata, "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result!.Origin!.Kind);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection", result.Namespace);
+        Assert.Empty(result.InjectedDependencies);
+        Assert.NotEmpty(result.PublicMembers);
+        Assert.Equal("", result.File);
+        Assert.Equal(0, result.Line);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class GetTypeHierarchyToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class GetTypeHierarchyToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,17 +24,18 @@ public class GetTypeHierarchyToolTests : IAsyncLifetime
     [Fact]
     public void GetHierarchy_ForGreeter_ShowsBaseAndDerived()
     {
-        var result = GetTypeHierarchyLogic.Execute(_loaded, _resolver, "Greeter");
+        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata, "Greeter");
 
         Assert.NotNull(result);
         Assert.Contains(result.Interfaces, i => i.FullName.Contains("IGreeter", StringComparison.Ordinal));
         Assert.Contains(result.Derived, d => d.FullName.Contains("FancyGreeter", StringComparison.Ordinal));
+        Assert.Equal("source", result.Origin?.Kind);
     }
 
     [Fact]
     public void GetHierarchy_ForGreeter_HasNoBases()
     {
-        var result = GetTypeHierarchyLogic.Execute(_loaded, _resolver, "Greeter");
+        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata, "Greeter");
 
         Assert.NotNull(result);
         Assert.Empty(result.Bases);
@@ -40,7 +44,7 @@ public class GetTypeHierarchyToolTests : IAsyncLifetime
     [Fact]
     public void GetHierarchy_ForFancyGreeter_ShowsGreeterAsBase()
     {
-        var result = GetTypeHierarchyLogic.Execute(_loaded, _resolver, "FancyGreeter");
+        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata, "FancyGreeter");
 
         Assert.NotNull(result);
         Assert.Contains(result.Bases, b => b.FullName.Contains("Greeter", StringComparison.Ordinal));
@@ -50,8 +54,21 @@ public class GetTypeHierarchyToolTests : IAsyncLifetime
     [Fact]
     public void GetHierarchy_ForUnknownType_ReturnsNull()
     {
-        var result = GetTypeHierarchyLogic.Execute(_loaded, _resolver, "NonExistentType");
+        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata, "NonExistentType");
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void TypeHierarchy_MetadataInterface_HasOrigin()
+    {
+        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata,
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result!.Origin?.Kind);
+        // IServiceCollection : IList<ServiceDescriptor>, ICollection<ServiceDescriptor>, ...
+        // -- the base-interface chain is present.
+        Assert.NotEmpty(result.Interfaces);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class GetTypeOverviewToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class GetTypeOverviewToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,20 +24,34 @@ public class GetTypeOverviewToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForGreeter_ReturnsFullOverview()
     {
-        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, "Greeter");
+        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "Greeter");
 
         Assert.NotNull(result);
         Assert.NotNull(result.Context);
         Assert.NotNull(result.Hierarchy);
         Assert.NotEmpty(result.Context.PublicMembers);
         Assert.NotEmpty(result.Hierarchy.Interfaces);
+        Assert.Equal("source", result.Origin?.Kind);
     }
 
     [Fact]
     public void Execute_ForUnknownType_ReturnsNull()
     {
-        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, "NonExistentType99");
+        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "NonExistentType99");
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void TypeOverview_MetadataInterface_ReturnsShapeWithOrigin()
+    {
+        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata,
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotNull(result);
+        Assert.Equal("metadata", result!.Origin?.Kind);
+        Assert.NotNull(result.Context);
+        Assert.NotEmpty(result.Context!.PublicMembers);
+        Assert.Empty(result.Diagnostics);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class GoToDefinitionToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class GoToDefinitionToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,17 +24,18 @@ public class GoToDefinitionToolTests : IAsyncLifetime
     [Fact]
     public void GoToDefinition_ForType_ReturnsLocation()
     {
-        var results = GoToDefinitionLogic.Execute(_resolver, "Greeter");
+        var results = GoToDefinitionLogic.Execute(_resolver, _metadata, "Greeter");
 
         Assert.Single(results);
         Assert.Contains("Greeter.cs", results[0].File, StringComparison.Ordinal);
         Assert.Equal("class", results[0].Type);
+        Assert.Equal("source", results[0].Origin?.Kind);
     }
 
     [Fact]
     public void GoToDefinition_ForInterface_ReturnsLocation()
     {
-        var results = GoToDefinitionLogic.Execute(_resolver, "IGreeter");
+        var results = GoToDefinitionLogic.Execute(_resolver, _metadata, "IGreeter");
 
         Assert.Single(results);
         Assert.Contains("IGreeter.cs", results[0].File, StringComparison.Ordinal);
@@ -41,7 +45,7 @@ public class GoToDefinitionToolTests : IAsyncLifetime
     [Fact]
     public void GoToDefinition_ForMethod_ReturnsLocation()
     {
-        var results = GoToDefinitionLogic.Execute(_resolver, "Greeter.Greet");
+        var results = GoToDefinitionLogic.Execute(_resolver, _metadata, "Greeter.Greet");
 
         Assert.NotEmpty(results);
         Assert.Equal("method", results[0].Type);
@@ -50,8 +54,21 @@ public class GoToDefinitionToolTests : IAsyncLifetime
     [Fact]
     public void GoToDefinition_UnknownSymbol_ReturnsEmpty()
     {
-        var results = GoToDefinitionLogic.Execute(_resolver, "NonExistent");
+        var results = GoToDefinitionLogic.Execute(_resolver, _metadata, "NonExistent");
 
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void GoToDefinition_MetadataType_ReturnsMetadataOrigin()
+    {
+        var result = GoToDefinitionLogic.Execute(
+            _resolver, _metadata, "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        var single = Assert.Single(result);
+        Assert.NotNull(single.Origin);
+        Assert.Equal("metadata", single.Origin!.Kind);
+        Assert.Equal("", single.File);
+        Assert.Equal(0, single.Line);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
@@ -54,15 +54,17 @@ public class InspectExternalAssemblyToolTests : IAsyncLifetime
     [Fact]
     public void UnreferencedAssembly_Throws()
     {
-        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+        var ex = Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
             _metadata, "Some.NotReferenced.Library", mode: "summary", namespaceFilter: null));
+        Assert.Contains("get_nuget_dependencies", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void NamespaceMode_UnknownNamespace_Throws()
     {
-        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+        var ex = Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
             _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
             mode: "namespace", namespaceFilter: "NoSuch.Namespace"));
+        Assert.Contains("NoSuch.Namespace", ex.Message, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
@@ -31,8 +31,8 @@ public class InspectExternalAssemblyToolTests : IAsyncLifetime
         Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.Name);
         Assert.NotEmpty(result.NamespaceTree);
         Assert.Contains(result.NamespaceTree,
-            n => n.Namespace == "Microsoft.Extensions.DependencyInjection"
-              && n.PublicTypeNames.Contains("IServiceCollection"));
+            n => string.Equals(n.Namespace, "Microsoft.Extensions.DependencyInjection", StringComparison.Ordinal)
+              && n.PublicTypeNames.Contains("IServiceCollection", StringComparer.Ordinal));
         Assert.Empty(result.Types);
     }
 

--- a/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
@@ -1,0 +1,68 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class InspectExternalAssemblyToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _metadata = new MetadataSymbolResolver(_loaded, new SymbolResolver(_loaded));
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Summary_ListsNamespacesAndCounts()
+    {
+        var result = InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "summary", namespaceFilter: null);
+
+        Assert.NotNull(result);
+        Assert.Equal("summary", result!.Mode);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.Name);
+        Assert.NotEmpty(result.NamespaceTree);
+        Assert.Contains(result.NamespaceTree,
+            n => n.Namespace == "Microsoft.Extensions.DependencyInjection"
+              && n.PublicTypeNames.Contains("IServiceCollection"));
+        Assert.Empty(result.Types);
+    }
+
+    [Fact]
+    public void Namespace_ReturnsTypesWithMembers()
+    {
+        var result = InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "namespace", namespaceFilter: "Microsoft.Extensions.DependencyInjection");
+
+        Assert.NotNull(result);
+        Assert.Equal("namespace", result!.Mode);
+        Assert.Contains(result.Types, t => t.FullName.EndsWith("IServiceCollection", StringComparison.Ordinal));
+        var svc = result.Types.First(t => t.FullName.EndsWith("IServiceCollection", StringComparison.Ordinal));
+        Assert.Equal("interface", svc.Kind);
+        Assert.NotEmpty(svc.Members);
+    }
+
+    [Fact]
+    public void UnreferencedAssembly_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+            _metadata, "Some.NotReferenced.Library", mode: "summary", namespaceFilter: null));
+    }
+
+    [Fact]
+    public void NamespaceMode_UnknownNamespace_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => InspectExternalAssemblyLogic.Execute(
+            _metadata, "Microsoft.Extensions.DependencyInjection.Abstractions",
+            mode: "namespace", namespaceFilter: "NoSuch.Namespace"));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class SearchSymbolsToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class SearchSymbolsToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class SearchSymbolsToolTests : IAsyncLifetime
     [Fact]
     public void SearchSymbols_ByTypeName_FindsTypes()
     {
-        var results = SearchSymbolsLogic.Execute(_resolver, "Greeter");
+        var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "Greeter");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.FullName.Contains("Greeter", StringComparison.Ordinal));
@@ -30,7 +33,7 @@ public class SearchSymbolsToolTests : IAsyncLifetime
     [Fact]
     public void SearchSymbols_ByMethodName_FindsMethods()
     {
-        var results = SearchSymbolsLogic.Execute(_resolver, "Greet");
+        var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "Greet");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => string.Equals(r.Type, "method", StringComparison.Ordinal));
@@ -39,7 +42,7 @@ public class SearchSymbolsToolTests : IAsyncLifetime
     [Fact]
     public void SearchSymbols_CaseInsensitive_Works()
     {
-        var results = SearchSymbolsLogic.Execute(_resolver, "greeter");
+        var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "greeter");
 
         Assert.NotEmpty(results);
     }
@@ -47,8 +50,18 @@ public class SearchSymbolsToolTests : IAsyncLifetime
     [Fact]
     public void SearchSymbols_NoMatch_ReturnsEmpty()
     {
-        var results = SearchSymbolsLogic.Execute(_resolver, "XyzNonExistent123");
+        var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "XyzNonExistent123");
 
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Search_MatchesMetadataSymbol()
+    {
+        var results = SearchSymbolsLogic.Execute(_resolver, _metadata, "IServiceCollection");
+        Assert.Contains(
+            results,
+            r => string.Equals(r.Origin?.Kind, "metadata", StringComparison.Ordinal)
+              && string.Equals(r.FullName, "Microsoft.Extensions.DependencyInjection.IServiceCollection", StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary

Closes #95

Adds closed-source / metadata assembly analysis to Roslyn CodeLens. Phase 1 ships the foundations and all immediately useful capabilities without any new NuGet dependencies.

- **`MetadataSymbolResolver`** — new central component providing source-first symbol resolution with metadata fallback via `Compilation.GetTypeByMetadataName` and inherited-member walking
- **`SymbolOrigin` provenance model** — `{ kind, assemblyName, assemblyVersion, docId }` appended as an optional trailing field on `SymbolLocation`, `SymbolContext`, `TypeOverview`, `TypeHierarchy`
- **6 Tier-1 tools extended** — `go_to_definition`, `get_symbol_context`, `get_type_overview`, `get_type_hierarchy`, `find_attribute_usages`, `search_symbols` now accept fully-qualified external symbol names and return `origin.kind="metadata"` results
- **New tool: `inspect_external_assembly`** — browse any solution-referenced assembly's public API surface; `mode="summary"` returns namespace tree + type counts; `mode="namespace"` returns full type+member listing with XML doc summaries and `TargetFramework`
- **SKILL.md updated** — decision tree for external assembly workflows, per-tool metadata support table, worked examples

## What's New

| Tool | External symbol support |
|------|------------------------|
| `go_to_definition` | Yes — returns `origin` block, `File=""`, `Line=0` |
| `get_symbol_context` | Yes — members, base, interfaces, XML docs |
| `get_type_overview` | Yes |
| `get_type_hierarchy` | Yes — base chain from metadata; derived types source-only |
| `find_attribute_usages` | Yes — resolves metadata attribute type, returns source usages |
| `search_symbols` | Yes — metadata types included (BCL budget heuristic) |
| `inspect_external_assembly` | New tool — API browser for closed-source assemblies |

## Design

[docs/plans/2026-04-24-closed-source-assemblies-design.md](docs/plans/2026-04-24-closed-source-assemblies-design.md)

## Not in Phase 1

- `find_references` / `find_callers` / `find_implementations` accepting external symbol names → Phase 2
- `peek_il` IL disassembly → Phase 3

## Test Plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test` — 143 tests pass (139 pre-existing + 4 new `InspectExternalAssemblyToolTests`)
- [ ] `go_to_definition("Microsoft.Extensions.DependencyInjection.IServiceCollection")` returns `origin.kind="metadata"`
- [ ] `inspect_external_assembly("Microsoft.Extensions.DependencyInjection.Abstractions", mode="summary")` lists namespaces
- [ ] `inspect_external_assembly(... mode="namespace", namespaceFilter="Microsoft.Extensions.DependencyInjection")` returns `IServiceCollection` with members

🤖 Generated with [Claude Code](https://claude.com/claude-code)