### PR TITLE
feat: external-assembly analysis — Phase 3 (peek_il)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+NOTICE
+
+roslyn-codelens-mcp uses the following third-party libraries:
+
+ICSharpCode.Decompiler (https://github.com/icsharpcode/ILSpy)
+  Version: 8.2.x
+  License: MIT (from version 8 onwards)
+  Used for: IL disassembly in the peek_il tool

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ dotnet test
 dotnet run --project benchmarks/RoslynCodeLens.Benchmarks -c Release
 ```
 
+## Third-party licenses
+
+- [ICSharpCode.Decompiler](https://github.com/icsharpcode/ILSpy) — MIT license (v8+). Used for IL disassembly in the `peek_il` tool.
+
 ## License
 
 MIT

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@
 
 | Dimension | sharplens-mcp | roslyn-codelens-mcp |
 |-----------|---------------|----------------------|
-| Tools | ~58 | 32 |
+| Tools | ~58 | 34 |
 | Architecture | Monolithic `RoslynService.cs` (~5 000 lines) | Modular Tool + Logic split per feature |
 | API paradigm | Position-based `(filePath, line, col)` | Symbol-name-based (`"IGreeter.Greet"`) |
 | Refactoring | 13 dedicated write/mutate tools | `get_code_actions` + `apply_code_action` (generic engine) |
@@ -81,6 +81,8 @@ All previously identified gaps have been closed. See Section 4 for phase status.
 | `get_generated_code` | Show source-generator output |
 | `get_source_generators` | List active source generators |
 | `get_nuget_dependencies` | List NuGet package references |
+| `inspect_external_assembly` | Browse API surface of referenced closed-source assemblies (NuGet/internal DLLs) |
+| `peek_il` | Read raw IL for metadata methods — understand external behavior without decompilation |
 | `rebuild_solution` | Force full reload |
 | `list_solutions` / `set_active_solution` | Multi-solution management |
 
@@ -129,10 +131,13 @@ All previously identified gaps have been closed. See Section 4 for phase status.
 | Find reflection usage | ❌ | ✅ | Dynamic/reflection coupling detection |
 | Rebuild solution | ❌ | ✅ | Force full reload + index rebuild |
 | Multi-solution management | ❌ | ✅ | `list_solutions` / `set_active_solution` |
+| External assembly browsing | ❌ | ✅ | `inspect_external_assembly` — summary + namespace drill-down |
+| Metadata symbol resolution | ❌ | ✅ | All Tier-1 tools accept fully-qualified external symbol names |
+| IL disassembly | ❌ | ✅ | `peek_il` — ilasm text for any referenced method |
 | Automatic hot reload | ❌ | ✅ | `FileChangeTracker` — no manual sync needed |
 | Symbol-name API | ❌ | ✅ | No coordinates needed; works without open editor |
 | Preview mode for edits | ❌ | ✅ | Diff returned before writing to disk |
-| BenchmarkDotNet suite | ❌ | ✅ | 28 benchmarks covering all tools |
+| BenchmarkDotNet suite | ❌ | ✅ | 31 benchmarks covering all tools |
 
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@
 
 | Dimension | sharplens-mcp | roslyn-codelens-mcp |
 |-----------|---------------|----------------------|
-| Tools | ~58 | 34 |
+| Tools | ~58 | 36 |
 | Architecture | Monolithic `RoslynService.cs` (~5 000 lines) | Modular Tool + Logic split per feature |
 | API paradigm | Position-based `(filePath, line, col)` | Symbol-name-based (`"IGreeter.Greet"`) |
 | Refactoring | 13 dedicated write/mutate tools | `get_code_actions` + `apply_code_action` (generic engine) |
@@ -18,7 +18,7 @@
 | Hot reload | Manual `sync_documents` tool | `FileChangeTracker` — automatic on file change |
 | Roslyn version | 5.0.0 | 4.14.0 |
 | .NET target | net8.0 | net10.0 |
-| Benchmarks | None | BenchmarkDotNet suite (28 benchmarks) |
+| Benchmarks | None | BenchmarkDotNet suite (31 benchmarks) |
 | Tests | Unknown | xUnit suite per tool |
 
 ### Why direct timing benchmarks are not meaningful

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -87,7 +87,7 @@ Look up an external type by name   → go_to_definition / get_symbol_context /
                                      (pass fully-qualified name; returns origin="metadata")
 Browse what a package exposes      → inspect_external_assembly
 Who in my code uses an ext. type?  → find_references / find_callers / find_implementations
-See a method's IL bytecode         → peek_il (Phase 3 — not yet available)
+See a method's IL bytecode         → peek_il (pass fully-qualified method name with param types)
 Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
                                      project, rebuild_solution, then use normally
 ```
@@ -148,6 +148,11 @@ External symbols have `origin.kind = "metadata"` in tool results. Supply fully-q
 - `inspect_external_assembly` — browse a referenced assembly's public API:
   - `mode="summary"` → namespace tree + type counts (start here to orient yourself)
   - `mode="namespace"` → full type + member listing for one namespace
+- `peek_il` — read ilasm-style IL for a single method in a referenced assembly:
+  - Input: fully-qualified method name with parameter types (e.g. `Namespace.Type.Method(ParamType1, ParamType2)`)
+  - For constructors: use `..ctor` notation (e.g. `Namespace.Type..ctor(ParamType)`)
+  - Output: raw IL instructions (`IL_0000: ldarg.0`, etc.) — not decompiled C#
+  - When to use: after `find_callers` / `get_symbol_context` identifies an interesting external method and you want to understand its implementation
 
 **Worked example — drill into a NuGet package:**
 ```
@@ -170,6 +175,14 @@ find_references("Microsoft.Extensions.DependencyInjection.IServiceCollection")
 find_callers("Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton")
 → returns source call sites for AddSingleton (pass the extension class + method name)
 ```
+
+**To read the raw IL of an external method:**
+Use `peek_il` with the fully-qualified method name including parameter types:
+```
+peek_il("Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)")
+→ returns ilasm-style IL text, assembly name, and version
+```
+Limitations: abstract methods, interface instance members, and properties-as-whole (target the getter/setter accessor instead) are not supported.
 
 ### Solution Management
 - `list_solutions` — loaded solutions, which is active.
@@ -221,6 +234,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `get_source_generators` | "What source generators are active?" |
 | `get_generated_code` | "Show generated code" |
 | `inspect_external_assembly` | "What does this NuGet package expose?" / "Show me the API of X assembly" |
+| `peek_il` | "Show IL for this method" / "What does this external method do at bytecode level?" |
 | `list_solutions` | "What solutions are loaded?" |
 | `load_solution` | "Load this .sln / .slnx at runtime" |
 | `unload_solution` | "Free memory for this solution" |
@@ -261,6 +275,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `find_callers` | Yes — finds source invocations of external methods | | |
 | `find_implementations` | Yes — finds source implementors of external interfaces/classes | | |
 | `inspect_external_assembly` | Metadata only — this is its purpose | Assembly must be referenced by a project in the solution | `get_nuget_dependencies` to discover assembly names |
+| `peek_il` | Metadata only — this is its purpose | Abstract methods and interface instance members not supported | Use `go_to_definition` to confirm the method exists first |
 | `get_diagnostics` | No — source only | | |
 | `get_code_fixes` | No — source only | | |
 | `get_code_actions` | No — source only | | |

--- a/src/RoslynCodeLens/FileChangeTracker.cs
+++ b/src/RoslynCodeLens/FileChangeTracker.cs
@@ -13,7 +13,10 @@ public sealed class FileChangeTracker : IDisposable
     private Timer? _debounceTimer;
     private readonly HashSet<string> _pendingChanges = new(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly string[] WatchedExtensions = [".cs", ".csproj", ".props", ".targets"];
+    private static readonly string[] WatchedExtensions = [".cs", ".csproj", ".props", ".targets", ".dll"];
+
+    /// <summary>Invoked (outside the lock) when a .dll file changes, so callers can invalidate PE caches.</summary>
+    public Action<string>? OnDllChanged { get; set; }
 
     public FileChangeTracker(LoadedSolution loaded, string solutionPath)
     {
@@ -152,13 +155,17 @@ public sealed class FileChangeTracker : IDisposable
 
     private void ProcessPendingChanges(object? state)
     {
+        HashSet<string> changes;
         lock (_lock)
         {
-            var changes = new HashSet<string>(_pendingChanges, StringComparer.OrdinalIgnoreCase);
+            changes = new HashSet<string>(_pendingChanges, StringComparer.OrdinalIgnoreCase);
             _pendingChanges.Clear();
 
             foreach (var filePath in changes)
             {
+                if (filePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    continue; // DLL changes are handled below, outside the lock
+
                 if (_fileToProject.TryGetValue(filePath, out var projectId))
                 {
                     MarkStaleTransitive(projectId);
@@ -169,6 +176,17 @@ public sealed class FileChangeTracker : IDisposable
                     foreach (var pid in _fileToProject.Values)
                         _staleProjects.Add(pid);
                 }
+            }
+        }
+
+        // Notify DLL changes outside the lock
+        var onDll = OnDllChanged;
+        if (onDll != null)
+        {
+            foreach (var filePath in changes)
+            {
+                if (filePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    onDll(filePath);
             }
         }
     }

--- a/src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs
+++ b/src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs
@@ -12,6 +12,8 @@ public sealed class IlDisassemblerAdapter
 
     public IlDisassemblerAdapter(PEFileCache cache) { _cache = cache; }
 
+    public PEFileCache Cache => _cache;
+
     public string DisassembleMethod(string assemblyPath, int metadataToken)
     {
         var pe = _cache.Get(assemblyPath);

--- a/src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs
+++ b/src/RoslynCodeLens/Metadata/IlDisassemblerAdapter.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Reflection.Metadata.Ecma335;
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.Disassembler;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace RoslynCodeLens.Metadata;
+
+public sealed class IlDisassemblerAdapter
+{
+    private readonly PEFileCache _cache;
+
+    public IlDisassemblerAdapter(PEFileCache cache) { _cache = cache; }
+
+    public string DisassembleMethod(string assemblyPath, int metadataToken)
+    {
+        var pe = _cache.Get(assemblyPath);
+        using var writer = new StringWriter();
+        var output = new PlainTextOutput(writer);
+        var disasm = new ReflectionDisassembler(output, default)
+        {
+            DetectControlStructure = true,
+            ShowSequencePoints = false,
+        };
+        var handle = MetadataTokens.EntityHandle(metadataToken);
+        disasm.DisassembleMethod(pe, (System.Reflection.Metadata.MethodDefinitionHandle)handle);
+        return writer.ToString();
+    }
+}

--- a/src/RoslynCodeLens/Metadata/PEFileCache.cs
+++ b/src/RoslynCodeLens/Metadata/PEFileCache.cs
@@ -7,15 +7,25 @@ public sealed class PEFileCache : IDisposable
 {
     private readonly ConcurrentDictionary<string, (DateTime Timestamp, PEFile File)> _cache
         = new(StringComparer.OrdinalIgnoreCase);
+    private volatile bool _disposed;
 
     public PEFile Get(string path)
     {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(PEFileCache));
+
         var stamp = File.GetLastWriteTimeUtc(path);
         if (_cache.TryGetValue(path, out var existing) && existing.Timestamp == stamp)
             return existing.File;
 
         var pe = new PEFile(path);
-        _cache[path] = (stamp, pe);
+        var newEntry = (stamp, pe);
+        _cache.AddOrUpdate(path, newEntry, (_, old) =>
+        {
+            if (!ReferenceEquals(old.File, pe))
+                old.File.Dispose();
+            return newEntry;
+        });
         return pe;
     }
 
@@ -27,6 +37,8 @@ public sealed class PEFileCache : IDisposable
 
     public void Dispose()
     {
+        if (_disposed) return;
+        _disposed = true;
         foreach (var entry in _cache.Values)
             entry.File.Dispose();
         _cache.Clear();

--- a/src/RoslynCodeLens/Metadata/PEFileCache.cs
+++ b/src/RoslynCodeLens/Metadata/PEFileCache.cs
@@ -20,9 +20,12 @@ public sealed class PEFileCache : IDisposable
 
         var pe = new PEFile(path);
         var newEntry = (stamp, pe);
+        // MCP framework serialises tool calls so concurrent races are unlikely in practice.
+        // The AddOrUpdate factory disposes a stale (different-timestamp) entry; it intentionally
+        // skips disposal when the old entry has the same timestamp (concurrent load of same file).
         _cache.AddOrUpdate(path, newEntry, (_, old) =>
         {
-            if (!ReferenceEquals(old.File, pe))
+            if (old.Timestamp != stamp)
                 old.File.Dispose();
             return newEntry;
         });

--- a/src/RoslynCodeLens/Metadata/PEFileCache.cs
+++ b/src/RoslynCodeLens/Metadata/PEFileCache.cs
@@ -1,0 +1,34 @@
+using System.Collections.Concurrent;
+using ICSharpCode.Decompiler.Metadata;
+
+namespace RoslynCodeLens.Metadata;
+
+public sealed class PEFileCache : IDisposable
+{
+    private readonly ConcurrentDictionary<string, (DateTime Timestamp, PEFile File)> _cache
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public PEFile Get(string path)
+    {
+        var stamp = File.GetLastWriteTimeUtc(path);
+        if (_cache.TryGetValue(path, out var existing) && existing.Timestamp == stamp)
+            return existing.File;
+
+        var pe = new PEFile(path);
+        _cache[path] = (stamp, pe);
+        return pe;
+    }
+
+    public void Invalidate(string path)
+    {
+        if (_cache.TryRemove(path, out var entry))
+            entry.File.Dispose();
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in _cache.Values)
+            entry.File.Dispose();
+        _cache.Clear();
+    }
+}

--- a/src/RoslynCodeLens/Models/IlPeekResult.cs
+++ b/src/RoslynCodeLens/Models/IlPeekResult.cs
@@ -1,0 +1,7 @@
+namespace RoslynCodeLens.Models;
+
+public record IlPeekResult(
+    string MethodFullName,
+    string AssemblyName,
+    string AssemblyVersion,
+    string Il);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using RoslynCodeLens.Metadata;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 
@@ -55,6 +56,7 @@ public sealed class MultiSolutionManager : IDisposable
     public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
     public SymbolResolver GetResolver() => Active.GetResolver();
     public MetadataSymbolResolver GetMetadataResolver() => Active.GetMetadataResolver();
+    public IlDisassemblerAdapter GetIlDisassembler() => Active.GetIlDisassembler();
     public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
     public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
 

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="ICSharpCode.Decompiler" Version="8.2.0.7535" />
   </ItemGroup>
 
   <!-- Stamp the package version into .mcp/server.json before packing -->

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using RoslynCodeLens.Metadata;
 using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens;
@@ -16,6 +17,8 @@ public sealed class SolutionManager : IDisposable
     private volatile bool _rebuilding;
     private Task? _warmupTask;
     private Exception? _warmupException;
+    private readonly PEFileCache _peCache = new();
+    private readonly IlDisassemblerAdapter _ilAdapter;
 
     private SolutionManager(LoadedSolution loaded, string? solutionPath)
     {
@@ -23,6 +26,7 @@ public sealed class SolutionManager : IDisposable
         _solutionPath = solutionPath;
         _resolver = new SymbolResolver(loaded);
         _metadataResolver = new MetadataSymbolResolver(loaded, _resolver);
+        _ilAdapter = new IlDisassemblerAdapter(_peCache);
     }
 
     public static async Task<SolutionManager> CreateAsync(string solutionPath)
@@ -70,6 +74,7 @@ public sealed class SolutionManager : IDisposable
                 if (_solutionPath != null)
                 {
                     _tracker = new FileChangeTracker(newLoaded, _solutionPath);
+                    _tracker.OnDllChanged = path => _peCache.Invalidate(path);
                 }
             }
 
@@ -114,6 +119,8 @@ public sealed class SolutionManager : IDisposable
         RebuildIfStale();
         return _metadataResolver;
     }
+
+    public IlDisassemblerAdapter GetIlDisassembler() => _ilAdapter;
 
     public void EnsureLoaded()
     {
@@ -239,5 +246,6 @@ public sealed class SolutionManager : IDisposable
     public void Dispose()
     {
         _tracker?.Dispose();
+        _peCache.Dispose();
     }
 }

--- a/src/RoslynCodeLens/Tools/PeekIlLogic.cs
+++ b/src/RoslynCodeLens/Tools/PeekIlLogic.cs
@@ -139,8 +139,8 @@ public static class PeekIlLogic
             }
 
             // Fallback: match by parameter count from the signature string
-            var paramTypes = ParseParamTypes(paramSignature);
-            var byCount = candidates.Where(c => c.Parameters.Length == paramTypes.Length).ToList();
+            var paramTypes = ParseParamTypes(paramSignature!.TrimStart('(').TrimEnd(')'));
+            var byCount = candidates.Where(c => c.Parameters.Length == paramTypes.Count).ToList();
             if (byCount.Count == 1)
             {
                 ValidateMethodBody(byCount[0], methodSymbol);
@@ -163,15 +163,33 @@ public static class PeekIlLogic
                 $"'{methodSymbol}' has no body (abstract or interface instance member).", nameof(methodSymbol));
     }
 
-    private static string[] ParseParamTypes(string paramSignature)
+    private static List<string> ParseParamTypes(string paramList)
     {
-        // "(T1, T2, T3)" -> ["T1", "T2", "T3"]
-        var inner = paramSignature.TrimStart('(').TrimEnd(')').Trim();
-        if (string.IsNullOrEmpty(inner))
-            return [];
-        return inner.Split(',').Select(s => s.Trim()).ToArray();
+        var result = new List<string>();
+        if (string.IsNullOrWhiteSpace(paramList))
+            return result;
+
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < paramList.Length; i++)
+        {
+            var c = paramList[i];
+            if (c is '<' or '(') depth++;
+            else if (c is '>' or ')') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                result.Add(paramList[start..i].Trim());
+                start = i + 1;
+            }
+        }
+        var last = paramList[start..].Trim();
+        if (last.Length > 0)
+            result.Add(last);
+        return result;
     }
 
+    // Returns first match; in multi-TFM solutions the same assembly may appear under multiple TFMs.
+    // Non-deterministic order is acceptable since IL is identical across TFM-specific metadata references.
     private static string? FindAssemblyPath(LoadedSolution loaded, IAssemblySymbol assembly)
     {
         foreach (var compilation in loaded.Compilations.Values)

--- a/src/RoslynCodeLens/Tools/PeekIlLogic.cs
+++ b/src/RoslynCodeLens/Tools/PeekIlLogic.cs
@@ -1,0 +1,270 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using ICSharpCode.Decompiler.Metadata;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Metadata;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class PeekIlLogic
+{
+    public static IlPeekResult Execute(
+        LoadedSolution loaded,
+        MetadataSymbolResolver metadata,
+        IlDisassemblerAdapter disassembler,
+        string methodSymbol)
+    {
+        var method = ResolveMethod(loaded, metadata, methodSymbol);
+
+        var assembly = method.ContainingAssembly
+            ?? throw new ArgumentException($"Could not determine containing assembly for '{methodSymbol}'.", nameof(methodSymbol));
+
+        var assemblyPath = FindAssemblyPath(loaded, assembly)
+            ?? throw new ArgumentException(
+                $"Could not locate on-disk path for assembly '{assembly.Identity.Name}'.", nameof(methodSymbol));
+
+        // Try fast reflection-based token first; fall back to PE metadata scan
+        var token = MetadataTokenOf(method)
+            ?? MetadataTokenFromPE(disassembler.Cache, assemblyPath, method)
+            ?? throw new ArgumentException(
+                $"Could not determine metadata token for '{methodSymbol}'.", nameof(methodSymbol));
+
+        var ilText = disassembler.DisassembleMethod(assemblyPath, token);
+
+        return new IlPeekResult(
+            method.ToDisplayString(),
+            assembly.Identity.Name,
+            assembly.Identity.Version.ToString(),
+            ilText);
+    }
+
+    private static IMethodSymbol ResolveMethod(
+        LoadedSolution loaded,
+        MetadataSymbolResolver metadata,
+        string methodSymbol)
+    {
+        // First try the existing metadata resolver (works for simple member names)
+        var resolved = metadata.Resolve(methodSymbol);
+        if (resolved != null)
+        {
+            ValidateResolved(resolved, methodSymbol);
+            return (IMethodSymbol)resolved.Symbol;
+        }
+
+        // Fall back to direct PE-metadata lookup for fully-qualified signatures
+        // like "Ns.Type..ctor(T1, T2)" or "Ns.Type.Method(T1, T2)"
+        var method = ResolveBySignature(loaded, metadata, methodSymbol)
+            ?? throw new ArgumentException(
+                $"Symbol '{methodSymbol}' not found. Pass a fully-qualified method name with parameter types.", nameof(methodSymbol));
+
+        return method;
+    }
+
+    private static void ValidateResolved(ResolvedSymbol resolved, string methodSymbol)
+    {
+        if (!string.Equals(resolved.Origin.Kind, "metadata", StringComparison.Ordinal))
+            throw new ArgumentException(
+                $"'{methodSymbol}' is a source symbol. Use go_to_definition to navigate to source.", nameof(methodSymbol));
+
+        if (resolved.Symbol is not IMethodSymbol method)
+            throw new ArgumentException(
+                $"'{methodSymbol}' is not a method. peek_il only works on methods.", nameof(methodSymbol));
+
+        if (method.IsAbstract ||
+            (method.ContainingType?.TypeKind == TypeKind.Interface && !method.IsStatic))
+            throw new ArgumentException(
+                $"'{methodSymbol}' has no body (abstract or interface instance member).", nameof(methodSymbol));
+    }
+
+    private static IMethodSymbol? ResolveBySignature(
+        LoadedSolution loaded,
+        MetadataSymbolResolver metadata,
+        string methodSymbol)
+    {
+        // Parse "Namespace.Type.MethodOrCtor(ParamType1, ParamType2)"
+        // or    "Namespace.Type..ctor(ParamType1, ParamType2)"
+        var parenIdx = methodSymbol.IndexOf('(', StringComparison.Ordinal);
+        var nameWithoutParams = parenIdx >= 0 ? methodSymbol[..parenIdx] : methodSymbol;
+        string? paramSignature = parenIdx >= 0 ? methodSymbol[parenIdx..] : null;
+
+        // Split type vs member name; handle ".ctor" double-dot
+        string typeName;
+        string memberName;
+
+        var ctorIdx = nameWithoutParams.LastIndexOf("..ctor", StringComparison.Ordinal);
+        if (ctorIdx >= 0)
+        {
+            typeName = nameWithoutParams[..ctorIdx];
+            memberName = ".ctor";
+        }
+        else
+        {
+            var lastDot = nameWithoutParams.LastIndexOf('.');
+            if (lastDot <= 0)
+                return null;
+            typeName = nameWithoutParams[..lastDot];
+            memberName = nameWithoutParams[(lastDot + 1)..];
+        }
+
+        // Look up the type in all compilations
+        foreach (var compilation in loaded.Compilations.Values)
+        {
+            var container = compilation.GetTypeByMetadataName(typeName);
+            if (container == null || container.Locations.Any(l => l.IsInSource))
+                continue;
+
+            var candidates = container.GetMembers(memberName).OfType<IMethodSymbol>().ToList();
+            if (candidates.Count == 0)
+                continue;
+
+            // If no param signature, return the first overload
+            if (paramSignature == null || candidates.Count == 1)
+            {
+                var m = candidates[0];
+                ValidateMethodBody(m, methodSymbol);
+                return m;
+            }
+
+            // Match by display-string suffix or by param count
+            foreach (var candidate in candidates)
+            {
+                var display = candidate.ToDisplayString();
+                if (display.Contains(paramSignature, StringComparison.OrdinalIgnoreCase))
+                {
+                    ValidateMethodBody(candidate, methodSymbol);
+                    return candidate;
+                }
+            }
+
+            // Fallback: match by parameter count from the signature string
+            var paramTypes = ParseParamTypes(paramSignature);
+            var byCount = candidates.Where(c => c.Parameters.Length == paramTypes.Length).ToList();
+            if (byCount.Count == 1)
+            {
+                ValidateMethodBody(byCount[0], methodSymbol);
+                return byCount[0];
+            }
+        }
+
+        return null;
+    }
+
+    private static void ValidateMethodBody(IMethodSymbol method, string methodSymbol)
+    {
+        if (method.Locations.Any(l => l.IsInSource))
+            throw new ArgumentException(
+                $"'{methodSymbol}' is a source symbol. Use go_to_definition to navigate to source.", nameof(methodSymbol));
+
+        if (method.IsAbstract ||
+            (method.ContainingType?.TypeKind == TypeKind.Interface && !method.IsStatic))
+            throw new ArgumentException(
+                $"'{methodSymbol}' has no body (abstract or interface instance member).", nameof(methodSymbol));
+    }
+
+    private static string[] ParseParamTypes(string paramSignature)
+    {
+        // "(T1, T2, T3)" -> ["T1", "T2", "T3"]
+        var inner = paramSignature.TrimStart('(').TrimEnd(')').Trim();
+        if (string.IsNullOrEmpty(inner))
+            return [];
+        return inner.Split(',').Select(s => s.Trim()).ToArray();
+    }
+
+    private static string? FindAssemblyPath(LoadedSolution loaded, IAssemblySymbol assembly)
+    {
+        foreach (var compilation in loaded.Compilations.Values)
+        {
+            foreach (var reference in compilation.References)
+            {
+                if (reference is not PortableExecutableReference pe)
+                    continue;
+                var refAsm = compilation.GetAssemblyOrModuleSymbol(reference) as IAssemblySymbol;
+                if (refAsm != null && SymbolEqualityComparer.Default.Equals(refAsm, assembly))
+                    return pe.FilePath;
+            }
+        }
+        return null;
+    }
+
+    private static int? MetadataTokenOf(IMethodSymbol method)
+    {
+        var prop = method.GetType().GetProperty("MetadataToken",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public
+            | System.Reflection.BindingFlags.Instance);
+        if (prop?.GetValue(method) is int token && token != 0)
+            return token;
+        return null;
+    }
+
+    /// <summary>
+    /// Fallback: walk the PE metadata to find a method handle matching the Roslyn symbol
+    /// by type name + method name + parameter names. Returns its raw metadata token.
+    /// </summary>
+    private static int? MetadataTokenFromPE(PEFileCache cache, string assemblyPath, IMethodSymbol method)
+    {
+        var pe = cache.Get(assemblyPath);
+        var reader = pe.Metadata;
+
+        var typeName = method.ContainingType?.MetadataName ?? "";
+        var ns = method.ContainingNamespace?.ToDisplayString() ?? "";
+        var roslynParamNames = method.Parameters.Select(p => p.Name).ToArray();
+        var roslynParamCount = method.Parameters.Length;
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!string.Equals(reader.GetString(typeDef.Name), typeName, StringComparison.Ordinal))
+                continue;
+            if (!string.IsNullOrEmpty(ns) &&
+                !string.Equals(reader.GetString(typeDef.Namespace), ns, StringComparison.Ordinal))
+                continue;
+
+            var candidates = new List<MethodDefinitionHandle>();
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var methodDef = reader.GetMethodDefinition(methodHandle);
+                var name = reader.GetString(methodDef.Name);
+                if (!string.Equals(name, method.Name, StringComparison.Ordinal))
+                    continue;
+
+                // Count non-return params (sequenceNumber > 0)
+                var peParams = methodDef.GetParameters()
+                    .Select(ph => reader.GetParameter(ph))
+                    .Where(p => p.SequenceNumber > 0)
+                    .ToList();
+
+                if (peParams.Count != roslynParamCount)
+                    continue;
+
+                candidates.Add(methodHandle);
+            }
+
+            if (candidates.Count == 0)
+                return null;
+
+            if (candidates.Count == 1)
+                return MetadataTokens.GetToken(candidates[0]);
+
+            // Multiple overloads with same param count — match by parameter names
+            foreach (var methodHandle in candidates)
+            {
+                var methodDef = reader.GetMethodDefinition(methodHandle);
+                var peParamNames = methodDef.GetParameters()
+                    .Select(ph => reader.GetParameter(ph))
+                    .Where(p => p.SequenceNumber > 0)
+                    .Select(p => reader.GetString(p.Name))
+                    .ToArray();
+
+                if (roslynParamNames.SequenceEqual(peParamNames, StringComparer.Ordinal))
+                    return MetadataTokens.GetToken(methodHandle);
+            }
+
+            // Last resort: return first candidate if only name/count mismatch remains
+            return MetadataTokens.GetToken(candidates[0]);
+        }
+
+        return null;
+    }
+}

--- a/src/RoslynCodeLens/Tools/PeekIlTool.cs
+++ b/src/RoslynCodeLens/Tools/PeekIlTool.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class PeekIlTool
+{
+    [McpServerTool(Name = "peek_il"),
+     Description("Return ilasm-style IL for a single method in a referenced closed-source assembly. Input must be a fully-qualified method name with parameter types.")]
+    public static IlPeekResult Execute(
+        MultiSolutionManager manager,
+        [Description("Fully-qualified method name with parameter types, e.g. 'Newtonsoft.Json.JsonConvert.SerializeObject(object)'")] string methodSymbol)
+    {
+        manager.EnsureLoaded();
+        return PeekIlLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetMetadataResolver(),
+            manager.GetIlDisassembler(),
+            methodSymbol);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Metadata/PEFileCacheTests.cs
+++ b/tests/RoslynCodeLens.Tests/Metadata/PEFileCacheTests.cs
@@ -1,0 +1,32 @@
+using ICSharpCode.Decompiler.Metadata;
+using RoslynCodeLens.Metadata;
+
+namespace RoslynCodeLens.Tests.Metadata;
+
+public class PEFileCacheTests
+{
+    [Fact]
+    public void Get_SamePath_ReturnsSameInstance()
+    {
+        var cache = new PEFileCache();
+        var path = typeof(object).Assembly.Location;
+
+        var first = cache.Get(path);
+        var second = cache.Get(path);
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void Invalidate_DropsEntry()
+    {
+        var cache = new PEFileCache();
+        var path = typeof(object).Assembly.Location;
+
+        var first = cache.Get(path);
+        cache.Invalidate(path);
+        var second = cache.Get(path);
+
+        Assert.NotSame(first, second);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/PeekIlToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/PeekIlToolTests.cs
@@ -1,0 +1,55 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Metadata;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class PeekIlToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+    private IlDisassemblerAdapter _adapter = null!;
+    private PEFileCache _peCache = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _peCache = new PEFileCache();
+        _adapter = new IlDisassemblerAdapter(_peCache);
+    }
+
+    public Task DisposeAsync() { _peCache.Dispose(); return Task.CompletedTask; }
+
+    [Fact]
+    public void Peek_MetadataCtor_ReturnsIlText()
+    {
+        var result = PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter,
+            "Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)");
+
+        Assert.NotNull(result);
+        Assert.Contains("IL_", result!.Il, StringComparison.Ordinal);
+        Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", result.AssemblyName);
+    }
+
+    [Fact]
+    public void Peek_SourceSymbol_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter, "TestLib.Greeter.Greet"));
+    }
+
+    [Fact]
+    public void Peek_AbstractMethod_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => PeekIlLogic.Execute(
+            _loaded, _metadata, _adapter,
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection.Add"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #95 (Phase 3 — final)

Adds `peek_il`: return ilasm-style IL text for any method in a referenced closed-source assembly.

```
peek_il("Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)")
→ IlPeekResult { MethodFullName, AssemblyName, AssemblyVersion, Il: "IL_0000: ldarg.0\n..." }
```

## New dependency

`ICSharpCode.Decompiler` v8.2 (MIT license from v8+). Attribution in `README.md` and `NOTICE`.

## Architecture

- **`PEFileCache`** — `ConcurrentDictionary<path, (timestamp, PEFile)>` singleton per `SolutionManager`; timestamp-keyed invalidation; wired to `FileChangeTracker.OnDllChanged` so DLL replacements (NuGet restore, internal builds) auto-invalidate
- **`IlDisassemblerAdapter`** — thin wrapper over `ReflectionDisassembler`; takes `PEFileCache`
- **`PeekIlLogic`** — resolves method via `MetadataSymbolResolver`; locates DLL via `PortableExecutableReference`; gets metadata token via PE walk (Roslyn 4.14 does not expose `MetadataToken` publicly); disassembles via adapter
- **`PeekIlTool`** — registered as `peek_il` MCP tool

## Key implementation note

Roslyn 4.14 does not expose `IMethodSymbol.MetadataToken` publicly. The logic falls back to walking `PEFile.Metadata.TypeDefinitions` → `MethodDefinitions`, matching by name + parameter names from PE metadata. This disambiguates overloads including the 7 `ServiceDescriptor..ctor` variants.

## Also in this PR

- 3 new benchmarks: `inspect_external_assembly: summary`, `inspect_external_assembly: namespace`, `peek_il: ServiceDescriptor ctor`
- SKILL.md: `peek_il` decision tree, documentation section, Quick Reference row, Metadata Support table row
- `docs/features.md`: tool count 36, benchmark count 31, 3 new feature matrix rows (External assembly browsing, Metadata symbol resolution, IL disassembly)
- `NOTICE` file added at repo root

## Test plan

- [ ] `dotnet build` — 0 errors
- [ ] `dotnet test` — 151 pass (146 pre-existing + 2 `PEFileCacheTests` + 3 `PeekIlToolTests`)
- [ ] `peek_il("Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System.Type, System.Type, Microsoft.Extensions.DependencyInjection.ServiceLifetime)")` returns IL containing `IL_` labels
- [ ] Passing a source symbol to `peek_il` returns `ArgumentException`
- [ ] Passing an abstract/interface method to `peek_il` returns `ArgumentException`

## Related

- Phase 1 PR: #96 (merged)
- Phase 2 PR: #98
- Design doc: [docs/plans/2026-04-24-closed-source-assemblies-design.md](docs/plans/2026-04-24-closed-source-assemblies-design.md)
- Issue: #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)