### PR TITLE
feat: add find_event_subscribers MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 29 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 30 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 
 - **find_implementations** — Find all classes/structs implementing an interface or extending a class
 - **find_callers** — Find every call site for a method, property, or constructor
+- **find_event_subscribers** — Every += / -= site for an event symbol, with resolved handler and subscribe/unsubscribe tag
 - **find_tests_for_symbol** — List xUnit/NUnit/MSTest methods that exercise a production symbol; opt-in transitive walk through helpers
 - **find_uncovered_symbols** — Public methods and properties no test transitively reaches; sorted by cyclomatic complexity for prioritization
 - **get_type_hierarchy** — Walk base classes, interfaces, and derived types

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -95,6 +95,13 @@ public class CodeGraphBenchmarks
         return FindCallersLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
     }
 
+    [Benchmark(Description = "find_event_subscribers: Clicked")]
+    public object FindEventSubscribers()
+    {
+        return FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+    }
+
     [Benchmark(Description = "find_tests_for_symbol: IGreeter.Greet")]
     public object FindTestsForSymbol()
     {

--- a/docs/plans/2026-04-29-find-event-subscribers-design.md
+++ b/docs/plans/2026-04-29-find-event-subscribers-design.md
@@ -1,0 +1,153 @@
+# `find_event_subscribers` Design
+
+**Status:** Approved 2026-04-29
+
+## Goal
+
+Given an event symbol (source or metadata), find every `+=` and `-=` site across the solution. Each site reports its source location, the resolved handler, and whether it's a subscribe or unsubscribe.
+
+## Use cases
+
+- "Who's listening to `Button.Click`?" — UI event subscriber audit.
+- "Who registers for `IMessageBus.MessageReceived`?" — interface-event dispatch.
+- "Find subscribed-but-not-unsubscribed pairs for `LongLivedService.DataChanged`" — memory-leak hunt; caller diffs subscribe vs. unsubscribe sites client-side.
+
+## API
+
+```csharp
+IReadOnlyList<EventSubscriberInfo> Execute(
+    string symbol  // e.g. "MyClass.Clicked" or "System.Diagnostics.Process.Exited"
+)
+```
+
+## Output
+
+```csharp
+public record EventSubscriberInfo(
+    string EventName,         // fully-qualified event name
+    string HandlerName,       // method FQN, or "<lambda at File.cs:42>"
+    SubscriptionKind Kind,    // Subscribe | Unsubscribe
+    string FilePath,
+    int Line,
+    string Snippet,           // the += / -= line text
+    string Project,
+    bool IsGenerated);
+
+public enum SubscriptionKind { Subscribe, Unsubscribe }
+```
+
+Flat list, sorted by `(FilePath, Line)` ordinal. Mirrors `CallerInfo` shape from `FindCallersLogic`.
+
+## Architecture
+
+### Symbol resolution
+
+1. Source path: extend `SymbolResolver` with a `FindEvents(string symbol)` method (the existing `FindMethods` only walks methods). Returns `IReadOnlyList<IEventSymbol>`.
+2. Metadata fallback: when source resolution returns empty, call `MetadataSymbolResolver.Resolve(symbol)` and accept the result if it's an `IEventSymbol`. Same pattern as `FindCallersLogic.cs:13-28`.
+3. Build a target set (`HashSet<IEventSymbol>` with `SymbolEqualityComparer.Default`) plus a `targetMetadataKeys` set keyed by `{ContainingTypeFqn}.{EventName}` for cross-compilation metadata matches.
+
+### Walk
+
+For each compilation's syntax trees, find `AssignmentExpressionSyntax` where `node.Kind() is AddAssignmentExpression or SubtractAssignmentExpression`.
+
+### Match
+
+Resolve `asg.Left` via `SemanticModel.GetSymbolInfo` to `IEventSymbol`. Compare against the target set:
+- Direct equality (`SymbolEqualityComparer.Default`).
+- `OriginalDefinition` equality (for generic instantiations).
+- Cross-compilation metadata fallback (compare by `{ContainingTypeFqn}.{EventName}`).
+- Interface-implementation fallback: if target is an interface event and the LHS resolves to an implementation, accept. Mirrors `FindCallersLogic.IsInterfaceImplementation`.
+
+### Handler resolution
+
+Examine `asg.Right`:
+
+| Right-hand side | Handler representation |
+|---|---|
+| `IdentifierNameSyntax` (method group) → resolves to `IMethodSymbol` | `IMethodSymbol.ToDisplayString()` (FQN with parameter types) |
+| `MemberAccessExpressionSyntax` (qualified method group) → `IMethodSymbol` | Same |
+| `LambdaExpressionSyntax` | `<lambda at {FilePath}:{Line}>` |
+| `AnonymousMethodExpressionSyntax` (`delegate (s, e) { ... }`) | `<anonymous-method at {FilePath}:{Line}>` |
+| Anything else (rare: indexer return, ternary, method invocation returning a delegate) | `<expression at {FilePath}:{Line}>` |
+
+### Build entry
+
+- `FilePath`, `Line` — from `asg.GetLocation().GetLineSpan()`.
+- `Snippet` — `asg.ToString()` (single-line statement-level snippet).
+- `Project` — from the iterating compilation's project.
+- `IsGenerated` — `SymbolResolver.IsGenerated(file)`.
+- Dedup by `(file, span)` (not `(file, line)`) so two `+=` on the same line both register.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Interface event with multiple implementations | Match all impls via `IsInterfaceImplementation` fallback |
+| Generic event types / instantiations | `SymbolEqualityComparer.Default` matches `OriginalDefinition`; works |
+| Cross-compilation metadata symbols | Name-based fallback (same as `FindCallersLogic.BuildMetadataKeys`) |
+| Test projects | Included (consistent with `find_callers`) |
+| Generated code | Included with `IsGenerated: true` flag |
+| `obj.E += a; obj.E += b;` on same line | Both entries — dedup by `(file, span)` not `(file, line)` |
+| `event` declaration with explicit `add`/`remove` accessors | Source resolution finds the declaration; subscriptions are still `+=` syntax |
+
+## MCP wrapper
+
+Standard pattern matching `find_callers`:
+
+```csharp
+[McpServerToolType]
+public static class FindEventSubscribersTool
+{
+    [McpServerTool(Name = "find_event_subscribers")]
+    [Description(...)]
+    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        MultiSolutionManager manager,
+        string symbol)
+    { ... }
+}
+```
+
+Auto-registered via `WithToolsFromAssembly()` — no `Program.cs` edit.
+
+## Testing
+
+Fixture additions to `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/`:
+- `EventSubscriberSamples.cs` — class declaring an event, multiple subscribers across method-group / lambda / anonymous-method patterns, a subscribe+unsubscribe pair, an interface event with two implementations.
+
+Tests:
+
+| Test | Asserts |
+|---|---|
+| `Subscribe_MethodGroup_ReportsHandlerFqn` | Handler name is the method's FQN |
+| `Subscribe_Lambda_ReportsSyntheticName` | Handler name starts with `<lambda` |
+| `Subscribe_AnonymousMethod_ReportsSyntheticName` | Handler name starts with `<anonymous-method` |
+| `Unsubscribe_TaggedAsUnsubscribe` | `Kind == Unsubscribe` for `-=` sites |
+| `ExternalEvent_FullyQualified_FindsSubscriptions` | Subscriber to e.g. `Console.CancelKeyPress` is found via FQN |
+| `InterfaceEvent_MatchesImplementations` | Subscribers via the implementation type are still found when querying the interface event |
+| `UnknownSymbol_ReturnsEmpty` | Empty list, no exception |
+| `Result_SortedByFileLine` | Sort invariant holds |
+| `Result_HasGeneratedFlag` | A subscription in a generated file gets `IsGenerated: true` |
+
+## Performance
+
+Benchmark added: `find_event_subscribers: known event`. Expected to be similar to `find_callers` — same per-tree syntax walk + semantic resolution.
+
+## Out of scope (deferred)
+
+- Static-analysis leak detection (subscribed-but-not-unsubscribed): caller can compute client-side from result.
+- Reflection-based subscriptions (`event.AddEventHandler(target, delegate)`).
+- Source-generator-emitted subscriptions only appear if the generated code is loaded — same as other tools.
+
+## File checklist
+
+- `src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs`
+- `src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs`
+- `src/RoslynCodeLens/Models/EventSubscriberInfo.cs`
+- `src/RoslynCodeLens/Models/SubscriptionKind.cs`
+- `src/RoslynCodeLens/Symbols/SymbolResolver.cs` — add `FindEvents` method
+- `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/EventSubscriberSamples.cs`
+- `tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs`
+- `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs` — add benchmark
+- `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` — Red Flags, Quick Reference, Navigating Code
+- `README.md` — Features list
+- `CLAUDE.md` — bump tool count

--- a/docs/plans/2026-04-29-find-event-subscribers.md
+++ b/docs/plans/2026-04-29-find-event-subscribers.md
@@ -1,0 +1,757 @@
+# `find_event_subscribers` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new MCP tool `find_event_subscribers` that finds every `+=` and `-=` site for a given event symbol (source or metadata). Each result reports source location, resolved handler, and subscription kind.
+
+**Architecture:** Walk all syntax trees for `AssignmentExpressionSyntax` whose kind is `AddAssignmentExpression` or `SubtractAssignmentExpression`. Resolve LHS to `IEventSymbol`, match against target event (with cross-compilation metadata + interface-implementation fallbacks). Resolve RHS handler — method group → `IMethodSymbol` FQN, lambda/anonymous → synthesized `<lambda at File.cs:N>`. Mirrors `FindCallersLogic` for matching strategy.
+
+**Tech Stack:** Roslyn (`Microsoft.CodeAnalysis`, `Microsoft.CodeAnalysis.CSharp.Syntax`), xUnit, BenchmarkDotNet, ModelContextProtocol.Server.
+
+**Reference design:** `docs/plans/2026-04-29-find-event-subscribers-design.md`
+
+**Patterns to mirror (read these before starting):**
+- Tool wrapper: `src/RoslynCodeLens/Tools/FindCallersTool.cs`
+- Logic class with metadata-fallback + interface-impl matching: `src/RoslynCodeLens/Tools/FindCallersLogic.cs`
+- `SymbolResolver.FindMethods`: `src/RoslynCodeLens/SymbolResolver.cs:215-230` (mirror this for `FindEvents`)
+- Existing event handling for inspiration: `src/RoslynCodeLens/Tools/PublicApiSurfaceExtractor.cs:252` (`IEventSymbol` case)
+- MCP auto-registration: `src/RoslynCodeLens/Program.cs:35` uses `WithToolsFromAssembly()` — no `Program.cs` edit needed
+
+---
+
+## Task 1: Add `SymbolResolver.FindEvents`
+
+**Files:**
+- Modify: `src/RoslynCodeLens/SymbolResolver.cs`
+
+**Step 1: Add the method** immediately after `FindMethods`:
+
+```csharp
+public IReadOnlyList<IEventSymbol> FindEvents(string symbol)
+{
+    var results = new List<IEventSymbol>();
+    var parts = symbol.Split('.');
+    if (parts.Length < 2) return results;
+
+    var typeName = string.Join('.', parts[..^1]);
+    var eventName = parts[^1];
+
+    foreach (var type in FindNamedTypes(typeName))
+    {
+        results.AddRange(type.GetMembers(eventName).OfType<IEventSymbol>());
+    }
+
+    return results;
+}
+```
+
+**Step 2: Build to verify**
+
+```bash
+dotnet build src/RoslynCodeLens
+```
+
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add src/RoslynCodeLens/SymbolResolver.cs
+git commit -m "feat: add SymbolResolver.FindEvents helper"
+```
+
+---
+
+## Task 2: Models
+
+Two files: enum + record.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/SubscriptionKind.cs`
+- Create: `src/RoslynCodeLens/Models/EventSubscriberInfo.cs`
+
+**Step 1: `SubscriptionKind.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public enum SubscriptionKind
+{
+    Subscribe,
+    Unsubscribe
+}
+```
+
+**Step 2: `EventSubscriberInfo.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record EventSubscriberInfo(
+    string EventName,
+    string HandlerName,
+    SubscriptionKind Kind,
+    string FilePath,
+    int Line,
+    string Snippet,
+    string Project,
+    bool IsGenerated);
+```
+
+**Step 3: Build**
+
+```bash
+dotnet build src/RoslynCodeLens
+```
+
+Expected: 0 errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/RoslynCodeLens/Models/SubscriptionKind.cs \
+  src/RoslynCodeLens/Models/EventSubscriberInfo.cs
+git commit -m "feat: add models for find_event_subscribers"
+```
+
+---
+
+## Task 3: Test fixture for event subscribers
+
+Self-contained fixture covering: method-group subscribe, lambda subscribe, anonymous-method subscribe, subscribe+unsubscribe pair, interface event with two implementations, two `+=` on the same line.
+
+**Files:**
+- Create: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/EventSubscriberSamples.cs`
+
+**Step 1: Create the fixture**
+
+```csharp
+using System;
+
+namespace TestLib;
+
+public class EventPublisher
+{
+    public event EventHandler? Clicked;
+    public event EventHandler? Clicked2;
+    public void Raise() => Clicked?.Invoke(this, EventArgs.Empty);
+}
+
+public interface IBusEventPublisher
+{
+    event EventHandler? MessageReceived;
+}
+
+public class BusA : IBusEventPublisher
+{
+    public event EventHandler? MessageReceived;
+}
+
+public class BusB : IBusEventPublisher
+{
+    public event EventHandler? MessageReceived;
+}
+
+public class EventSubscriberSamples
+{
+    private readonly EventPublisher _publisher = new();
+    private readonly BusA _busA = new();
+    private readonly BusB _busB = new();
+
+    public void SubscribeMethodGroup()
+    {
+        _publisher.Clicked += OnClicked;
+    }
+
+    public void UnsubscribeMethodGroup()
+    {
+        _publisher.Clicked -= OnClicked;
+    }
+
+    public void SubscribeLambda()
+    {
+        _publisher.Clicked += (s, e) => { };
+    }
+
+    public void SubscribeAnonymousMethod()
+    {
+        _publisher.Clicked += delegate (object? s, EventArgs e) { };
+    }
+
+    public void SubscribeBothBuses()
+    {
+        _busA.MessageReceived += OnBusMessage;
+        _busB.MessageReceived += OnBusMessage;
+    }
+
+    public void TwoSubscriptionsOnSameLine()
+    {
+        _publisher.Clicked += OnClicked; _publisher.Clicked2 += OnClicked;
+    }
+
+    private void OnClicked(object? sender, EventArgs e) { }
+    private void OnBusMessage(object? sender, EventArgs e) { }
+}
+```
+
+**Step 2: Build**
+
+```bash
+dotnet build tests/RoslynCodeLens.Tests
+```
+
+Expected: 0 errors.
+
+**Step 3: Run existing tests** (sanity — adding fixture types shouldn't break anything):
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetPublicApiSurfaceToolTests"
+```
+
+Expected: all green.
+
+**Step 4: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/EventSubscriberSamples.cs
+git commit -m "test: add EventSubscriberSamples fixture"
+```
+
+---
+
+## Task 4: `FindEventSubscribersLogic` with comprehensive tests (TDD)
+
+The walker. Source + metadata symbol resolution, interface-impl matching, handler resolution, subscribe/unsubscribe tagging, dedup by `(file, span)`.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs`
+- Create: `tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs`
+
+**Step 1: Write the failing tests**
+
+`tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs`:
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class FindEventSubscribersToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void UnknownSymbol_ReturnsEmpty()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "Does.Not.Exist");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Subscribe_MethodGroup_ReportsHandlerFqn()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        var match = Assert.Single(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.Contains("OnClicked", StringComparison.Ordinal) &&
+            r.FilePath.EndsWith("EventSubscriberSamples.cs", StringComparison.Ordinal) &&
+            !r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+
+        Assert.True(match.Line > 0);
+        Assert.Equal("TestLib", match.Project);
+    }
+
+    [Fact]
+    public void Subscribe_Lambda_ReportsSyntheticName()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.StartsWith("<lambda at ", StringComparison.Ordinal) &&
+            r.HandlerName.Contains("EventSubscriberSamples.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Subscribe_AnonymousMethod_ReportsSyntheticName()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.StartsWith("<anonymous-method at ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Unsubscribe_TaggedAsUnsubscribe()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Unsubscribe &&
+            r.HandlerName.Contains("OnClicked", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InterfaceEvent_MatchesImplementations()
+    {
+        // Query the interface event; subscribers via BusA/BusB should both surface.
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "IBusEventPublisher.MessageReceived");
+
+        // Subscribers go through BusA.MessageReceived and BusB.MessageReceived (concrete impls).
+        // Either we match via the interface event symbol set + implementation fallback, OR
+        // the fallback reaches the impl events through `FindEvents("IBusEventPublisher.MessageReceived")`.
+        // At minimum: at least 2 subscriptions found across BusA/BusB.
+        Assert.True(results.Count >= 2,
+            $"Expected >=2 subscribers across implementations, got {results.Count}");
+    }
+
+    [Fact]
+    public void TwoSubscriptionsOnSameLine_BothReported()
+    {
+        var clickedResults = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+        var clicked2Results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked2");
+
+        // The TwoSubscriptionsOnSameLine method has BOTH events += on one source line.
+        // Each event query must find its subscription in TwoSubscriptionsOnSameLine.
+        Assert.Contains(clickedResults, r =>
+            r.Snippet.Contains("Clicked", StringComparison.Ordinal) &&
+            !r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+        Assert.Contains(clicked2Results, r =>
+            r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Result_SortedByFileLine()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        for (int i = 1; i < results.Count; i++)
+        {
+            var prev = results[i - 1];
+            var curr = results[i];
+            var fileCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+            Assert.True(
+                fileCmp < 0 || (fileCmp == 0 && prev.Line <= curr.Line),
+                $"Sort violation at {i}: '{prev.FilePath}:{prev.Line}' before '{curr.FilePath}:{curr.Line}'");
+        }
+    }
+
+    [Fact]
+    public void EventName_IsFullyQualified()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.NotEmpty(results);
+        foreach (var r in results)
+        {
+            Assert.Contains("Clicked", r.EventName, StringComparison.Ordinal);
+            Assert.NotEmpty(r.Project);
+        }
+    }
+}
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindEventSubscribersToolTests"
+```
+
+Expected: compile error — `FindEventSubscribersLogic` doesn't exist.
+
+**Step 3: Create `src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs`**
+
+```csharp
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class FindEventSubscribersLogic
+{
+    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+    {
+        var targetEvents = source.FindEvents(symbol);
+        if (targetEvents.Count == 0)
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved?.Symbol is IEventSymbol e)
+                targetEvents = [e];
+            else
+                return [];
+        }
+
+        var targetSet = new HashSet<IEventSymbol>(targetEvents, SymbolEqualityComparer.Default);
+        var targetMetadataKeys = BuildMetadataKeys(targetEvents);
+        var results = new List<EventSubscriberInfo>();
+        var seen = new HashSet<(string, TextSpan)>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            var projectName = source.GetProjectName(projectId);
+
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var root = syntaxTree.GetRoot();
+
+                foreach (var asg in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+                {
+                    var kind = asg.Kind() switch
+                    {
+                        SyntaxKind.AddAssignmentExpression => SubscriptionKind.Subscribe,
+                        SyntaxKind.SubtractAssignmentExpression => SubscriptionKind.Unsubscribe,
+                        _ => (SubscriptionKind?)null
+                    };
+                    if (kind is null) continue;
+
+                    if (semanticModel.GetSymbolInfo(asg.Left).Symbol is not IEventSymbol called)
+                        continue;
+                    if (!IsEventMatch(called, targetSet, targetEvents, targetMetadataKeys))
+                        continue;
+
+                    if (!seen.Add((syntaxTree.FilePath, asg.Span)))
+                        continue;
+
+                    var lineSpan = asg.GetLocation().GetLineSpan();
+                    var file = lineSpan.Path;
+                    var line = lineSpan.StartLinePosition.Line + 1;
+                    var handler = ResolveHandlerName(asg.Right, semanticModel, file, line);
+
+                    results.Add(new EventSubscriberInfo(
+                        EventName: called.ToDisplayString(),
+                        HandlerName: handler,
+                        Kind: kind.Value,
+                        FilePath: file,
+                        Line: line,
+                        Snippet: asg.ToString(),
+                        Project: projectName,
+                        IsGenerated: source.IsGenerated(file)));
+                }
+            }
+        }
+
+        results.Sort((a, b) =>
+        {
+            var fileCmp = string.CompareOrdinal(a.FilePath, b.FilePath);
+            return fileCmp != 0 ? fileCmp : a.Line.CompareTo(b.Line);
+        });
+
+        return results;
+    }
+
+    private static HashSet<string> BuildMetadataKeys(IReadOnlyList<IEventSymbol> events)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var e in events)
+        {
+            if (e.Locations.All(l => !l.IsInSource))
+            {
+                var typeName = e.ContainingType?.ToDisplayString() ?? string.Empty;
+                keys.Add($"{typeName}.{e.Name}");
+            }
+        }
+        return keys;
+    }
+
+    private static bool IsEventMatch(
+        IEventSymbol called,
+        HashSet<IEventSymbol> targetSet,
+        IReadOnlyList<IEventSymbol> targetEvents,
+        HashSet<string> targetMetadataKeys)
+    {
+        if (targetSet.Contains(called) || targetSet.Contains((IEventSymbol)called.OriginalDefinition))
+            return true;
+
+        if (targetMetadataKeys.Count > 0 && called.Locations.All(l => !l.IsInSource))
+        {
+            var typeName = (called.OriginalDefinition.ContainingType ?? called.ContainingType)
+                ?.ToDisplayString() ?? string.Empty;
+            if (targetMetadataKeys.Contains($"{typeName}.{called.Name}"))
+                return true;
+        }
+
+        for (int i = 0; i < targetEvents.Count; i++)
+        {
+            if (!string.Equals(called.Name, targetEvents[i].Name, StringComparison.Ordinal))
+                continue;
+            if (IsInterfaceImplementation(called, targetEvents[i]))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsInterfaceImplementation(IEventSymbol called, IEventSymbol target)
+    {
+        if (target.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            if (SymbolEqualityComparer.Default.Equals(called, target))
+                return true;
+
+            var containingType = called.ContainingType;
+            var implementation = containingType.FindImplementationForInterfaceMember(target);
+            if (implementation != null &&
+                SymbolEqualityComparer.Default.Equals(implementation, called))
+                return true;
+        }
+
+        if (called.ContainingType.TypeKind == TypeKind.Interface &&
+            target.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            return SymbolEqualityComparer.Default.Equals(
+                       called.ContainingType, target.ContainingType) &&
+                   string.Equals(called.Name, target.Name, StringComparison.Ordinal);
+        }
+
+        return false;
+    }
+
+    private static string ResolveHandlerName(
+        ExpressionSyntax rhs, SemanticModel semanticModel, string file, int line)
+    {
+        switch (rhs)
+        {
+            case LambdaExpressionSyntax:
+                return $"<lambda at {file}:{line}>";
+
+            case AnonymousMethodExpressionSyntax:
+                return $"<anonymous-method at {file}:{line}>";
+
+            case IdentifierNameSyntax or MemberAccessExpressionSyntax:
+                if (semanticModel.GetSymbolInfo(rhs).Symbol is IMethodSymbol m)
+                    return m.ToDisplayString();
+                break;
+        }
+
+        return $"<expression at {file}:{line}>";
+    }
+}
+```
+
+Note: `TextSpan` is in `Microsoft.CodeAnalysis.Text`. Add the using if the build complains.
+
+**Step 4: Run the tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindEventSubscribersToolTests" -v normal
+```
+
+Expected: all 9 tests pass.
+
+**Common debugging:**
+- If `Subscribe_MethodGroup` has the wrong handler name: `IdentifierNameSyntax` resolves via `GetSymbolInfo` only when it's a method group; if the rhs is `OnClicked` (no args), `GetSymbolInfo` returns the method symbol — good.
+- If `InterfaceEvent_MatchesImplementations` returns 0: check `IsInterfaceImplementation` — `BusA.MessageReceived` is an explicit re-declaration, not a `FindImplementationForInterfaceMember` hit. The fallback may need to also accept "same name + same containing-interface in the type's interface list."
+- If lambda test fails because handler name is from `GetSymbolInfo`: ensure the `LambdaExpressionSyntax` case is BEFORE the generic `GetSymbolInfo` fallthrough.
+- If duplicate entries appear: the dedup key `(filePath, asg.Span)` should prevent it; ensure `syntaxTree.FilePath` is non-null.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs \
+  tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
+git commit -m "feat: add FindEventSubscribersLogic with += / -= site detection"
+```
+
+---
+
+## Task 5: `FindEventSubscribersTool` MCP wrapper
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs`
+
+**Step 1: Create the wrapper**
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class FindEventSubscribersTool
+{
+    [McpServerTool(Name = "find_event_subscribers")]
+    [Description(
+        "Find every += and -= site for an event symbol across the solution. " +
+        "Accepts source events (e.g. 'MyClass.Clicked') or metadata events " +
+        "(e.g. 'System.Diagnostics.Process.Exited'). " +
+        "Each result reports the source location, the resolved handler (method FQN, " +
+        "or '<lambda at File.cs:N>' for inline handlers), and the subscription kind " +
+        "(Subscribe for +=, Unsubscribe for -=). " +
+        "Use this for memory-leak audits (compare subscribe/unsubscribe pairs), " +
+        "UI event subscriber inspection, or when Grep over '+= EventName' would miss " +
+        "qualified or fully-typed subscription sites. " +
+        "Sort: file path ASC then line ASC.")]
+    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        MultiSolutionManager manager,
+        [Description("Event symbol (e.g. 'MyClass.Clicked' or 'System.Diagnostics.Process.Exited')")]
+        string symbol)
+    {
+        manager.EnsureLoaded();
+        return FindEventSubscribersLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            symbol);
+    }
+}
+```
+
+**Step 2: Build the whole solution**
+
+```bash
+dotnet build
+```
+
+Expected: 0 errors. Auto-registration via `Program.cs:35`.
+
+**Step 3: Run targeted tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindEventSubscribersToolTests" -v normal
+```
+
+Expected: 9/9 pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
+git commit -m "feat: register find_event_subscribers MCP tool"
+```
+
+---
+
+## Task 6: Add benchmark
+
+**Files:**
+- Modify: `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs`
+
+**Step 1:** Find the `find_callers: IGreeter.Greet` benchmark and add the new one immediately after.
+
+```csharp
+[Benchmark(Description = "find_event_subscribers: Clicked")]
+public object FindEventSubscribers()
+{
+    return FindEventSubscribersLogic.Execute(
+        _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+}
+```
+
+**Step 2: Build the benchmarks project**
+
+```bash
+dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release
+```
+
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+git commit -m "bench: add find_event_subscribers benchmark"
+```
+
+---
+
+## Task 7: Update SKILL.md, README, CLAUDE.md
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Step 1: SKILL.md — Red Flags routing table**
+
+Add near `find_callers`:
+
+```
+| "Who subscribes to this event?" / "Find += sites" / "Are we leaking event subscriptions?" | `find_event_subscribers` |
+```
+
+**Step 2: SKILL.md — Quick Reference table**
+
+Add near `find_callers`:
+
+```
+| `find_event_subscribers` | "Who subscribes to this event?" |
+```
+
+**Step 3: SKILL.md — Navigating Code section**
+
+Add as a new bullet near `find_callers`:
+
+```
+- `find_event_subscribers` — Every += / -= site for an event symbol, with resolved handler name and subscribe/unsubscribe tag. Use for UI-event audits or memory-leak hunts (compare subscribe/unsubscribe pairs).
+```
+
+**Step 4: README.md Features list**
+
+Add near `find_callers`:
+
+```
+- **find_event_subscribers** — Every += / -= site for an event symbol, with resolved handler and subscribe/unsubscribe tag.
+```
+
+**Step 5: CLAUDE.md — bump tool count**
+
+Change "29 code intelligence tools" to "30 code intelligence tools".
+
+**Step 6: Sanity check**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "FindEventSubscribersToolTests" -v normal
+```
+
+Expected: 9/9 pass.
+
+**Step 7: Commit**
+
+```bash
+git add plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md \
+  README.md \
+  CLAUDE.md
+git commit -m "docs: announce find_event_subscribers in SKILL.md, README, CLAUDE.md"
+```
+
+---
+
+## Done
+
+After Task 7 the branch should have ~9 commits (design + plan + 7 implementation tasks), all `FindEventSubscribersToolTests` green, the benchmark project compiling, and the tool auto-registered. From there: `/superpowers:requesting-code-review` → PR.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -31,6 +31,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 |---|---|
 | "Let me `Grep` for `class Foo`" | `search_symbols` or `go_to_definition` |
 | "Let me `Grep` for `Foo\\.Bar\\(`" (finding callers) | `find_callers` |
+| "Who subscribes to this event?" / "Find += sites" / "Are we leaking event subscriptions?" | `find_event_subscribers` |
 | "What does this method end up calling?" / "Show me the transitive callees" / "What's the blast radius for changing X?" | `get_call_graph` |
 | "Let me `Grep` for `: IFoo`" (finding implementations) | `find_implementations` |
 | "Let me `Grep` for `new Foo(`" | `find_references` |
@@ -118,6 +119,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 
 ### Finding Dependencies and Usage
 - `find_callers` — every call site for a method.
+- `find_event_subscribers` — every += / -= site for an event symbol, with resolved handler name and subscribe/unsubscribe tag. Use for UI-event audits or memory-leak hunts (compare subscribe/unsubscribe pairs).
 - `find_implementations` — all implementors of an interface / extenders of a class.
 - `find_tests_for_symbol` — xUnit/NUnit/MSTest methods that exercise a production symbol; opt-in transitive walk through helpers.
 - `find_uncovered_symbols` — Public methods and properties no test transitively reaches (≤ 3 helper hops); sorted by cyclomatic complexity for prioritization. Strict reference-based: an override is not marked covered just because its base or interface declaration is reached — a test calling `IFoo.Bar` does not cover `Foo.Bar`.
@@ -227,6 +229,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 |------|-------------|
 | `find_implementations` | "What implements this interface?" / "What extends this class?" |
 | `find_callers` | "Who calls this method?" / "What depends on this?" |
+| `find_event_subscribers` | "Who subscribes to this event?" |
 | `find_references` | "Where is this symbol used?" / "Show all references" |
 | `find_tests_for_symbol` | "What tests cover this method?" / "Which tests will break if I change X?" |
 | `find_uncovered_symbols` | "What should I write tests for?" / "Where's our testing debt?" |

--- a/src/RoslynCodeLens/Models/EventSubscriberInfo.cs
+++ b/src/RoslynCodeLens/Models/EventSubscriberInfo.cs
@@ -1,0 +1,11 @@
+namespace RoslynCodeLens.Models;
+
+public record EventSubscriberInfo(
+    string EventName,
+    string HandlerName,
+    SubscriptionKind Kind,
+    string FilePath,
+    int Line,
+    string Snippet,
+    string Project,
+    bool IsGenerated);

--- a/src/RoslynCodeLens/Models/SubscriptionKind.cs
+++ b/src/RoslynCodeLens/Models/SubscriptionKind.cs
@@ -1,0 +1,7 @@
+namespace RoslynCodeLens.Models;
+
+public enum SubscriptionKind
+{
+    Subscribe,
+    Unsubscribe
+}

--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -229,6 +229,23 @@ public class SymbolResolver
         return results;
     }
 
+    public IReadOnlyList<IEventSymbol> FindEvents(string symbol)
+    {
+        var results = new List<IEventSymbol>();
+        var parts = symbol.Split('.');
+        if (parts.Length < 2) return results;
+
+        var typeName = string.Join('.', parts[..^1]);
+        var eventName = parts[^1];
+
+        foreach (var type in FindNamedTypes(typeName))
+        {
+            results.AddRange(type.GetMembers(eventName).OfType<IEventSymbol>());
+        }
+
+        return results;
+    }
+
     public static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
     {
         return ns.GetTypeMembers().SelectMany(GetAllNestedTypes)

--- a/src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindEventSubscribersLogic.cs
@@ -1,0 +1,183 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class FindEventSubscribersLogic
+{
+    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        LoadedSolution loaded, SymbolResolver source, MetadataSymbolResolver metadata, string symbol)
+    {
+        var targetEvents = source.FindEvents(symbol);
+        if (targetEvents.Count == 0)
+        {
+            var resolved = metadata.Resolve(symbol);
+            if (resolved?.Symbol is IEventSymbol e)
+                targetEvents = [e];
+            else
+                return [];
+        }
+
+        var targetSet = new HashSet<IEventSymbol>(targetEvents, SymbolEqualityComparer.Default);
+        var targetMetadataKeys = BuildMetadataKeys(targetEvents);
+        var results = new List<EventSubscriberInfo>();
+        var seen = new HashSet<(string, TextSpan)>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            var projectName = source.GetProjectName(projectId);
+
+            foreach (var syntaxTree in compilation.SyntaxTrees)
+            {
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+                var root = syntaxTree.GetRoot();
+
+                foreach (var asg in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+                {
+                    var kind = asg.Kind() switch
+                    {
+                        SyntaxKind.AddAssignmentExpression => SubscriptionKind.Subscribe,
+                        SyntaxKind.SubtractAssignmentExpression => SubscriptionKind.Unsubscribe,
+                        _ => (SubscriptionKind?)null
+                    };
+                    if (kind is null) continue;
+
+                    if (semanticModel.GetSymbolInfo(asg.Left).Symbol is not IEventSymbol called)
+                        continue;
+                    if (!IsEventMatch(called, targetSet, targetEvents, targetMetadataKeys))
+                        continue;
+
+                    if (!seen.Add((syntaxTree.FilePath, asg.Span)))
+                        continue;
+
+                    var lineSpan = asg.GetLocation().GetLineSpan();
+                    var file = lineSpan.Path;
+                    var line = lineSpan.StartLinePosition.Line + 1;
+                    var handler = ResolveHandlerName(asg.Right, semanticModel, file, line);
+
+                    var sourceText = syntaxTree.GetText();
+                    var lineText = sourceText.Lines[lineSpan.StartLinePosition.Line].ToString().Trim();
+
+                    results.Add(new EventSubscriberInfo(
+                        EventName: called.ToDisplayString(),
+                        HandlerName: handler,
+                        Kind: kind.Value,
+                        FilePath: file,
+                        Line: line,
+                        Snippet: lineText,
+                        Project: projectName,
+                        IsGenerated: source.IsGenerated(file)));
+                }
+            }
+        }
+
+        results.Sort((a, b) =>
+        {
+            var fileCmp = string.CompareOrdinal(a.FilePath, b.FilePath);
+            return fileCmp != 0 ? fileCmp : a.Line.CompareTo(b.Line);
+        });
+
+        return results;
+    }
+
+    private static HashSet<string> BuildMetadataKeys(IReadOnlyList<IEventSymbol> events)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var e in events)
+        {
+            if (e.Locations.All(l => !l.IsInSource))
+            {
+                var typeName = e.ContainingType?.ToDisplayString() ?? string.Empty;
+                keys.Add($"{typeName}.{e.Name}");
+            }
+        }
+        return keys;
+    }
+
+    private static bool IsEventMatch(
+        IEventSymbol called,
+        HashSet<IEventSymbol> targetSet,
+        IReadOnlyList<IEventSymbol> targetEvents,
+        HashSet<string> targetMetadataKeys)
+    {
+        if (targetSet.Contains(called) || targetSet.Contains((IEventSymbol)called.OriginalDefinition))
+            return true;
+
+        if (targetMetadataKeys.Count > 0 && called.Locations.All(l => !l.IsInSource))
+        {
+            var typeName = (called.OriginalDefinition.ContainingType ?? called.ContainingType)
+                ?.ToDisplayString() ?? string.Empty;
+            if (targetMetadataKeys.Contains($"{typeName}.{called.Name}"))
+                return true;
+        }
+
+        for (int i = 0; i < targetEvents.Count; i++)
+        {
+            if (!string.Equals(called.Name, targetEvents[i].Name, StringComparison.Ordinal))
+                continue;
+            if (IsInterfaceImplementation(called, targetEvents[i]))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsInterfaceImplementation(IEventSymbol called, IEventSymbol target)
+    {
+        if (target.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            if (SymbolEqualityComparer.Default.Equals(called, target))
+                return true;
+
+            var containingType = called.ContainingType;
+            var implementation = containingType.FindImplementationForInterfaceMember(target);
+            if (implementation != null &&
+                SymbolEqualityComparer.Default.Equals(implementation, called))
+                return true;
+        }
+
+        if (called.ContainingType.TypeKind == TypeKind.Interface &&
+            target.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            return SymbolEqualityComparer.Default.Equals(
+                       called.ContainingType, target.ContainingType) &&
+                   string.Equals(called.Name, target.Name, StringComparison.Ordinal);
+        }
+
+        // Last-resort: target is interface event, called is a non-interface event whose containing type
+        // implements the interface (covers explicit re-declarations of interface events).
+        if (target.ContainingType.TypeKind == TypeKind.Interface &&
+            called.ContainingType.TypeKind != TypeKind.Interface &&
+            string.Equals(called.Name, target.Name, StringComparison.Ordinal) &&
+            called.ContainingType.AllInterfaces.Contains(target.ContainingType, SymbolEqualityComparer.Default))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string ResolveHandlerName(
+        ExpressionSyntax rhs, SemanticModel semanticModel, string file, int line)
+    {
+        switch (rhs)
+        {
+            case LambdaExpressionSyntax:
+                return $"<lambda at {file}:{line}>";
+
+            case AnonymousMethodExpressionSyntax:
+                return $"<anonymous-method at {file}:{line}>";
+
+            case IdentifierNameSyntax or MemberAccessExpressionSyntax:
+                if (semanticModel.GetSymbolInfo(rhs).Symbol is IMethodSymbol m)
+                    return m.ToDisplayString();
+                break;
+        }
+
+        return $"<expression at {file}:{line}>";
+    }
+}

--- a/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class FindEventSubscribersTool
+{
+    [McpServerTool(Name = "find_event_subscribers")]
+    [Description(
+        "Find every += and -= site for an event symbol across the solution. " +
+        "Accepts source events (e.g. 'MyClass.Clicked') or metadata events " +
+        "(e.g. 'System.Diagnostics.Process.Exited'). " +
+        "Each result reports the source location, the resolved handler (method FQN, " +
+        "or '<lambda at File.cs:N>' for inline handlers), and the subscription kind " +
+        "(Subscribe for +=, Unsubscribe for -=). " +
+        "Use this for memory-leak audits (compare subscribe/unsubscribe pairs), " +
+        "UI event subscriber inspection, or when Grep over '+= EventName' would miss " +
+        "qualified or fully-typed subscription sites. " +
+        "Sort: file path ASC then line ASC.")]
+    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        MultiSolutionManager manager,
+        [Description("Event symbol (e.g. 'MyClass.Clicked' or 'System.Diagnostics.Process.Exited')")]
+        string symbol)
+    {
+        manager.EnsureLoaded();
+        return FindEventSubscribersLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            symbol);
+    }
+}

--- a/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
@@ -13,7 +13,7 @@ public static class FindEventSubscribersTool
         "Accepts source events (e.g. 'MyClass.Clicked') or metadata events " +
         "(e.g. 'System.Diagnostics.Process.Exited'). " +
         "Each result reports the source location, the resolved handler (method FQN, " +
-        "or '<lambda at File.cs:N>' for inline handlers), and the subscription kind " +
+        "or a synthetic name like 'lambda at File.cs:N' for inline handlers), and the subscription kind " +
         "(Subscribe for +=, Unsubscribe for -=). " +
         "Use this for memory-leak audits (compare subscribe/unsubscribe pairs), " +
         "UI event subscriber inspection, or when Grep over '+= EventName' would miss " +

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/EventSubscriberSamples.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/EventSubscriberSamples.cs
@@ -1,0 +1,66 @@
+using System;
+
+namespace TestLib;
+
+public class EventPublisher
+{
+    public event EventHandler? Clicked;
+    public event EventHandler? Clicked2;
+    public void Raise() => Clicked?.Invoke(this, EventArgs.Empty);
+}
+
+public interface IBusEventPublisher
+{
+    event EventHandler? MessageReceived;
+}
+
+public class BusA : IBusEventPublisher
+{
+    public event EventHandler? MessageReceived;
+}
+
+public class BusB : IBusEventPublisher
+{
+    public event EventHandler? MessageReceived;
+}
+
+public class EventSubscriberSamples
+{
+    private readonly EventPublisher _publisher = new();
+    private readonly BusA _busA = new();
+    private readonly BusB _busB = new();
+
+    public void SubscribeMethodGroup()
+    {
+        _publisher.Clicked += OnClicked;
+    }
+
+    public void UnsubscribeMethodGroup()
+    {
+        _publisher.Clicked -= OnClicked;
+    }
+
+    public void SubscribeLambda()
+    {
+        _publisher.Clicked += (s, e) => { };
+    }
+
+    public void SubscribeAnonymousMethod()
+    {
+        _publisher.Clicked += delegate (object? s, EventArgs e) { };
+    }
+
+    public void SubscribeBothBuses()
+    {
+        _busA.MessageReceived += OnBusMessage;
+        _busB.MessageReceived += OnBusMessage;
+    }
+
+    public void TwoSubscriptionsOnSameLine()
+    {
+        _publisher.Clicked += OnClicked; _publisher.Clicked2 += OnClicked;
+    }
+
+    private void OnClicked(object? sender, EventArgs e) { }
+    private void OnBusMessage(object? sender, EventArgs e) { }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
@@ -1,0 +1,139 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class FindEventSubscribersToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void UnknownSymbol_ReturnsEmpty()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "Does.Not.Exist");
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Subscribe_MethodGroup_ReportsHandlerFqn()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        var match = Assert.Single(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.Contains("OnClicked", StringComparison.Ordinal) &&
+            r.FilePath.EndsWith("EventSubscriberSamples.cs", StringComparison.Ordinal) &&
+            !r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+
+        Assert.True(match.Line > 0);
+        Assert.Equal("TestLib", match.Project);
+    }
+
+    [Fact]
+    public void Subscribe_Lambda_ReportsSyntheticName()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.StartsWith("<lambda at ", StringComparison.Ordinal) &&
+            r.HandlerName.Contains("EventSubscriberSamples.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Subscribe_AnonymousMethod_ReportsSyntheticName()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Subscribe &&
+            r.HandlerName.StartsWith("<anonymous-method at ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Unsubscribe_TaggedAsUnsubscribe()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.Contains(results, r =>
+            r.Kind == SubscriptionKind.Unsubscribe &&
+            r.HandlerName.Contains("OnClicked", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InterfaceEvent_MatchesImplementations()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "IBusEventPublisher.MessageReceived");
+
+        Assert.True(results.Count >= 2,
+            $"Expected >=2 subscribers across implementations, got {results.Count}");
+    }
+
+    [Fact]
+    public void TwoSubscriptionsOnSameLine_BothReported()
+    {
+        var clickedResults = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+        var clicked2Results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked2");
+
+        Assert.Contains(clickedResults, r =>
+            r.Snippet.Contains("Clicked", StringComparison.Ordinal) &&
+            !r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+        Assert.Contains(clicked2Results, r =>
+            r.Snippet.Contains("Clicked2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Result_SortedByFileLine()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        for (int i = 1; i < results.Count; i++)
+        {
+            var prev = results[i - 1];
+            var curr = results[i];
+            var fileCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+            Assert.True(
+                fileCmp < 0 || (fileCmp == 0 && prev.Line <= curr.Line),
+                $"Sort violation at {i}: '{prev.FilePath}:{prev.Line}' before '{curr.FilePath}:{curr.Line}'");
+        }
+    }
+
+    [Fact]
+    public void EventName_IsFullyQualified()
+    {
+        var results = FindEventSubscribersLogic.Execute(
+            _loaded, _resolver, _metadata, "EventPublisher.Clicked");
+
+        Assert.NotEmpty(results);
+        foreach (var r in results)
+        {
+            Assert.Contains("Clicked", r.EventName, StringComparison.Ordinal);
+            Assert.NotEmpty(r.Project);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `find_event_subscribers` MCP tool: every `+=` and `-=` site for an event symbol across the solution
- Accepts source events (`MyClass.Clicked`) or metadata events (`System.Diagnostics.Process.Exited`)
- Reports source location, resolved handler (method FQN, or `<lambda at File.cs:N>` for inline handlers), and `Subscribe`/`Unsubscribe` kind
- Use cases: UI-event audits, memory-leak hunts (compare subscribe/unsubscribe pairs)

## Test plan
- [x] 9 `FindEventSubscribersToolTests` (method group, lambda, anonymous method, unsubscribe, interface event with multiple impls, two on same line, sort, FQN, unknown symbol)
- [x] `dotnet build` clean (0 errors)
- [x] Benchmark added: `find_event_subscribers: Clicked`
- [x] Docs updated: SKILL.md (Red Flags, Quick Reference, Finding Dependencies), README, CLAUDE.md tool count (29 → 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)