### PR TITLE
feat: external-assembly analysis — Phase 2 (Tier-2 references)

### DIFF
--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -62,13 +62,13 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "find_implementations: IGreeter")]
     public object FindImplementations()
     {
-        return FindImplementationsLogic.Execute(_loaded, _resolver, "IGreeter");
+        return FindImplementationsLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
     }
 
     [Benchmark(Description = "find_callers: IGreeter.Greet")]
     public object FindCallers()
     {
-        return FindCallersLogic.Execute(_loaded, _resolver, "IGreeter.Greet");
+        return FindCallersLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
     }
 
     [Benchmark(Description = "get_type_hierarchy: Greeter")]
@@ -104,7 +104,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "find_references: IGreeter")]
     public object FindReferences()
     {
-        return FindReferencesLogic.Execute(_loaded, _resolver, "IGreeter");
+        return FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
     }
 
     [Benchmark(Description = "go_to_definition: Greeter")]
@@ -194,7 +194,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "analyze_change_impact: IGreeter.Greet")]
     public object? AnalyzeChangeImpact()
     {
-        return AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, "IGreeter.Greet");
+        return AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
     }
 
     [Benchmark(Description = "get_type_overview: Greeter")]
@@ -206,7 +206,7 @@ public class CodeGraphBenchmarks
     [Benchmark(Description = "analyze_method: Greeter.Greet")]
     public object? AnalyzeMethod()
     {
-        return AnalyzeMethodLogic.Execute(_loaded, _resolver, "Greeter.Greet");
+        return AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "Greeter.Greet");
     }
 
     [Benchmark(Description = "get_file_overview: Greeter.cs")]

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -86,8 +86,7 @@ Look up an external type by name   → go_to_definition / get_symbol_context /
                                      get_type_overview / get_type_hierarchy
                                      (pass fully-qualified name; returns origin="metadata")
 Browse what a package exposes      → inspect_external_assembly
-Who in my code uses an ext. type?  → find_references / find_callers /
-                                     find_implementations (Phase 2 — extended)
+Who in my code uses an ext. type?  → find_references / find_callers / find_implementations
 See a method's IL bytecode         → peek_il (Phase 3 — not yet available)
 Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
                                      project, rebuild_solution, then use normally
@@ -160,8 +159,17 @@ inspect_external_assembly(assemblyName: "Microsoft.Extensions.DependencyInjectio
 → returns IServiceCollection, ServiceDescriptor, ServiceLifetime, etc. with members and XML doc summaries
 ```
 
-**To find where your code uses an external symbol** (Phase 2 — not yet available):
-`find_references` / `find_callers` / `find_implementations` do not yet accept external symbol names. Use `inspect_external_assembly` to discover the API surface, then search your source for usages manually.
+**To find where your code uses an external symbol:**
+Use `find_references` / `find_callers` / `find_implementations` with the fully-qualified external symbol name. Results will be source locations in your codebase.
+
+**To find all source files using `IServiceCollection`:**
+```
+find_references("Microsoft.Extensions.DependencyInjection.IServiceCollection")
+→ returns source locations (all origin.kind="source") where your code references IServiceCollection
+
+find_callers("Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton")
+→ returns source call sites for AddSingleton (pass the extension class + method name)
+```
 
 ### Solution Management
 - `list_solutions` — loaded solutions, which is active.
@@ -249,9 +257,9 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_type_hierarchy` | Yes — base chain from metadata; derived types from source only | Cannot enumerate all ecosystem implementors | |
 | `find_attribute_usages` | Yes — resolves metadata attribute type, returns source usages | | |
 | `search_symbols` | Yes — includes metadata types (budget heuristic: BCL skipped when source hits exist) | May miss BCL types if source has matches | Use fully-qualified name with `go_to_definition` |
-| `find_references` | No — source only (Phase 2) | | |
-| `find_callers` | No — source only (Phase 2) | | |
-| `find_implementations` | No — source only (Phase 2) | | |
+| `find_references` | Yes — finds source usages/references of external symbols | | |
+| `find_callers` | Yes — finds source invocations of external methods | | |
+| `find_implementations` | Yes — finds source implementors of external interfaces/classes | | |
 | `inspect_external_assembly` | Metadata only — this is its purpose | Assembly must be referenced by a project in the solution | `get_nuget_dependencies` to discover assembly names |
 | `get_diagnostics` | No — source only | | |
 | `get_code_fixes` | No — source only | | |

--- a/src/RoslynCodeLens/Tools/AnalyzeChangeImpactLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeChangeImpactLogic.cs
@@ -1,13 +1,14 @@
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class AnalyzeChangeImpactLogic
 {
-    public static ChangeImpact? Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static ChangeImpact? Execute(LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
-        var references = FindReferencesLogic.Execute(loaded, resolver, symbol);
-        var callers = FindCallersLogic.Execute(loaded, resolver, symbol);
+        var references = FindReferencesLogic.Execute(loaded, resolver, metadata, symbol);
+        var callers = FindCallersLogic.Execute(loaded, resolver, metadata, symbol);
 
         // If neither found anything, symbol doesn't exist
         if (references.Count == 0 && callers.Count == 0)

--- a/src/RoslynCodeLens/Tools/AnalyzeChangeImpactTool.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeChangeImpactTool.cs
@@ -18,6 +18,6 @@ public static class AnalyzeChangeImpactTool
         manager.EnsureLoaded();
         var loaded = manager.GetLoadedSolution();
         var resolver = manager.GetResolver();
-        return AnalyzeChangeImpactLogic.Execute(loaded, resolver, symbol);
+        return AnalyzeChangeImpactLogic.Execute(loaded, resolver, manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs
@@ -1,12 +1,13 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class AnalyzeMethodLogic
 {
-    public static MethodAnalysis? Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static MethodAnalysis? Execute(LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
         var methods = resolver.FindMethods(symbol);
         if (methods.Count == 0)
@@ -17,7 +18,7 @@ public static class AnalyzeMethodLogic
         var projectName = resolver.GetProjectName(target);
         var signature = target.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
-        var callers = FindCallersLogic.Execute(loaded, resolver, symbol);
+        var callers = FindCallersLogic.Execute(loaded, resolver, metadata, symbol);
         var outgoing = FindOutgoingCalls(loaded, target);
 
         return new MethodAnalysis(symbol, file, line, projectName, signature, callers, outgoing);

--- a/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
@@ -18,6 +18,6 @@ public static class AnalyzeMethodTool
         manager.EnsureLoaded();
         var loaded = manager.GetLoadedSolution();
         var resolver = manager.GetResolver();
-        return AnalyzeMethodLogic.Execute(loaded, resolver, symbol);
+        return AnalyzeMethodLogic.Execute(loaded, resolver, manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindCallersLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersLogic.cs
@@ -1,24 +1,43 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class FindCallersLogic
 {
-    public static IReadOnlyList<CallerInfo> Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static IReadOnlyList<CallerInfo> Execute(
+        LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
     {
-        var targetMethods = resolver.FindMethods(symbol);
+        var targetMethods = source.FindMethods(symbol);
         if (targetMethods.Count == 0)
-            return [];
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved?.Symbol is IMethodSymbol m)
+            {
+                // Include all overloads with the same name from the same containing type
+                // so that generic overloads (e.g. AddScoped<T1,T2>) are all matched.
+                var allOverloads = (IReadOnlyList<IMethodSymbol>)(m.ContainingType?.GetMembers(m.Name)
+                    .OfType<IMethodSymbol>()
+                    .ToArray() ?? []);
+                targetMethods = allOverloads.Count > 0 ? allOverloads : [m];
+            }
+            else
+                return [];
+        }
 
         var targetSet = new HashSet<IMethodSymbol>(targetMethods, SymbolEqualityComparer.Default);
+        // For metadata targets resolved from one compilation, build a name-based fallback
+        // so cross-compilation symbol comparisons work (metadata from different compilations
+        // have different ISymbol instances but the same containing type + name).
+        var targetMetadataKeys = BuildMetadataKeys(targetMethods);
         var results = new List<CallerInfo>();
         var seen = new HashSet<(string, int)>();
 
         foreach (var (projectId, compilation) in loaded.Compilations)
         {
-            var projectName = resolver.GetProjectName(projectId);
+            var projectName = source.GetProjectName(projectId);
 
             foreach (var syntaxTree in compilation.SyntaxTrees)
             {
@@ -31,7 +50,7 @@ public static class FindCallersLogic
                     if (symbolInfo.Symbol is not IMethodSymbol calledMethod)
                         continue;
 
-                    if (!IsMethodMatch(calledMethod, targetSet, targetMethods))
+                    if (!IsMethodMatch(calledMethod, targetSet, targetMethods, targetMetadataKeys))
                         continue;
 
                     var lineSpan = invocation.GetLocation().GetLineSpan();
@@ -44,7 +63,7 @@ public static class FindCallersLogic
                     var callerName = GetCallerName(invocation);
                     var snippet = invocation.ToString();
 
-                    results.Add(new CallerInfo(callerName, file, line, snippet, projectName, resolver.IsGenerated(file)));
+                    results.Add(new CallerInfo(callerName, file, line, snippet, projectName, source.IsGenerated(file)));
                 }
             }
         }
@@ -52,10 +71,37 @@ public static class FindCallersLogic
         return results;
     }
 
-    private static bool IsMethodMatch(IMethodSymbol calledMethod, HashSet<IMethodSymbol> targetSet, IReadOnlyList<IMethodSymbol> targetMethods)
+    private static HashSet<string> BuildMetadataKeys(IReadOnlyList<IMethodSymbol> methods)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var m in methods)
+        {
+            if (m.Locations.All(l => !l.IsInSource))
+            {
+                var typeName = m.ContainingType?.ToDisplayString() ?? string.Empty;
+                keys.Add($"{typeName}.{m.Name}");
+            }
+        }
+        return keys;
+    }
+
+    private static bool IsMethodMatch(
+        IMethodSymbol calledMethod,
+        HashSet<IMethodSymbol> targetSet,
+        IReadOnlyList<IMethodSymbol> targetMethods,
+        HashSet<string> targetMetadataKeys)
     {
         if (targetSet.Contains(calledMethod) || targetSet.Contains(calledMethod.OriginalDefinition))
             return true;
+
+        // Cross-compilation fallback for metadata symbols: compare by containing type name + method name
+        if (targetMetadataKeys.Count > 0 && calledMethod.Locations.All(l => !l.IsInSource))
+        {
+            var typeName = (calledMethod.OriginalDefinition.ContainingType ?? calledMethod.ContainingType)
+                ?.ToDisplayString() ?? string.Empty;
+            if (targetMetadataKeys.Contains($"{typeName}.{calledMethod.Name}"))
+                return true;
+        }
 
         for (int i = 0; i < targetMethods.Count; i++)
         {

--- a/src/RoslynCodeLens/Tools/FindCallersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersTool.cs
@@ -14,6 +14,6 @@ public static class FindCallersTool
         [Description("Method name as Type.Method (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
-        return FindCallersLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        return FindCallersLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindImplementationsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindImplementationsLogic.cs
@@ -1,13 +1,24 @@
 using Microsoft.CodeAnalysis;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class FindImplementationsLogic
 {
-    public static IReadOnlyList<SymbolLocation> Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static IReadOnlyList<SymbolLocation> Execute(
+        LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
     {
-        var targetTypes = resolver.FindNamedTypes(symbol);
+        var targetTypes = source.FindNamedTypes(symbol);
+        if (targetTypes.Count == 0)
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved?.Symbol is INamedTypeSymbol nt)
+                targetTypes = [nt];
+            else
+                return [];
+        }
+
         var results = new List<SymbolLocation>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
 
@@ -16,9 +27,9 @@ public static class FindImplementationsLogic
             IReadOnlyList<INamedTypeSymbol> candidates;
 
             if (target.TypeKind == TypeKind.Interface)
-                candidates = resolver.GetInterfaceImplementors(target);
+                candidates = source.GetInterfaceImplementors(target);
             else
-                candidates = resolver.GetDerivedTypes(target);
+                candidates = source.GetDerivedTypes(target);
 
             foreach (var candidate in candidates)
             {
@@ -26,15 +37,15 @@ public static class FindImplementationsLogic
                 if (!seen.Add(fullName))
                     continue;
 
-                var (file, line) = resolver.GetFileAndLine(candidate);
-                var project = resolver.GetProjectName(candidate);
+                var (file, line) = source.GetFileAndLine(candidate);
+                var project = source.GetProjectName(candidate);
                 var kind = candidate.TypeKind switch
                 {
                     TypeKind.Struct => "struct",
                     TypeKind.Interface => "interface",
                     _ => "class"
                 };
-                results.Add(new SymbolLocation(kind, fullName, file, line, project, resolver.IsGenerated(file)));
+                results.Add(new SymbolLocation(kind, fullName, file, line, project, source.IsGenerated(file)));
             }
         }
 

--- a/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
@@ -14,6 +14,6 @@ public static class FindImplementationsTool
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
-        return FindImplementationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        return FindImplementationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
@@ -1,19 +1,26 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
 public static class FindReferencesLogic
 {
-    public static IReadOnlyList<SymbolReference> Execute(LoadedSolution loaded, SymbolResolver resolver, string symbol)
+    public static IReadOnlyList<SymbolReference> Execute(
+        LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
     {
-        var targets = resolver.FindSymbols(symbol);
+        var targets = source.FindSymbols(symbol);
         if (targets.Count == 0)
-            return [];
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved == null)
+                return [];
+            targets = [resolved.Symbol];
+        }
 
         var targetSet = BuildTargetSet(targets);
-        return ScanForReferences(loaded, resolver, targetSet);
+        return ScanForReferences(loaded, source, targetSet);
     }
 
     private static HashSet<ISymbol> BuildTargetSet(IReadOnlyList<ISymbol> targets)

--- a/src/RoslynCodeLens/Tools/FindReferencesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesTool.cs
@@ -14,6 +14,6 @@ public static class FindReferencesTool
         [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyProperty)")] string symbol)
     {
         manager.EnsureLoaded();
-        return FindReferencesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        return FindReferencesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/Greeter.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/Greeter.cs
@@ -3,7 +3,7 @@ using System;
 namespace TestLib;
 
 [Serializable]
-public class Greeter : IGreeter
+public class Greeter : IGreeter, IDisposable
 {
     public virtual string Greet(string name) => $"Hello, {name}!";
 
@@ -12,4 +12,6 @@ public class Greeter : IGreeter
 
     // Helper method intentionally triggers CA1822 (can be made static)
     public int ComputeLength(string value) => value.Length;
+
+    public void Dispose() { }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeChangeImpactToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeChangeImpactToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class AnalyzeChangeImpactToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class AnalyzeChangeImpactToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class AnalyzeChangeImpactToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForInterfaceMethod_ReturnsImpact()
     {
-        var result = AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, "IGreeter.Greet");
+        var result = AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
 
         Assert.NotNull(result);
         Assert.True(result.DirectReferenceCount > 0 || result.CallerCount > 0);
@@ -32,7 +35,7 @@ public class AnalyzeChangeImpactToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForUnknownSymbol_ReturnsNull()
     {
-        var result = AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, "NonExistentClass.NoMethod");
+        var result = AnalyzeChangeImpactLogic.Execute(_loaded, _resolver, _metadata, "NonExistentClass.NoMethod");
 
         Assert.Null(result);
     }

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForGreeterGreet_ReturnsAnalysis()
     {
-        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, "Greeter.Greet");
+        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "Greeter.Greet");
 
         Assert.NotNull(result);
         Assert.NotEmpty(result.Signature);
@@ -32,7 +35,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForGreeterGreet_HasCallers()
     {
-        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, "Greeter.Greet");
+        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "Greeter.Greet");
 
         Assert.NotNull(result);
         // Greet is called from GreeterConsumer.SayHello
@@ -42,7 +45,7 @@ public class AnalyzeMethodToolTests : IAsyncLifetime
     [Fact]
     public void Execute_ForUnknownMethod_ReturnsNull()
     {
-        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, "NoSuchClass.NoSuchMethod");
+        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "NoSuchClass.NoSuchMethod");
 
         Assert.Null(result);
     }

--- a/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class FindCallersToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class FindCallersToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,8 +24,18 @@ public class FindCallersToolTests : IAsyncLifetime
     [Fact]
     public void FindCallers_ForMethod_ReturnsCallSites()
     {
-        var results = FindCallersLogic.Execute(_loaded, _resolver, "IGreeter.Greet");
+        var results = FindCallersLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
 
         Assert.Contains(results, r => r.Caller.Contains("GreeterConsumer", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindCallers_MetadataExtensionMethod_FindsSourceInvocations()
+    {
+        var results = FindCallersLogic.Execute(
+            _loaded, _resolver, _metadata,
+            "Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddScoped");
+
+        Assert.NotEmpty(results);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class FindImplementationsToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class FindImplementationsToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class FindImplementationsToolTests : IAsyncLifetime
     [Fact]
     public void FindImplementations_ForInterface_ReturnsImplementors()
     {
-        var results = FindImplementationsLogic.Execute(_loaded, _resolver, "IGreeter");
+        var results = FindImplementationsLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
 
         Assert.Contains(results, r => r.FullName.Contains("Greeter", StringComparison.Ordinal));
         Assert.True(results.Count >= 1);
@@ -30,8 +33,17 @@ public class FindImplementationsToolTests : IAsyncLifetime
     [Fact]
     public void FindImplementations_ForBaseClass_ReturnsDerived()
     {
-        var results = FindImplementationsLogic.Execute(_loaded, _resolver, "Greeter");
+        var results = FindImplementationsLogic.Execute(_loaded, _resolver, _metadata, "Greeter");
 
         Assert.Contains(results, r => r.FullName.Contains("FancyGreeter", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindImplementations_MetadataInterface_FindsSourceImplementors()
+    {
+        var results = FindImplementationsLogic.Execute(
+            _loaded, _resolver, _metadata, "System.IDisposable");
+
+        Assert.Contains(results, r => r.FullName.EndsWith("Greeter", StringComparison.Ordinal));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -7,6 +8,7 @@ public class FindReferencesToolTests : IAsyncLifetime
 {
     private LoadedSolution _loaded = null!;
     private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
 
     public async Task InitializeAsync()
     {
@@ -14,6 +16,7 @@ public class FindReferencesToolTests : IAsyncLifetime
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
         _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
         _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -21,7 +24,7 @@ public class FindReferencesToolTests : IAsyncLifetime
     [Fact]
     public void FindReferences_ForInterface_ReturnsUsages()
     {
-        var results = FindReferencesLogic.Execute(_loaded, _resolver, "IGreeter");
+        var results = FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.File.Contains("GreeterConsumer", StringComparison.Ordinal));
@@ -30,7 +33,7 @@ public class FindReferencesToolTests : IAsyncLifetime
     [Fact]
     public void FindReferences_ForMethod_ReturnsCallSites()
     {
-        var results = FindReferencesLogic.Execute(_loaded, _resolver, "IGreeter.Greet");
+        var results = FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.File.Contains("GreeterConsumer", StringComparison.Ordinal));
@@ -39,8 +42,19 @@ public class FindReferencesToolTests : IAsyncLifetime
     [Fact]
     public void FindReferences_UnknownSymbol_ReturnsEmpty()
     {
-        var results = FindReferencesLogic.Execute(_loaded, _resolver, "NonExistent");
+        var results = FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "NonExistent");
 
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void FindReferences_MetadataInterface_FindsSourceUsages()
+    {
+        var results = FindReferencesLogic.Execute(
+            _loaded, _resolver, _metadata,
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection");
+
+        Assert.NotEmpty(results);
+        Assert.All(results, r => Assert.True(!string.IsNullOrEmpty(r.File)));
     }
 }


### PR DESCRIPTION
## Summary

Closes #95 (Phase 2)

Extends `find_references`, `find_callers`, and `find_implementations` to accept fully-qualified metadata symbol names as input, returning source call/reference/implementation sites in your codebase.

- **`find_references("Microsoft.Extensions.DependencyInjection.IServiceCollection")`** → source locations where your code references an external type
- **`find_callers("...ServiceCollectionServiceExtensions.AddScoped")`** → source invocations of an external method (handles generic overloads)
- **`find_implementations("System.IDisposable")`** → source types that implement a metadata interface

## How it works

When `SymbolResolver.FindSymbols/FindMethods/FindNamedTypes` returns empty (no source match), the logic falls back to `MetadataSymbolResolver.Resolve(symbol)` and uses the resolved metadata `ISymbol` as the scan target. The downstream scan loops already use `SymbolEqualityComparer` which works uniformly for metadata symbols — no changes to the scan logic were needed.

**`find_callers` cross-compilation note:** Metadata symbols resolved from one compilation don't satisfy `SymbolEqualityComparer.Default.Equals` against symbol instances from another compilation. A name-based fallback (`FullyQualifiedContainingType.MethodName`) bridges this gap without false positives.

## Also updated

- `AnalyzeChangeImpactLogic` and `AnalyzeMethodLogic` (downstream callers of the extended tools) updated for new signatures
- SKILL.md: Phase 2 decision tree annotation resolved, metadata support table updated, worked examples added
- Benchmarks: all 5 affected benchmark call sites updated

## Test plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test` — 146 tests pass (143 pre-existing + 3 new)
- [ ] `find_references("Microsoft.Extensions.DependencyInjection.IServiceCollection")` returns source usages
- [ ] `find_callers("...AddScoped")` returns source invocations
- [ ] `find_implementations("System.IDisposable")` returns `Greeter` (and any other implementors)

## Related

- Phase 1 PR: #96 (merged)
- Design doc: [docs/plans/2026-04-24-closed-source-assemblies-design.md](docs/plans/2026-04-24-closed-source-assemblies-design.md)
- Phase 3 (peek_il): pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)