### PR TITLE
feat: add find_async_violations MCP tool (sync-over-async, async void, missing await, fire-and-forget)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 24 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 25 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **find_circular_dependencies** — Detect cycles in project or namespace dependency graphs
 - **get_complexity_metrics** — Cyclomatic complexity analysis per method
 - **find_naming_violations** — Check .NET naming convention compliance
+- **find_async_violations** — Sync-over-async, `async void` misuse, missing awaits, fire-and-forget tasks; per-violation report with severity
 - **find_large_classes** — Find oversized types by member or line count
 - **find_unused_symbols** — Dead code detection via reference analysis
 - **get_source_generators** — List source generators and their output per project

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -218,6 +218,12 @@ public class CodeGraphBenchmarks
         return FindUncoveredSymbolsLogic.Execute(_loaded, _resolver);
     }
 
+    [Benchmark(Description = "find_async_violations: whole solution")]
+    public object FindAsyncViolations()
+    {
+        return FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+    }
+
     [Benchmark(Description = "get_source_generators: all")]
     public object GetSourceGenerators()
     {

--- a/docs/plans/2026-04-28-find-async-violations-design.md
+++ b/docs/plans/2026-04-28-find-async-violations-design.md
@@ -1,0 +1,239 @@
+# `find_async_violations` — Design
+
+**Date:** 2026-04-28
+**Backlog source:** `docs/BACKLOG.md` § 3 (async & concurrency tools)
+
+## Goal
+
+Detect six classes of async/await misuse across all production projects in the active solution. Surface each violation with a stable pattern enum, severity, location, containing method, and a short snippet — enough for an agent to triage and fix.
+
+This is a static-analysis tool. No runtime instrumentation, no fix suggestions. Reports what's wrong; the agent decides what to do.
+
+## Why
+
+Async sins cause real production deadlocks (`.Result`, `.Wait()` on `SynchronizationContext`-using stacks), unobserved exceptions (`async void` outside event handlers), and silent test failures (missing `await` in async methods). These are universally recognized anti-patterns. No other code-graph MCP tool surfaces them today, and the .NET analyzers that catch some of them aren't on by default in every project.
+
+---
+
+## Tool surface
+
+```
+find_async_violations()
+```
+
+No parameters in v1. Whole-solution scope, hardcoded scope (skip test projects, skip generated code).
+
+### Output
+
+```jsonc
+{
+  "summary": {
+    "totalViolations": 23,
+    "byPattern": {
+      "SyncOverAsyncResult": 5,
+      "SyncOverAsyncWait": 2,
+      "SyncOverAsyncGetAwaiterGetResult": 1,
+      "AsyncVoid": 2,
+      "MissingAwait": 3,
+      "FireAndForget": 10
+    },
+    "bySeverity": { "error": 10, "warning": 13 }
+  },
+  "violations": [
+    {
+      "pattern": "SyncOverAsyncResult",
+      "severity": "error",
+      "filePath": "OrderService.cs",
+      "line": 42,
+      "containingMethod": "OrderService.Submit",
+      "project": "MyApp.Core",
+      "snippet": "result.Result"
+    },
+    ...
+  ]
+}
+```
+
+Sort: `severity` DESC (errors first), then `filePath` ASC, then `line` ASC.
+
+`snippet` is the violation expression as source text, capped at ~80 chars.
+
+---
+
+## Six patterns
+
+### 1. `SyncOverAsyncResult` — severity `error`
+
+**Pattern:** `someTask.Result` access — synchronous wait that risks deadlock.
+
+**Detection:** walk every `MemberAccessExpressionSyntax` where `Name.Identifier.Text == "Result"`. Use `SemanticModel.GetTypeInfo(expression.Expression)` to check the receiver type. If `Type` is `System.Threading.Tasks.Task` or `System.Threading.Tasks.Task<T>` (constructed-from), flag.
+
+### 2. `SyncOverAsyncWait` — severity `error`
+
+**Pattern:** `someTask.Wait()`, `Task.WaitAll(...)`, `Task.WaitAny(...)`.
+
+**Detection:** walk every `InvocationExpressionSyntax`. Resolve to `IMethodSymbol`. If method's containing type is `Task` (instance `Wait`) or static method `Task.WaitAll` / `Task.WaitAny`, flag.
+
+### 3. `SyncOverAsyncGetAwaiterGetResult` — severity `error`
+
+**Pattern:** `someTask.GetAwaiter().GetResult()` — common idiom to dodge async, equally bad.
+
+**Detection:** walk every `InvocationExpressionSyntax` with `MemberAccessExpressionSyntax` named `.GetResult()`. Resolve. If receiver type is `TaskAwaiter`, `TaskAwaiter<T>`, `ConfiguredTaskAwaitable.ConfiguredTaskAwaiter`, or `ConfiguredTaskAwaitable<T>.ConfiguredTaskAwaiter`, flag.
+
+### 4. `AsyncVoid` — severity `error`
+
+**Pattern:** `async void` method declaration outside the event-handler exemption.
+
+**Detection:** walk every `MethodDeclarationSyntax`. If `Modifiers` contains `async` AND `ReturnType` is `void` AND method does **not** match the event-handler signature, flag.
+
+**Event-handler exemption:** signature is `(object sender, T e)` where `T` is `EventArgs` or any type derived from it. Also accept `(object? sender, T? e)` (nullable variants). Two-parameter methods that don't match this exact shape are flagged.
+
+### 5. `MissingAwait` — severity `warning`
+
+**Pattern:** inside an `async Task` / `async Task<T>` method body, a `Task`-returning call used as a bare expression statement (result implicitly discarded). The author probably meant to await it.
+
+**Detection:** for each method with `async` modifier and a Task-shaped return type, walk its body's `ExpressionStatementSyntax` nodes. If the expression is an `InvocationExpressionSyntax` whose return type (per `SemanticModel`) is `Task` / `Task<T>` / `ValueTask` / `ValueTask<T>`, flag.
+
+(This is the high-noise pattern but generally indicative of real bugs in async methods. Sync methods that intentionally return `Task` are excluded from the walk.)
+
+### 6. `FireAndForget` — severity `warning`
+
+**Pattern:** in a **non-async** method body, a `Task`-returning call used as a bare expression statement, NOT prefixed by `_ = ` or assigned to a variable.
+
+**Detection:** same as `MissingAwait`, but only when the containing method is **not** `async`. Bare `_ = SomeAsyncMethod()` or `var t = SomeAsyncMethod()` are explicit acknowledgments and skipped.
+
+---
+
+## Algorithm shape
+
+Single pass over non-test compilations. Per syntax tree:
+
+1. For each `MethodDeclarationSyntax` in the tree:
+   - Check the method itself for `AsyncVoid` (rule 4).
+   - Walk its body for invocations / member accesses to detect rules 1–3, 5, 6.
+2. Record violations with their location, pattern, severity, containing method, project.
+
+Roslyn's `SemanticModel.GetTypeInfo` and `SemanticModel.GetSymbolInfo` are the workhorses — both run in microseconds and are cached internally.
+
+Performance shape: roughly equivalent to `find_callers` (linear in syntax-tree size, semantic-model lookups per node of interest).
+
+---
+
+## Hardcoded constants
+
+| Constant | Value | Why hardcoded |
+|----------|------:|---------------|
+| Severity per pattern | error / warning per the table above | Clear-cut categorization; no team disagreement on these. |
+| Snippet length | ~80 chars | Enough context, doesn't bloat output. |
+| Skip test projects | true | Tests legitimately use various async patterns; reporting them produces noise. |
+| Skip compiler-generated | true | `IsImplicitlyDeclared`. |
+| Skip auto-generated source | true | `<auto-generated>` header detection. |
+
+No tool parameters, no env vars, no config file. Same justification as the rest of this codebase.
+
+---
+
+## Reuse
+
+| Component | Source | Action |
+|-----------|--------|--------|
+| `TestProjectDetector` | shipped earlier | Reuse for the production-only filter. |
+| `LoadedSolution` / `SymbolResolver` | core | Reuse the existing `(projectId, compilation)` iteration pattern. |
+| Auto-generated source detection | none yet | Small helper: read first ~5 lines of source tree, check for `<auto-generated>` marker. |
+
+---
+
+## Edge cases
+
+| Case | Behaviour |
+|------|-----------|
+| `await someTask` | Not flagged (not a violation). |
+| `_ = someAsyncMethod()` | Not flagged (explicit fire-and-forget acknowledgment). |
+| `var t = someAsyncMethod()` (assigned but never awaited) | Not flagged at the call site — the variable is "tracked", and we don't do flow analysis. |
+| `return someAsyncMethod()` in a non-async `Task`-returning method | Not flagged (perfectly valid pattern — the caller awaits). |
+| `Task.Run(() => task.Result)` | The inner `.Result` IS flagged. Even on a thread-pool thread, `.Result` blocks; not idiomatic. |
+| Conversion operators / properties / indexers / accessors | Walked the same way as methods (Roslyn's `MethodDeclarationSyntax` covers methods only; we should also walk `AccessorDeclarationSyntax` and arrow-bodied members). v1: only `MethodDeclarationSyntax`. Property / accessor support deferred. |
+| Local functions | Walked as part of containing method's body. Their violations attribute to the containing method (acceptable for v1; agents can drill in if needed). |
+| Lambdas (`Action`, `Func<Task>`, etc.) | Same — walked as part of containing method. |
+| Async methods called from `Main` | Reported normally (Main is just another method). If the project's `Main` legitimately uses `.Result` or `.Wait()`, the agent suppresses by ignoring. |
+| Top-level statements | The compiler synthesises a `<Main>$` method; its violations are reported. Containing method shows as `Program.<Main>$` or similar — fine. |
+
+---
+
+## Tests
+
+### Fixture additions
+
+Add a new project `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/`:
+
+- `AsyncFixture.csproj` — minimal SDK-style project, no test framework reference (so it counts as a production project for `TestProjectDetector`).
+- `Violations.cs` — one method per positive case for each of the 6 patterns. Plus negative cases:
+  - A properly-awaited task call (negative for MissingAwait).
+  - An `async void` event handler (negative for AsyncVoid — must NOT flag).
+  - A `_ = SomeAsync()` discard (negative for FireAndForget).
+  - A `var t = SomeAsync()` variable assignment (negative for FireAndForget).
+  - A non-async `Task`-returning method that does `return SomeAsync();` (negative for FireAndForget — perfectly valid forwarding pattern).
+
+Update `TestSolution.slnx` to include the new project.
+
+### Test cases
+
+| File | What it covers |
+|------|---------------|
+| `Tools/FindAsyncViolationsToolTests.cs` | One [Fact] per pattern asserting exactly-one positive hit. Negative-case assertions: properly-awaited tasks not flagged, event-handler async void not flagged, discards/assignments not flagged. Summary count tests: byPattern correct, bySeverity correct, totalViolations matches list length. Sort-order test: errors before warnings, then file ASC, then line ASC. Test-project exclusion test: an `async void DisposeAsync()` in any of the test fixtures is NOT reported (test projects skipped). |
+
+### Benchmark
+
+Add to `CodeGraphBenchmarks.cs`:
+
+```csharp
+[Benchmark(Description = "find_async_violations: whole solution")]
+public object FindAsyncViolations()
+    => FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+```
+
+---
+
+## SKILL.md / README updates
+
+**SKILL.md:** add a routing row in Red Flags:
+
+> | "Are there async bugs?" / "Find sync-over-async" / "Are we using `.Result` anywhere?" | `find_async_violations` |
+
+Add to "Diagnostics" or a new "Code-quality" section:
+
+> - `find_async_violations` — Detects sync-over-async (`.Result`/`.Wait()`/`GetAwaiter().GetResult()`), `async void` outside event handlers, missing awaits in async methods, and fire-and-forget tasks. Reports per-violation with severity (error/warning).
+
+**README:** add to Features list near `find_naming_violations`:
+
+> - **find_async_violations** — Sync-over-async, `async void` misuse, missing awaits, fire-and-forget tasks; per-violation report with severity.
+
+Tool count: 24 → 25 in `CLAUDE.md`.
+
+---
+
+## Out of scope (explicit non-goals)
+
+- No `ConfigureAwait(false)` recommendations — modern .NET (ASP.NET Core, console apps, libraries targeting net6+) doesn't always benefit; reporting it would produce noise on contemporary codebases.
+- No `Task.Run` on CPU-bound heuristics — distinguishing CPU-bound from I/O-bound code statically is unreliable.
+- No custom-awaiter pattern detection (`AsyncMethodBuilder`, custom `INotifyCompletion`) — vanishingly rare in user code.
+- No suppression mechanism (`[SuppressMessage]`, comment-based) — every existing tool in this repo reports everything; agents post-filter the JSON.
+- No project / namespace filter — whole-solution; add only on demand.
+- No fix suggestions — analysis only.
+- No accessor / property / indexer body analysis — only `MethodDeclarationSyntax` in v1.
+- No flow-sensitive analysis for "task assigned but never awaited" — once a Task is in a variable, we trust the user.
+
+---
+
+## Decisions log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Pattern scope | Six (sync-over-async × 3, async void, missing await, fire-and-forget) | Drops controversial ConfigureAwait + heuristic Task.Run + rare custom awaiters; keeps every reported pattern unambiguously useful |
+| Output shape | Summary + flat violations list | Matches `find_uncovered_symbols` precedent; summary lets agents triage in one glance |
+| Severity split | Error for sync-over-async + AsyncVoid; warning for MissingAwait + FireAndForget | Errors are always-bugs; warnings are usually-bugs with documented intentional uses |
+| Suppression | None in v1 | Consistent with existing tools; agents post-filter |
+| Scope filter | None in v1 | Whole-solution; add on demand |
+| Tool parameters | None | Project has zero per-tool tunables today; YAGNI |
+| Test project handling | Skip via `TestProjectDetector` | Tests legitimately use async patterns; reporting them = noise |
+| Accessor / property bodies | Skip in v1 | Most async sins live in regular methods; expand later if demand emerges |

--- a/docs/plans/2026-04-28-find-async-violations.md
+++ b/docs/plans/2026-04-28-find-async-violations.md
@@ -1,0 +1,937 @@
+# `find_async_violations` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new MCP tool `find_async_violations` that detects six classes of async/await misuse (sync-over-async × 3, async void outside event handlers, missing await, fire-and-forget) across non-test projects, returning a summary plus a flat per-violation list with severity (error/warning).
+
+**Architecture:** Single forward sweep per non-test compilation. For each method declaration: check the method itself for `AsyncVoid`, then walk its body for the other five patterns via `MemberAccessExpressionSyntax` (`.Result`), `InvocationExpressionSyntax` (`Wait*`, `GetAwaiter().GetResult()`), and `ExpressionStatementSyntax` (Task-returning bare expressions → MissingAwait if inside async, FireAndForget otherwise). Reuses `TestProjectDetector` to skip test projects.
+
+**Tech Stack:** Roslyn (`Microsoft.CodeAnalysis`), xUnit, BenchmarkDotNet, ModelContextProtocol.Server.
+
+**Reference design:** `docs/plans/2026-04-28-find-async-violations-design.md`
+
+**Patterns to mirror (read these before starting):**
+- Tool wrapper: `src/RoslynCodeLens/Tools/FindUncoveredSymbolsTool.cs` (parameter-less wrapper)
+- Logic class: `src/RoslynCodeLens/Tools/FindUncoveredSymbolsLogic.cs` (production-only filter via `TestProjectDetector`, single-pass enumeration)
+- Test pattern: `tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs` (fixture loading via `IAsyncLifetime`)
+- MCP auto-registration: `src/RoslynCodeLens/Program.cs:35` uses `WithToolsFromAssembly()` — no `Program.cs` edit needed
+
+---
+
+## Task 1: Add `AsyncFixture` production project
+
+The fixture solution needs a project containing one positive case per pattern + several negative cases. The project must NOT reference any test framework (so it counts as a production project under `TestProjectDetector`).
+
+**Files:**
+- Create: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/AsyncFixture.csproj`
+- Create: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs`
+- Modify: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx`
+
+**Step 1: Create `AsyncFixture.csproj`**
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>
+```
+
+(No `<ProjectReference>` to TestLib/TestLib2 — this fixture is self-contained.)
+
+**Step 2: Create `Violations.cs`**
+
+```csharp
+using System;
+using System.Threading.Tasks;
+
+namespace AsyncFixture;
+
+public class Violations
+{
+    // ============ POSITIVE CASES (each must produce exactly one violation) ============
+
+    // 1. SyncOverAsyncResult: .Result on Task<T>
+    public string GetResultViolation()
+    {
+        var task = Task.FromResult("hello");
+        return task.Result;
+    }
+
+    // 2. SyncOverAsyncWait: .Wait() on Task
+    public void WaitViolation()
+    {
+        var task = Task.Delay(10);
+        task.Wait();
+    }
+
+    // 3. SyncOverAsyncGetAwaiterGetResult
+    public string GetAwaiterGetResultViolation()
+    {
+        var task = Task.FromResult("hello");
+        return task.GetAwaiter().GetResult();
+    }
+
+    // 4. AsyncVoid (NOT event-handler shaped)
+    public async void AsyncVoidViolation()
+    {
+        await Task.Delay(10);
+    }
+
+    // 5. MissingAwait: bare Task call inside async method
+    public async Task MissingAwaitViolation()
+    {
+        Task.Delay(10);
+        await Task.CompletedTask;
+    }
+
+    // 6. FireAndForget: bare Task call in non-async method
+    public void FireAndForgetViolation()
+    {
+        Task.Delay(10);
+    }
+
+    // ============ NEGATIVE CASES (must NOT be flagged) ============
+
+    public async Task ProperAwait()
+    {
+        await Task.Delay(10);
+    }
+
+    public async void EventHandler(object sender, EventArgs e)
+    {
+        await Task.Delay(10);
+    }
+
+    public void DiscardFireAndForget()
+    {
+        _ = Task.Delay(10);
+    }
+
+    public void AssignedFireAndForget()
+    {
+        var t = Task.Delay(10);
+        _ = t;
+    }
+
+    public Task ForwardingMethod()
+    {
+        return Task.Delay(10);
+    }
+}
+```
+
+**Step 3: Update `TestSolution.slnx`** — read first to preserve existing entries, then append the new project:
+
+```xml
+<Solution>
+  <Project Path="TestLib/TestLib.csproj" />
+  <Project Path="TestLib2/TestLib2.csproj" />
+  <Project Path="NUnitFixture/NUnitFixture.csproj" />
+  <Project Path="MSTestFixture/MSTestFixture.csproj" />
+  <Project Path="XUnitFixture/XUnitFixture.csproj" />
+  <Project Path="AsyncFixture/AsyncFixture.csproj" />
+</Solution>
+```
+
+**Step 4: Restore + build the fixture solution**
+
+```bash
+dotnet restore tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
+dotnet build tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx -c Debug
+```
+
+Expected: 0 errors. May emit a CS0219 warning on `AssignedFireAndForget`'s `var t` (unused variable) — that's why we added `_ = t;` to silence it. May emit CS1998 on `AsyncVoidViolation` if it doesn't await — it does, so should be fine.
+
+**Step 5: Run existing test suite to verify no regressions**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests
+```
+
+Expected: same pass count as before this task (the new project just adds more candidates for existing tools; nothing should newly fail).
+
+**Step 6: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/ \
+  tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
+git commit -m "test: add AsyncFixture project with async-violation positive and negative cases"
+```
+
+---
+
+## Task 2: Models for output
+
+Five files: two enums + three records.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/AsyncViolationPattern.cs`
+- Create: `src/RoslynCodeLens/Models/AsyncViolationSeverity.cs`
+- Create: `src/RoslynCodeLens/Models/AsyncViolation.cs`
+- Create: `src/RoslynCodeLens/Models/AsyncViolationSummary.cs`
+- Create: `src/RoslynCodeLens/Models/FindAsyncViolationsResult.cs`
+
+**Step 1: `AsyncViolationPattern.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public enum AsyncViolationPattern
+{
+    SyncOverAsyncResult,
+    SyncOverAsyncWait,
+    SyncOverAsyncGetAwaiterGetResult,
+    AsyncVoid,
+    MissingAwait,
+    FireAndForget
+}
+```
+
+**Step 2: `AsyncViolationSeverity.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public enum AsyncViolationSeverity
+{
+    Error,
+    Warning
+}
+```
+
+(Order matters: `Error` is value 0 so ascending sort puts errors first.)
+
+**Step 3: `AsyncViolation.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record AsyncViolation(
+    AsyncViolationPattern Pattern,
+    AsyncViolationSeverity Severity,
+    string FilePath,
+    int Line,
+    string ContainingMethod,
+    string Project,
+    string Snippet);
+```
+
+**Step 4: `AsyncViolationSummary.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record AsyncViolationSummary(
+    int TotalViolations,
+    IReadOnlyDictionary<string, int> ByPattern,
+    IReadOnlyDictionary<string, int> BySeverity);
+```
+
+(String keys so JSON serializes cleanly. Values are pattern enum names and severity enum names.)
+
+**Step 5: `FindAsyncViolationsResult.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record FindAsyncViolationsResult(
+    AsyncViolationSummary Summary,
+    IReadOnlyList<AsyncViolation> Violations);
+```
+
+**Step 6: Build to verify**
+
+```bash
+dotnet build src/RoslynCodeLens
+```
+
+Expected: 0 errors.
+
+**Step 7: Commit**
+
+```bash
+git add src/RoslynCodeLens/Models/AsyncViolationPattern.cs \
+  src/RoslynCodeLens/Models/AsyncViolationSeverity.cs \
+  src/RoslynCodeLens/Models/AsyncViolation.cs \
+  src/RoslynCodeLens/Models/AsyncViolationSummary.cs \
+  src/RoslynCodeLens/Models/FindAsyncViolationsResult.cs
+git commit -m "feat: add models for find_async_violations output"
+```
+
+---
+
+## Task 3: `FindAsyncViolationsLogic` + comprehensive tests
+
+The core engine. Single pass, six patterns, severity sort, summary aggregation.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs`
+- Create: `tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+// tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class FindAsyncViolationsToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncResult, "GetResultViolation")]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncWait, "WaitViolation")]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult, "GetAwaiterGetResultViolation")]
+    [InlineData(AsyncViolationPattern.AsyncVoid, "AsyncVoidViolation")]
+    [InlineData(AsyncViolationPattern.MissingAwait, "MissingAwaitViolation")]
+    [InlineData(AsyncViolationPattern.FireAndForget, "FireAndForgetViolation")]
+    public void DetectsExactlyOneViolationPerPattern(AsyncViolationPattern pattern, string methodName)
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        var hits = result.Violations.Where(v =>
+            v.Pattern == pattern &&
+            v.ContainingMethod.EndsWith(methodName, StringComparison.Ordinal)).ToList();
+
+        Assert.Single(hits);
+    }
+
+    [Fact]
+    public void DoesNotFlag_ProperlyAwaited()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("ProperAwait", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_EventHandlerAsyncVoid()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("EventHandler", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_DiscardOrAssignedTask()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("DiscardFireAndForget", StringComparison.Ordinal) ||
+            v.ContainingMethod.EndsWith("AssignedFireAndForget", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_ForwardingReturn()
+    {
+        // Non-async method that does `return SomeAsync();` — perfectly valid.
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("ForwardingMethod", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_TestProjectMembers()
+    {
+        // Test fixtures may contain async patterns; they must be skipped.
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.Project.EndsWith("Fixture", StringComparison.Ordinal) &&
+            v.Project != "AsyncFixture");
+    }
+
+    [Fact]
+    public void Summary_TotalMatchesListLength()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.Equal(result.Violations.Count, result.Summary.TotalViolations);
+    }
+
+    [Fact]
+    public void Summary_ByPatternCountsAreCorrect()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var (patternName, count) in result.Summary.ByPattern)
+        {
+            var actual = result.Violations.Count(v => v.Pattern.ToString() == patternName);
+            Assert.Equal(actual, count);
+        }
+    }
+
+    [Fact]
+    public void Summary_BySeverityCountsAreCorrect()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var (severityName, count) in result.Summary.BySeverity)
+        {
+            var actual = result.Violations.Count(v => v.Severity.ToString() == severityName);
+            Assert.Equal(actual, count);
+        }
+    }
+
+    [Fact]
+    public void Violations_SortedBySeverityThenLocation()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        for (int i = 1; i < result.Violations.Count; i++)
+        {
+            var prev = result.Violations[i - 1];
+            var curr = result.Violations[i];
+
+            // Errors (enum value 0) before Warnings (1)
+            Assert.True((int)prev.Severity <= (int)curr.Severity,
+                $"Severity sort violation at {i}");
+
+            if (prev.Severity == curr.Severity)
+            {
+                var pathCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+                Assert.True(pathCmp <= 0, $"FilePath sort violation at {i}");
+                if (pathCmp == 0)
+                    Assert.True(prev.Line <= curr.Line, $"Line sort violation at {i}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Violations_HaveLocationAndSnippet()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var v in result.Violations)
+        {
+            Assert.NotEmpty(v.FilePath);
+            Assert.True(v.Line > 0);
+            Assert.NotEmpty(v.Project);
+            Assert.NotEmpty(v.Snippet);
+            Assert.NotEmpty(v.ContainingMethod);
+        }
+    }
+}
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindAsyncViolationsToolTests" -v normal
+```
+
+Expected: compile errors — `FindAsyncViolationsLogic` doesn't exist.
+
+**Step 3: Create `FindAsyncViolationsLogic.cs`**
+
+```csharp
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.TestDiscovery;
+
+namespace RoslynCodeLens.Tools;
+
+public static class FindAsyncViolationsLogic
+{
+    private const int SnippetMaxLength = 80;
+
+    public static FindAsyncViolationsResult Execute(LoadedSolution loaded, SymbolResolver source)
+    {
+        var testProjectIds = TestProjectDetector.GetTestProjectIds(loaded.Solution);
+        var violations = new List<AsyncViolation>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            if (testProjectIds.Contains(projectId))
+                continue;
+
+            var projectName = source.GetProjectName(projectId);
+            var taskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            var taskGenericSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            var valueTaskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask");
+            var valueTaskGenericSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+            var eventArgsSymbol = compilation.GetTypeByMetadataName("System.EventArgs");
+
+            if (taskSymbol is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                if (IsGeneratedFile(tree))
+                    continue;
+
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = tree.GetRoot();
+
+                foreach (var methodDecl in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                {
+                    var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl);
+                    if (methodSymbol is null || methodSymbol.IsImplicitlyDeclared)
+                        continue;
+
+                    var containingMethodName = methodSymbol.ContainingType is null
+                        ? methodSymbol.Name
+                        : $"{methodSymbol.ContainingType.Name}.{methodSymbol.Name}";
+
+                    // Pattern 4: AsyncVoid
+                    if (IsAsyncVoid(methodDecl) && !IsEventHandlerShaped(methodSymbol, eventArgsSymbol))
+                    {
+                        var loc = methodDecl.Identifier.GetLocation();
+                        violations.Add(BuildViolation(
+                            AsyncViolationPattern.AsyncVoid,
+                            AsyncViolationSeverity.Error,
+                            loc,
+                            containingMethodName,
+                            projectName,
+                            "async void " + methodDecl.Identifier.Text + "(...)"));
+                    }
+
+                    var body = (SyntaxNode?)methodDecl.Body ?? methodDecl.ExpressionBody;
+                    if (body is null) continue;
+
+                    var isAsync = methodDecl.Modifiers.Any(SyntaxKind.AsyncKeyword);
+
+                    // Patterns 1-3: walk member-access + invocation expressions
+                    foreach (var node in body.DescendantNodes())
+                    {
+                        // Pattern 1: SyncOverAsyncResult
+                        if (node is MemberAccessExpressionSyntax memberAccess &&
+                            memberAccess.Name.Identifier.Text == "Result" &&
+                            memberAccess.Parent is not InvocationExpressionSyntax)
+                        {
+                            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+                            if (IsTaskType(receiverType, taskSymbol, taskGenericSymbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncResult,
+                                    AsyncViolationSeverity.Error,
+                                    memberAccess.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(memberAccess.ToString())));
+                            }
+                        }
+                        // Patterns 2 & 3 share the InvocationExpressionSyntax shape
+                        else if (node is InvocationExpressionSyntax invocation)
+                        {
+                            var symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+                            if (symbol is null) continue;
+
+                            // Pattern 2: SyncOverAsyncWait
+                            if (IsTaskWaitMethod(symbol, taskSymbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncWait,
+                                    AsyncViolationSeverity.Error,
+                                    invocation.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(invocation.ToString())));
+                            }
+                            // Pattern 3: SyncOverAsyncGetAwaiterGetResult
+                            else if (IsGetResultOnAwaiter(invocation, symbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult,
+                                    AsyncViolationSeverity.Error,
+                                    invocation.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(invocation.ToString())));
+                            }
+                        }
+                    }
+
+                    // Patterns 5 & 6: bare expression statement of Task-returning invocation
+                    foreach (var stmt in body.DescendantNodes().OfType<ExpressionStatementSyntax>())
+                    {
+                        if (stmt.Expression is not InvocationExpressionSyntax invocation)
+                            continue;
+
+                        var symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+                        if (symbol is null) continue;
+
+                        if (!IsTaskOrValueTaskType(symbol.ReturnType, taskSymbol, taskGenericSymbol, valueTaskSymbol, valueTaskGenericSymbol))
+                            continue;
+
+                        var pattern = isAsync
+                            ? AsyncViolationPattern.MissingAwait
+                            : AsyncViolationPattern.FireAndForget;
+
+                        violations.Add(BuildViolation(
+                            pattern,
+                            AsyncViolationSeverity.Warning,
+                            invocation.GetLocation(),
+                            containingMethodName,
+                            projectName,
+                            Snippet(invocation.ToString())));
+                    }
+                }
+            }
+        }
+
+        // Sort: severity ASC (Error=0 first), then file ASC, then line ASC.
+        violations.Sort((a, b) =>
+        {
+            var bySeverity = ((int)a.Severity).CompareTo((int)b.Severity);
+            if (bySeverity != 0) return bySeverity;
+            var byPath = string.CompareOrdinal(a.FilePath, b.FilePath);
+            if (byPath != 0) return byPath;
+            return a.Line.CompareTo(b.Line);
+        });
+
+        var byPattern = violations
+            .GroupBy(v => v.Pattern.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+        var bySeverity = violations
+            .GroupBy(v => v.Severity.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var summary = new AsyncViolationSummary(
+            TotalViolations: violations.Count,
+            ByPattern: byPattern,
+            BySeverity: bySeverity);
+
+        return new FindAsyncViolationsResult(summary, violations);
+    }
+
+    private static bool IsAsyncVoid(MethodDeclarationSyntax methodDecl)
+    {
+        if (!methodDecl.Modifiers.Any(SyntaxKind.AsyncKeyword)) return false;
+        return methodDecl.ReturnType is PredefinedTypeSyntax pts &&
+               pts.Keyword.IsKind(SyntaxKind.VoidKeyword);
+    }
+
+    private static bool IsEventHandlerShaped(IMethodSymbol method, INamedTypeSymbol? eventArgsSymbol)
+    {
+        if (eventArgsSymbol is null) return false;
+        if (method.Parameters.Length != 2) return false;
+
+        // First param: typically `object`, but accept any reference-ish type.
+        var firstParam = method.Parameters[0].Type;
+        var firstOk = firstParam.SpecialType == SpecialType.System_Object ||
+                      firstParam.TypeKind == TypeKind.Class ||
+                      firstParam.TypeKind == TypeKind.Interface;
+        if (!firstOk) return false;
+
+        // Second param: EventArgs or any subclass.
+        return InheritsFromOrIs(method.Parameters[1].Type, eventArgsSymbol);
+    }
+
+    private static bool InheritsFromOrIs(ITypeSymbol type, INamedTypeSymbol baseType)
+    {
+        var current = type as INamedTypeSymbol;
+        while (current is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType)) return true;
+            current = current.BaseType;
+        }
+        return false;
+    }
+
+    private static bool IsTaskType(ITypeSymbol? type, INamedTypeSymbol taskSymbol, INamedTypeSymbol? taskGenericSymbol)
+    {
+        if (type is null) return false;
+        if (SymbolEqualityComparer.Default.Equals(type, taskSymbol)) return true;
+        if (taskGenericSymbol is not null &&
+            type is INamedTypeSymbol named &&
+            named.IsGenericType &&
+            SymbolEqualityComparer.Default.Equals(named.ConstructedFrom, taskGenericSymbol))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsTaskOrValueTaskType(
+        ITypeSymbol type,
+        INamedTypeSymbol taskSymbol,
+        INamedTypeSymbol? taskGenericSymbol,
+        INamedTypeSymbol? valueTaskSymbol,
+        INamedTypeSymbol? valueTaskGenericSymbol)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, taskSymbol)) return true;
+        if (valueTaskSymbol is not null && SymbolEqualityComparer.Default.Equals(type, valueTaskSymbol)) return true;
+
+        if (type is INamedTypeSymbol named && named.IsGenericType)
+        {
+            var ctor = named.ConstructedFrom;
+            if (taskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, taskGenericSymbol)) return true;
+            if (valueTaskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, valueTaskGenericSymbol)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsTaskWaitMethod(IMethodSymbol method, INamedTypeSymbol taskSymbol)
+    {
+        var containing = method.ContainingType?.OriginalDefinition;
+        if (!SymbolEqualityComparer.Default.Equals(containing, taskSymbol)) return false;
+        return method.Name is "Wait" or "WaitAll" or "WaitAny";
+    }
+
+    private static bool IsGetResultOnAwaiter(InvocationExpressionSyntax invocation, IMethodSymbol symbol)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return false;
+        if (memberAccess.Name.Identifier.Text != "GetResult") return false;
+
+        var containingType = symbol.ContainingType?.OriginalDefinition;
+        if (containingType is null) return false;
+
+        var fqn = containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+            .Replace("global::", string.Empty, StringComparison.Ordinal);
+
+        return fqn is "System.Runtime.CompilerServices.TaskAwaiter"
+            or "System.Runtime.CompilerServices.TaskAwaiter<TResult>"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>";
+    }
+
+    private static bool IsGeneratedFile(SyntaxTree tree)
+    {
+        var path = tree.FilePath;
+        if (!string.IsNullOrEmpty(path))
+        {
+            if (path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)) return true;
+            if (path.EndsWith(".designer.cs", StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        var text = tree.GetText();
+        var headerLength = Math.Min(text.Length, 1024);
+        var header = text.GetSubText(new TextSpan(0, headerLength)).ToString();
+        return header.Contains("<auto-generated>", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Snippet(string source)
+    {
+        if (source.Length <= SnippetMaxLength) return source;
+        return source[..SnippetMaxLength] + "...";
+    }
+
+    private static AsyncViolation BuildViolation(
+        AsyncViolationPattern pattern,
+        AsyncViolationSeverity severity,
+        Location location,
+        string containingMethod,
+        string projectName,
+        string snippet)
+    {
+        var span = location.GetLineSpan();
+        return new AsyncViolation(
+            Pattern: pattern,
+            Severity: severity,
+            FilePath: span.Path ?? string.Empty,
+            Line: span.StartLinePosition.Line + 1,
+            ContainingMethod: containingMethod,
+            Project: projectName,
+            Snippet: snippet);
+    }
+}
+```
+
+**Step 4: Run all 11 tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindAsyncViolationsToolTests" -v normal
+```
+
+Expected: all pass.
+
+Common debugging if a test fails:
+- **Pattern not detected**: check the symbol resolution — are you using `OriginalDefinition` for generic types?
+- **Negative case flagged**: re-read the negative fixture; ensure `ProperAwait`'s `await` keyword excludes it from `ExpressionStatementSyntax` walking (an `await` is part of an expression, not a bare statement).
+- **Wrong severity sort**: `AsyncViolationSeverity` order — `Error` must be enum value 0.
+- **AsyncFixture members missing from output**: ensure the project isn't accidentally classified as a test project.
+
+**Step 5: Run full suite**
+
+```bash
+dotnet test
+```
+
+Expected: all green.
+
+**Step 6: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs \
+  tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+git commit -m "feat: add FindAsyncViolationsLogic with six pattern detectors"
+```
+
+---
+
+## Task 4: `FindAsyncViolationsTool` MCP wrapper
+
+Thin wrapper. Auto-registered via `WithToolsFromAssembly()` in `Program.cs:35`.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs`
+
+**Step 1: Create the wrapper**
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class FindAsyncViolationsTool
+{
+    [McpServerTool(Name = "find_async_violations")]
+    [Description(
+        "Detect six classes of async/await misuse across all production projects: " +
+        "sync-over-async (.Result, .Wait*, GetAwaiter().GetResult()), async void " +
+        "outside event handlers, missing await in async methods, and fire-and-forget " +
+        "tasks. Returns a summary plus a per-violation list (severity error/warning, " +
+        "location, containing method, snippet). Skips test projects and generated " +
+        "code. Static analysis only — no fix suggestions.")]
+    public static FindAsyncViolationsResult Execute(MultiSolutionManager manager)
+    {
+        manager.EnsureLoaded();
+        return FindAsyncViolationsLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver());
+    }
+}
+```
+
+**Step 2: Build the whole solution**
+
+```bash
+dotnet build
+```
+
+Expected: 0 errors. Auto-registration picks up the new `[McpServerToolType]`.
+
+**Step 3: Run full test suite**
+
+```bash
+dotnet test
+```
+
+Expected: all green.
+
+**Step 4: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs
+git commit -m "feat: register find_async_violations MCP tool"
+```
+
+---
+
+## Task 5: Add benchmark
+
+**Files:**
+- Modify: `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs`
+
+**Step 1: Read the file** to find the existing `find_*` benchmarks.
+
+**Step 2: Add the benchmark method** alongside existing ones (e.g. near `find_uncovered_symbols`):
+
+```csharp
+[Benchmark(Description = "find_async_violations: whole solution")]
+public object FindAsyncViolations()
+{
+    return FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+}
+```
+
+**Step 3: Build the benchmarks project**
+
+```bash
+dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release
+```
+
+Expected: 0 errors.
+
+**Step 4: Commit**
+
+```bash
+git add benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+git commit -m "bench: add find_async_violations benchmark"
+```
+
+---
+
+## Task 6: Update SKILL.md, README, CLAUDE.md
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Step 1: Read SKILL.md** and add the tool. Suggested entries (mirror how `find_naming_violations` and `find_uncovered_symbols` are integrated):
+
+For the Red Flags / routing table:
+> | "Are there async bugs?" / "Find sync-over-async" / "Are we using `.Result` anywhere?" | `find_async_violations` |
+
+For the Quick Reference table:
+> | `find_async_violations` | "Are there async bugs?" / "Find sync-over-async" |
+
+For the relevant tool-listing section (likely "Diagnostics" or "Code-quality"):
+> - `find_async_violations` — Detects sync-over-async (`.Result`/`.Wait()`/`GetAwaiter().GetResult()`), `async void` outside event handlers, missing awaits in async methods, and fire-and-forget tasks. Severity error/warning per violation. Static analysis; no runtime data.
+
+NOTE: do NOT add a metadata-support row — this tool only operates on source.
+
+**Step 2: Read README.md** and add to the Features list near `find_naming_violations`:
+
+> - **find_async_violations** — Sync-over-async, `async void` misuse, missing awaits, fire-and-forget tasks; per-violation report with severity.
+
+**Step 3: Update `CLAUDE.md`** — change "24 code intelligence tools" to "25 code intelligence tools".
+
+**Step 4: Sanity check**
+
+```bash
+dotnet test
+```
+
+Expected: all green.
+
+**Step 5: Commit**
+
+```bash
+git add plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md \
+  README.md \
+  CLAUDE.md
+git commit -m "docs: announce find_async_violations in SKILL.md, README, CLAUDE.md"
+```
+
+---
+
+## Done
+
+After Task 6 the branch should have ~7 commits, all tests green, the benchmark project compiling, and the tool auto-registered. From there: `/requesting-code-review` → PR.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -44,6 +44,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 | "Let me `Grep` for tests that call this method" | `find_tests_for_symbol` |
 | "Which tests will break if I change this?" | `find_tests_for_symbol` |
 | "What should I write tests for?" / "Where's our testing debt?" / "Show me untested public methods" | `find_uncovered_symbols` |
+| "Are there async bugs?" / "Find sync-over-async" / "Are we using `.Result` anywhere?" | `find_async_violations` |
 
 **All of these mean: the MCP tool is the correct tool. Use it.**
 
@@ -139,6 +140,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 - `find_unused_symbols` — dead code (reference-based).
 - `get_complexity_metrics` — cyclomatic complexity per method.
 - `find_naming_violations` — .NET naming conventions.
+- `find_async_violations` — Detects sync-over-async (`.Result`/`.Wait()`/`GetAwaiter().GetResult()`), `async void` outside event handlers, missing awaits in async methods, and fire-and-forget tasks. Severity error/warning per violation. Static analysis; no runtime data.
 - `find_large_classes` — oversized types.
 - `find_circular_dependencies` — project/namespace cycles.
 
@@ -236,6 +238,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `find_unused_symbols` | "Any dead code?" |
 | `get_complexity_metrics` | "Which methods are too complex?" |
 | `find_naming_violations` | "Check naming conventions" |
+| `find_async_violations` | "Are there async bugs?" / "Find sync-over-async" |
 | `find_large_classes` | "Find classes that need splitting" |
 | `find_circular_dependencies` | "Any circular dependencies?" |
 | `get_source_generators` | "What source generators are active?" |

--- a/src/RoslynCodeLens/Models/AsyncViolation.cs
+++ b/src/RoslynCodeLens/Models/AsyncViolation.cs
@@ -1,0 +1,10 @@
+namespace RoslynCodeLens.Models;
+
+public record AsyncViolation(
+    AsyncViolationPattern Pattern,
+    AsyncViolationSeverity Severity,
+    string FilePath,
+    int Line,
+    string ContainingMethod,
+    string Project,
+    string Snippet);

--- a/src/RoslynCodeLens/Models/AsyncViolationPattern.cs
+++ b/src/RoslynCodeLens/Models/AsyncViolationPattern.cs
@@ -1,0 +1,11 @@
+namespace RoslynCodeLens.Models;
+
+public enum AsyncViolationPattern
+{
+    SyncOverAsyncResult,
+    SyncOverAsyncWait,
+    SyncOverAsyncGetAwaiterGetResult,
+    AsyncVoid,
+    MissingAwait,
+    FireAndForget
+}

--- a/src/RoslynCodeLens/Models/AsyncViolationSeverity.cs
+++ b/src/RoslynCodeLens/Models/AsyncViolationSeverity.cs
@@ -1,0 +1,7 @@
+namespace RoslynCodeLens.Models;
+
+public enum AsyncViolationSeverity
+{
+    Error,
+    Warning
+}

--- a/src/RoslynCodeLens/Models/AsyncViolationSummary.cs
+++ b/src/RoslynCodeLens/Models/AsyncViolationSummary.cs
@@ -1,0 +1,6 @@
+namespace RoslynCodeLens.Models;
+
+public record AsyncViolationSummary(
+    int TotalViolations,
+    IReadOnlyDictionary<string, int> ByPattern,
+    IReadOnlyDictionary<string, int> BySeverity);

--- a/src/RoslynCodeLens/Models/FindAsyncViolationsResult.cs
+++ b/src/RoslynCodeLens/Models/FindAsyncViolationsResult.cs
@@ -1,0 +1,5 @@
+namespace RoslynCodeLens.Models;
+
+public record FindAsyncViolationsResult(
+    AsyncViolationSummary Summary,
+    IReadOnlyList<AsyncViolation> Violations);

--- a/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
@@ -1,0 +1,300 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.TestDiscovery;
+
+namespace RoslynCodeLens.Tools;
+
+public static class FindAsyncViolationsLogic
+{
+    private const int SnippetMaxLength = 80;
+
+    public static FindAsyncViolationsResult Execute(LoadedSolution loaded, SymbolResolver source)
+    {
+        var testProjectIds = TestProjectDetector.GetTestProjectIds(loaded.Solution);
+        var violations = new List<AsyncViolation>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            if (testProjectIds.Contains(projectId))
+                continue;
+
+            var projectName = source.GetProjectName(projectId);
+            var taskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            var taskGenericSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            var valueTaskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask");
+            var valueTaskGenericSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+            var eventArgsSymbol = compilation.GetTypeByMetadataName("System.EventArgs");
+
+            if (taskSymbol is null) continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                if (IsGeneratedFile(tree))
+                    continue;
+
+                var semanticModel = compilation.GetSemanticModel(tree);
+                var root = tree.GetRoot();
+
+                foreach (var methodDecl in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+                {
+                    var methodSymbol = semanticModel.GetDeclaredSymbol(methodDecl);
+                    if (methodSymbol is null || methodSymbol.IsImplicitlyDeclared)
+                        continue;
+
+                    var containingMethodName = methodSymbol.ContainingType is null
+                        ? methodSymbol.Name
+                        : $"{methodSymbol.ContainingType.Name}.{methodSymbol.Name}";
+
+                    // Pattern 4: AsyncVoid
+                    if (IsAsyncVoid(methodDecl) && !IsEventHandlerShaped(methodSymbol, eventArgsSymbol))
+                    {
+                        violations.Add(BuildViolation(
+                            AsyncViolationPattern.AsyncVoid,
+                            AsyncViolationSeverity.Error,
+                            methodDecl.Identifier.GetLocation(),
+                            containingMethodName,
+                            projectName,
+                            "async void " + methodDecl.Identifier.Text + "(...)"));
+                    }
+
+                    var body = (SyntaxNode?)methodDecl.Body ?? methodDecl.ExpressionBody;
+                    if (body is null) continue;
+
+                    var isAsync = methodDecl.Modifiers.Any(SyntaxKind.AsyncKeyword);
+
+                    // Patterns 1-3: walk member-access + invocation expressions in the body
+                    foreach (var node in body.DescendantNodes())
+                    {
+                        if (node is MemberAccessExpressionSyntax memberAccess &&
+                            memberAccess.Name.Identifier.Text == "Result" &&
+                            memberAccess.Parent is not InvocationExpressionSyntax)
+                        {
+                            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
+                            if (IsTaskType(receiverType, taskSymbol, taskGenericSymbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncResult,
+                                    AsyncViolationSeverity.Error,
+                                    memberAccess.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(memberAccess.ToString())));
+                            }
+                        }
+                        else if (node is InvocationExpressionSyntax invocation)
+                        {
+                            var symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+                            if (symbol is null) continue;
+
+                            if (IsTaskWaitMethod(symbol, taskSymbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncWait,
+                                    AsyncViolationSeverity.Error,
+                                    invocation.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(invocation.ToString())));
+                            }
+                            else if (IsGetResultOnAwaiter(invocation, symbol))
+                            {
+                                violations.Add(BuildViolation(
+                                    AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult,
+                                    AsyncViolationSeverity.Error,
+                                    invocation.GetLocation(),
+                                    containingMethodName,
+                                    projectName,
+                                    Snippet(invocation.ToString())));
+                            }
+                        }
+                    }
+
+                    // Patterns 5 & 6: bare expression statement of Task-returning invocation
+                    foreach (var stmt in body.DescendantNodes().OfType<ExpressionStatementSyntax>())
+                    {
+                        if (stmt.Expression is not InvocationExpressionSyntax invocation)
+                            continue;
+
+                        var symbol = semanticModel.GetSymbolInfo(invocation).Symbol as IMethodSymbol;
+                        if (symbol is null) continue;
+
+                        if (!IsTaskOrValueTaskType(symbol.ReturnType, taskSymbol, taskGenericSymbol, valueTaskSymbol, valueTaskGenericSymbol))
+                            continue;
+
+                        var pattern = isAsync
+                            ? AsyncViolationPattern.MissingAwait
+                            : AsyncViolationPattern.FireAndForget;
+
+                        violations.Add(BuildViolation(
+                            pattern,
+                            AsyncViolationSeverity.Warning,
+                            invocation.GetLocation(),
+                            containingMethodName,
+                            projectName,
+                            Snippet(invocation.ToString())));
+                    }
+                }
+            }
+        }
+
+        // Sort: severity ASC (Error=0 first), then file ASC, then line ASC.
+        violations.Sort((a, b) =>
+        {
+            var bySeverity = ((int)a.Severity).CompareTo((int)b.Severity);
+            if (bySeverity != 0) return bySeverity;
+            var byPath = string.CompareOrdinal(a.FilePath, b.FilePath);
+            if (byPath != 0) return byPath;
+            return a.Line.CompareTo(b.Line);
+        });
+
+        var byPattern = violations
+            .GroupBy(v => v.Pattern.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+        var bySeverity = violations
+            .GroupBy(v => v.Severity.ToString())
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var summary = new AsyncViolationSummary(
+            TotalViolations: violations.Count,
+            ByPattern: byPattern,
+            BySeverity: bySeverity);
+
+        return new FindAsyncViolationsResult(summary, violations);
+    }
+
+    private static bool IsAsyncVoid(MethodDeclarationSyntax methodDecl)
+    {
+        if (!methodDecl.Modifiers.Any(SyntaxKind.AsyncKeyword)) return false;
+        return methodDecl.ReturnType is PredefinedTypeSyntax pts &&
+               pts.Keyword.IsKind(SyntaxKind.VoidKeyword);
+    }
+
+    private static bool IsEventHandlerShaped(IMethodSymbol method, INamedTypeSymbol? eventArgsSymbol)
+    {
+        if (eventArgsSymbol is null) return false;
+        if (method.Parameters.Length != 2) return false;
+
+        var firstParam = method.Parameters[0].Type;
+        var firstOk = firstParam.SpecialType == SpecialType.System_Object ||
+                      firstParam.TypeKind == TypeKind.Class ||
+                      firstParam.TypeKind == TypeKind.Interface;
+        if (!firstOk) return false;
+
+        return InheritsFromOrIs(method.Parameters[1].Type, eventArgsSymbol);
+    }
+
+    private static bool InheritsFromOrIs(ITypeSymbol type, INamedTypeSymbol baseType)
+    {
+        var current = type as INamedTypeSymbol;
+        while (current is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType)) return true;
+            current = current.BaseType;
+        }
+        return false;
+    }
+
+    private static bool IsTaskType(ITypeSymbol? type, INamedTypeSymbol taskSymbol, INamedTypeSymbol? taskGenericSymbol)
+    {
+        if (type is null) return false;
+        if (SymbolEqualityComparer.Default.Equals(type, taskSymbol)) return true;
+        if (taskGenericSymbol is not null &&
+            type is INamedTypeSymbol named &&
+            named.IsGenericType &&
+            SymbolEqualityComparer.Default.Equals(named.ConstructedFrom, taskGenericSymbol))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private static bool IsTaskOrValueTaskType(
+        ITypeSymbol type,
+        INamedTypeSymbol taskSymbol,
+        INamedTypeSymbol? taskGenericSymbol,
+        INamedTypeSymbol? valueTaskSymbol,
+        INamedTypeSymbol? valueTaskGenericSymbol)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, taskSymbol)) return true;
+        if (valueTaskSymbol is not null && SymbolEqualityComparer.Default.Equals(type, valueTaskSymbol)) return true;
+
+        if (type is INamedTypeSymbol named && named.IsGenericType)
+        {
+            var ctor = named.ConstructedFrom;
+            if (taskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, taskGenericSymbol)) return true;
+            if (valueTaskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, valueTaskGenericSymbol)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsTaskWaitMethod(IMethodSymbol method, INamedTypeSymbol taskSymbol)
+    {
+        var containing = method.ContainingType?.OriginalDefinition;
+        if (!SymbolEqualityComparer.Default.Equals(containing, taskSymbol)) return false;
+        return method.Name is "Wait" or "WaitAll" or "WaitAny";
+    }
+
+    private static bool IsGetResultOnAwaiter(InvocationExpressionSyntax invocation, IMethodSymbol symbol)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess) return false;
+        if (memberAccess.Name.Identifier.Text != "GetResult") return false;
+
+        var containingType = symbol.ContainingType?.OriginalDefinition;
+        if (containingType is null) return false;
+
+        var fqn = containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+            .Replace("global::", string.Empty, StringComparison.Ordinal);
+
+        return fqn is "System.Runtime.CompilerServices.TaskAwaiter"
+            or "System.Runtime.CompilerServices.TaskAwaiter<TResult>"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter"
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>";
+    }
+
+    private static bool IsGeneratedFile(SyntaxTree tree)
+    {
+        var path = tree.FilePath;
+        if (!string.IsNullOrEmpty(path))
+        {
+            if (path.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)) return true;
+            if (path.EndsWith(".designer.cs", StringComparison.OrdinalIgnoreCase)) return true;
+        }
+
+        var text = tree.GetText();
+        var headerLength = Math.Min(text.Length, 1024);
+        var header = text.GetSubText(new TextSpan(0, headerLength)).ToString();
+        return header.Contains("<auto-generated>", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Snippet(string source)
+    {
+        if (source.Length <= SnippetMaxLength) return source;
+        return source[..SnippetMaxLength] + "...";
+    }
+
+    private static AsyncViolation BuildViolation(
+        AsyncViolationPattern pattern,
+        AsyncViolationSeverity severity,
+        Location location,
+        string containingMethod,
+        string projectName,
+        string snippet)
+    {
+        var span = location.GetLineSpan();
+        return new AsyncViolation(
+            Pattern: pattern,
+            Severity: severity,
+            FilePath: span.Path ?? string.Empty,
+            Line: span.StartLinePosition.Line + 1,
+            ContainingMethod: containingMethod,
+            Project: projectName,
+            Snippet: snippet);
+    }
+}

--- a/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
@@ -255,7 +255,9 @@ public static class FindAsyncViolationsLogic
             or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter"
             or "System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult>.ConfiguredTaskAwaiter"
             or "System.Runtime.CompilerServices.ValueTaskAwaiter"
-            or "System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>";
+            or "System.Runtime.CompilerServices.ValueTaskAwaiter<TResult>"
+            or "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter"
+            or "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable<TResult>.ConfiguredValueTaskAwaiter";
     }
 
     private static bool IsGeneratedFile(SyntaxTree tree)

--- a/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindAsyncViolationsLogic.cs
@@ -73,7 +73,7 @@ public static class FindAsyncViolationsLogic
                             memberAccess.Parent is not InvocationExpressionSyntax)
                         {
                             var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression).Type;
-                            if (IsTaskType(receiverType, taskSymbol, taskGenericSymbol))
+                            if (HasTaskResultProperty(receiverType, taskSymbol, taskGenericSymbol, valueTaskGenericSymbol))
                             {
                                 violations.Add(BuildViolation(
                                     AsyncViolationPattern.SyncOverAsyncResult,
@@ -151,11 +151,11 @@ public static class FindAsyncViolationsLogic
         });
 
         var byPattern = violations
-            .GroupBy(v => v.Pattern.ToString())
-            .ToDictionary(g => g.Key, g => g.Count());
+            .GroupBy(v => v.Pattern.ToString(), StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
         var bySeverity = violations
-            .GroupBy(v => v.Severity.ToString())
-            .ToDictionary(g => g.Key, g => g.Count());
+            .GroupBy(v => v.Severity.ToString(), StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
 
         var summary = new AsyncViolationSummary(
             TotalViolations: violations.Count,
@@ -197,16 +197,17 @@ public static class FindAsyncViolationsLogic
         return false;
     }
 
-    private static bool IsTaskType(ITypeSymbol? type, INamedTypeSymbol taskSymbol, INamedTypeSymbol? taskGenericSymbol)
+    private static bool HasTaskResultProperty(ITypeSymbol? type, INamedTypeSymbol taskSymbol, INamedTypeSymbol? taskGenericSymbol, INamedTypeSymbol? valueTaskGenericSymbol)
     {
         if (type is null) return false;
         if (SymbolEqualityComparer.Default.Equals(type, taskSymbol)) return true;
-        if (taskGenericSymbol is not null &&
-            type is INamedTypeSymbol named &&
-            named.IsGenericType &&
-            SymbolEqualityComparer.Default.Equals(named.ConstructedFrom, taskGenericSymbol))
+        if (type is INamedTypeSymbol named && named.IsGenericType)
         {
-            return true;
+            var ctor = named.ConstructedFrom;
+            if (taskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, taskGenericSymbol)) return true;
+            if (valueTaskGenericSymbol is not null &&
+                SymbolEqualityComparer.Default.Equals(ctor, valueTaskGenericSymbol)) return true;
         }
         return false;
     }

--- a/src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class FindAsyncViolationsTool
+{
+    [McpServerTool(Name = "find_async_violations")]
+    [Description(
+        "Detect six classes of async/await misuse across all production projects: " +
+        "sync-over-async (.Result, .Wait*, GetAwaiter().GetResult()), async void " +
+        "outside event handlers, missing await in async methods, and fire-and-forget " +
+        "tasks. Returns a summary plus a per-violation list (severity error/warning, " +
+        "location, containing method, snippet). Skips test projects and generated " +
+        "code. Static analysis only — no fix suggestions.")]
+    public static FindAsyncViolationsResult Execute(MultiSolutionManager manager)
+    {
+        manager.EnsureLoaded();
+        return FindAsyncViolationsLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver());
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/AsyncFixture.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/AsyncFixture.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
@@ -54,6 +54,13 @@ public class Violations
         return task.ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
+    // 1b. SyncOverAsyncResult on ValueTask<T> (same blocking pattern, different awaitable type)
+    public string GetResultOnValueTaskViolation()
+    {
+        var task = new System.Threading.Tasks.ValueTask<string>("hello");
+        return task.Result;
+    }
+
     // ============ NEGATIVE CASES (must NOT be flagged) ============
 
     public async Task ProperAwait()

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
@@ -47,6 +47,13 @@ public class Violations
         Task.Delay(10);
     }
 
+    // 3b. SyncOverAsyncGetAwaiterGetResult via ConfigureAwait — same pattern, different awaiter type
+    public string ConfiguredGetAwaiterGetResultViolation()
+    {
+        var task = Task.FromResult("hello");
+        return task.ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
     // ============ NEGATIVE CASES (must NOT be flagged) ============
 
     public async Task ProperAwait()

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/AsyncFixture/Violations.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+
+namespace AsyncFixture;
+
+public class Violations
+{
+    // ============ POSITIVE CASES (each must produce exactly one violation) ============
+
+    // 1. SyncOverAsyncResult: .Result on Task<T>
+    public string GetResultViolation()
+    {
+        var task = Task.FromResult("hello");
+        return task.Result;
+    }
+
+    // 2. SyncOverAsyncWait: .Wait() on Task
+    public void WaitViolation()
+    {
+        var task = Task.Delay(10);
+        task.Wait();
+    }
+
+    // 3. SyncOverAsyncGetAwaiterGetResult
+    public string GetAwaiterGetResultViolation()
+    {
+        var task = Task.FromResult("hello");
+        return task.GetAwaiter().GetResult();
+    }
+
+    // 4. AsyncVoid (NOT event-handler shaped)
+    public async void AsyncVoidViolation()
+    {
+        await Task.Delay(10);
+    }
+
+    // 5. MissingAwait: bare Task call inside async method
+    public async Task MissingAwaitViolation()
+    {
+        Task.Delay(10);
+        await Task.CompletedTask;
+    }
+
+    // 6. FireAndForget: bare Task call in non-async method
+    public void FireAndForgetViolation()
+    {
+        Task.Delay(10);
+    }
+
+    // ============ NEGATIVE CASES (must NOT be flagged) ============
+
+    public async Task ProperAwait()
+    {
+        await Task.Delay(10);
+    }
+
+    public async void EventHandler(object sender, EventArgs e)
+    {
+        await Task.Delay(10);
+    }
+
+    public void DiscardFireAndForget()
+    {
+        _ = Task.Delay(10);
+    }
+
+    public void AssignedFireAndForget()
+    {
+        var t = Task.Delay(10);
+        _ = t;
+    }
+
+    public Task ForwardingMethod()
+    {
+        return Task.Delay(10);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
@@ -4,4 +4,5 @@
   <Project Path="NUnitFixture/NUnitFixture.csproj" />
   <Project Path="MSTestFixture/MSTestFixture.csproj" />
   <Project Path="XUnitFixture/XUnitFixture.csproj" />
+  <Project Path="AsyncFixture/AsyncFixture.csproj" />
 </Solution>

--- a/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
@@ -49,6 +49,16 @@ public class FindAsyncViolationsToolTests : IAsyncLifetime
     }
 
     [Fact]
+    public void DetectsResult_OnValueTask()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.Contains(result.Violations, v =>
+            v.Pattern == AsyncViolationPattern.SyncOverAsyncResult &&
+            v.ContainingMethod.EndsWith("GetResultOnValueTaskViolation", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void DoesNotFlag_ProperlyAwaited()
     {
         var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);

--- a/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
@@ -1,0 +1,161 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class FindAsyncViolationsToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncResult, "GetResultViolation")]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncWait, "WaitViolation")]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult, "GetAwaiterGetResultViolation")]
+    [InlineData(AsyncViolationPattern.AsyncVoid, "AsyncVoidViolation")]
+    [InlineData(AsyncViolationPattern.MissingAwait, "MissingAwaitViolation")]
+    [InlineData(AsyncViolationPattern.FireAndForget, "FireAndForgetViolation")]
+    public void DetectsExactlyOneViolationPerPattern(AsyncViolationPattern pattern, string methodName)
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        var hits = result.Violations.Where(v =>
+            v.Pattern == pattern &&
+            v.ContainingMethod.EndsWith(methodName, StringComparison.Ordinal)).ToList();
+
+        Assert.Single(hits);
+    }
+
+    [Fact]
+    public void DoesNotFlag_ProperlyAwaited()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("ProperAwait", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_EventHandlerAsyncVoid()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("EventHandler", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_DiscardOrAssignedTask()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("DiscardFireAndForget", StringComparison.Ordinal) ||
+            v.ContainingMethod.EndsWith("AssignedFireAndForget", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_ForwardingReturn()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.Violations, v =>
+            v.ContainingMethod.EndsWith("ForwardingMethod", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DoesNotFlag_TestProjectMembers()
+    {
+        // Test fixtures may contain async patterns; they must be skipped.
+        // Use TestProjectDetector to determine which projects are test projects (matches production semantics).
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+        var testProjectNames = RoslynCodeLens.TestDiscovery.TestProjectDetector
+            .GetTestProjectIds(_loaded.Solution)
+            .Select(id => _loaded.Solution.GetProject(id)!.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.DoesNotContain(result.Violations, v => testProjectNames.Contains(v.Project));
+    }
+
+    [Fact]
+    public void Summary_TotalMatchesListLength()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.Equal(result.Violations.Count, result.Summary.TotalViolations);
+    }
+
+    [Fact]
+    public void Summary_ByPatternCountsAreCorrect()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var kvp in result.Summary.ByPattern)
+        {
+            var actual = result.Violations.Count(v => v.Pattern.ToString() == kvp.Key);
+            Assert.Equal(actual, kvp.Value);
+        }
+    }
+
+    [Fact]
+    public void Summary_BySeverityCountsAreCorrect()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var kvp in result.Summary.BySeverity)
+        {
+            var actual = result.Violations.Count(v => v.Severity.ToString() == kvp.Key);
+            Assert.Equal(actual, kvp.Value);
+        }
+    }
+
+    [Fact]
+    public void Violations_SortedBySeverityThenLocation()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        for (int i = 1; i < result.Violations.Count; i++)
+        {
+            var prev = result.Violations[i - 1];
+            var curr = result.Violations[i];
+
+            Assert.True((int)prev.Severity <= (int)curr.Severity,
+                $"Severity sort violation at {i}");
+
+            if (prev.Severity == curr.Severity)
+            {
+                var pathCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+                Assert.True(pathCmp <= 0, $"FilePath sort violation at {i}");
+                if (pathCmp == 0)
+                    Assert.True(prev.Line <= curr.Line, $"Line sort violation at {i}");
+            }
+        }
+    }
+
+    [Fact]
+    public void Violations_HaveLocationAndSnippet()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        foreach (var v in result.Violations)
+        {
+            Assert.NotEmpty(v.FilePath);
+            Assert.True(v.Line > 0);
+            Assert.NotEmpty(v.Project);
+            Assert.NotEmpty(v.Snippet);
+            Assert.NotEmpty(v.ContainingMethod);
+        }
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
@@ -23,7 +23,7 @@ public class FindAsyncViolationsToolTests : IAsyncLifetime
     [Theory]
     [InlineData(AsyncViolationPattern.SyncOverAsyncResult, "GetResultViolation")]
     [InlineData(AsyncViolationPattern.SyncOverAsyncWait, "WaitViolation")]
-    [InlineData(AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult, "GetAwaiterGetResultViolation")]
+    [InlineData(AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult, ".GetAwaiterGetResultViolation")]
     [InlineData(AsyncViolationPattern.AsyncVoid, "AsyncVoidViolation")]
     [InlineData(AsyncViolationPattern.MissingAwait, "MissingAwaitViolation")]
     [InlineData(AsyncViolationPattern.FireAndForget, "FireAndForgetViolation")]
@@ -36,6 +36,16 @@ public class FindAsyncViolationsToolTests : IAsyncLifetime
             v.ContainingMethod.EndsWith(methodName, StringComparison.Ordinal)).ToList();
 
         Assert.Single(hits);
+    }
+
+    [Fact]
+    public void DetectsConfiguredAwaiter_GetResult()
+    {
+        var result = FindAsyncViolationsLogic.Execute(_loaded, _resolver);
+
+        Assert.Contains(result.Violations, v =>
+            v.Pattern == AsyncViolationPattern.SyncOverAsyncGetAwaiterGetResult &&
+            v.ContainingMethod.EndsWith("ConfiguredGetAwaiterGetResultViolation", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
@@ -1,6 +1,7 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
+using RoslynCodeLens.TestDiscovery;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -114,8 +115,13 @@ public class FindUncoveredSymbolsToolTests : IAsyncLifetime
     {
         var result = FindUncoveredSymbolsLogic.Execute(_loaded, _resolver);
 
+        var testProjectNames = TestProjectDetector
+            .GetTestProjectIds(_loaded.Solution)
+            .Select(id => _loaded.Solution.GetProject(id)!.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
         Assert.DoesNotContain(result.UncoveredSymbols, s =>
-            s.Project.EndsWith("Fixture", StringComparison.Ordinal));
+            testProjectNames.Contains(s.Project));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

New MCP tool `find_async_violations` — detects six classes of async/await misuse across non-test projects and returns a summary plus a per-violation list with severity (error/warning).

## Patterns detected

| Pattern enum | Severity | What it catches |
|-------------|---------|----------------|
| `SyncOverAsyncResult` | error | `someTask.Result` access on `Task` / `Task<T>` / `ValueTask<T>` |
| `SyncOverAsyncWait` | error | `Task.Wait()` / `Task.WaitAll()` / `Task.WaitAny()` |
| `SyncOverAsyncGetAwaiterGetResult` | error | `.GetResult()` on `TaskAwaiter` / `ConfiguredTaskAwaitable.ConfiguredTaskAwaiter` / `ValueTaskAwaiter` / `ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter` (and generic variants) |
| `AsyncVoid` | error | `async void` declarations not matching event-handler signature `(object, EventArgs-derived)` |
| `MissingAwait` | warning | `Task`-returning bare expression statement inside an `async` method body |
| `FireAndForget` | warning | `Task`-returning bare expression statement inside a non-async method body |

Sort: severity ASC (errors first), then file ASC, then line ASC.

## What's in this PR

| Layer | Files |
|------|-------|
| Refactors (test-fix) | `Result_DoesNotIncludeTestProjectMembers` in `FindUncoveredSymbolsToolTests` switched from fragile `EndsWith(""Fixture"")` heuristic to `TestProjectDetector` (closes M5 from PR #124's review) |
| Models | `Models/{AsyncViolation, AsyncViolationPattern, AsyncViolationSeverity, AsyncViolationSummary, FindAsyncViolationsResult}.cs` |
| Logic + tool | `Tools/FindAsyncViolations{Logic, Tool}.cs` |
| Fixtures | new `AsyncFixture` production project (no test framework refs) with positive cases for each pattern + negative cases (proper await, event-handler async void, discards, assignments, return-forwarding, ValueTask<T>.Result, Configured ValueTask awaiter) |
| Tests | 18 cases across [Theory] + [Fact]s; all pass |
| Benchmark | `find_async_violations: whole solution` |
| Docs | SKILL.md routing + features, README features list, CLAUDE.md tool count 24 → 25 |

## Test plan

- [x] `dotnet build` — 0 errors
- [x] Filtered: 18/18 `FindAsyncViolationsToolTests` pass
- [x] `dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release` — 0 errors

Test coverage:
- Each of the 6 patterns has a positive case asserted exactly-once via `[Theory]`
- Configured awaiter variant locked in via dedicated `[Fact] DetectsConfiguredAwaiter_GetResult`
- ValueTask<T>.Result locked in via `[Fact] DetectsResult_OnValueTask`
- Properly-awaited Tasks: not flagged
- Event-handler `async void` (`(object, EventArgs)`): not flagged
- Discards (`_ = ...`) and assignments (`var t = ...`): not flagged
- Non-async `return SomeAsync();` forwarding: not flagged
- Test-project members: not flagged (uses `TestProjectDetector` directly)
- Sort order: severity ASC, file ASC, line ASC
- Summary counts (totalViolations, byPattern, bySeverity) match the violations list

## Hardcoded constants (per design)

- No tool parameters; no env vars (matches the rest of this codebase's convention)
- Severity per pattern: hardcoded — every team agrees on these
- `SnippetMaxLength = 80`
- Skip test projects (via `TestProjectDetector`), generated code (`<auto-generated>` header / `.g.cs` / `.designer.cs`), compiler-generated members

## Known follow-ups (deferred, non-blocking)

Surfaced by code review, intentionally deferred to keep this PR focused:

- **Lambda / local-function async-ness mislabeling** — when a bare Task expression statement lives inside a nested lambda or local function, the pattern label uses the OUTER method's `async` modifier. Severity is preserved (both labels are warnings); only the pattern name is wrong in this nested case. Cheap fix: walk up to nearest enclosing method/lambda/local-function.
- **`MA0051` method-too-long** on `Execute` (151 lines) — pre-existing pattern in `PeekIlLogic`. Worth extracting per-method-decl walker into a helper.
- **`MA0006` string `==`/`!=` on `Identifier.Text`** — cosmetic; analyzer prefers `string.Equals(Ordinal)`.
- **No analysis of async lambdas / local functions as standalone units** — design explicitly scoped to `MethodDeclarationSyntax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)