### PR TITLE
fix: enable release-please manifest mode + sync version files to 1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "roslyn-codelens-mcp",
   "description": "Roslyn-based .NET code graph intelligence for Claude Code",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "owner": {
     "name": "Marcel Roozekrans"
   },
@@ -9,7 +9,7 @@
     {
       "name": "roslyn-codelens",
       "description": "Roslyn-based code graph intelligence for .NET codebases. Provides semantic understanding of type hierarchies, call sites, DI registrations, and reflection usage.",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "author": {
         "name": "Marcel Roozekrans"
       },

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,6 @@ jobs:
         uses: googleapis/release-please-action@v5
         id: release
         with:
-          release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
     "source": "github"
   },
-  "version": "1.1.6",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
-      "version": "1.1.6",
+      "version": "1.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Drop the inline `release-type: simple` from `.github/workflows/release-please.yml`. With `release-type` set in the workflow `with:` block, `release-please-action@v5` runs in **non-manifest mode** and silently ignores `release-please-config.json` (per the [v3→v4 upgrade notes](https://github.com/googleapis/release-please-action#upgrading-from-v3-to-v4)). That's why every release PR (1.1.7 and 1.2.0) only touched `.release-please-manifest.json` + `CHANGELOG.md` and never bumped `server.json` / `marketplace.json` even though `extra-files` was configured for them.
- Bring `server.json` and `.claude-plugin/marketplace.json` to `1.2.0` to clear the drift left by the broken config. After this, the next release-please PR will have a clean `1.2.0`-baseline to bump from.

## Why the MCP publish failed

The `Publish to MCP Registry` job for the 1.2.0 release tag checked out `main`, read `server.json` (still at `1.1.6`), and tried to push 1.1.6 to the registry → rejected as duplicate.

## Recovery

After this PR is merged:

1. Re-run the failed `publish-mcp-registry` job: `gh run rerun 24925512400 --failed` — `server.json` will now show 1.2.0 and the publish will succeed.
2. Future release PRs will bump all four version paths automatically (no manual sync needed).

## Test plan

- [ ] Merge → next release-please PR shows version bumps in `server.json` and `marketplace.json`
- [ ] Re-run failed `publish-mcp-registry` job → 1.2.0 lands in the MCP registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)