### PR TITLE
feat: add get_overloads MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 33 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 34 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **analyze_change_impact** — Show all files, projects, and call sites affected by changing a symbol — combines find_references and find_callers
 - **get_type_overview** — Compound tool: type context + hierarchy + file diagnostics in one call
 - **analyze_method** — Compound tool: method signature + callers + outgoing calls in one call
+- **get_overloads** — Every overload of a method/constructor (source + metadata) with full parameter and modifier detail in one call
 - **get_call_graph** — Transitive caller/callee graph for a method, depth-bounded with cycle detection
 - **get_file_overview** — Compound tool: types defined in a file + file-scoped diagnostics in one call
 

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -329,6 +329,12 @@ public class CodeGraphBenchmarks
         return AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "Greeter.Greet");
     }
 
+    [Benchmark(Description = "get_overloads: System.Console.WriteLine")]
+    public object GetOverloads()
+    {
+        return GetOverloadsLogic.Execute(_resolver, _metadata, "System.Console.WriteLine");
+    }
+
     [Benchmark(Description = "get_call_graph: Greet (callees, depth 3)")]
     public async Task<object?> GetCallGraphCallees()
     {

--- a/docs/plans/2026-05-01-get-overloads-design.md
+++ b/docs/plans/2026-05-01-get-overloads-design.md
@@ -1,0 +1,196 @@
+# `get_overloads` Design
+
+**Status:** Approved 2026-05-01
+
+## Goal
+
+Return every overload of a method (or constructor) symbol — source AND metadata — with full signature/parameter/modifier detail in one call. Saves agents from calling `analyze_method` per overload to compare signatures side-by-side.
+
+## Use cases
+
+- "What overloads does `Console.WriteLine` have?" — 18+ BCL overloads in one call.
+- "Which `Add` overload should I call here?" — agent inspects parameters/types/`params`/optional defaults across all overloads at once.
+- "Show me all constructor variants" — `Greeter.Greeter` returns the ctor overload set.
+
+## API
+
+```csharp
+GetOverloadsResult Execute(string symbol)
+```
+
+- `symbol` is a method or constructor name (e.g. `Greeter.Greet`, `Greeter.Greeter`, `System.Console.WriteLine`).
+
+## Output
+
+```csharp
+public record GetOverloadsResult(
+    string ContainingType,
+    IReadOnlyList<OverloadInfo> Overloads);
+
+public record OverloadInfo(
+    string Signature,
+    string ReturnType,
+    IReadOnlyList<OverloadParameter> Parameters,
+    string Accessibility,
+    bool IsStatic,
+    bool IsVirtual,
+    bool IsAbstract,
+    bool IsOverride,
+    bool IsAsync,
+    bool IsExtensionMethod,
+    IReadOnlyList<string> TypeParameters,
+    string? XmlDocSummary,
+    string FilePath,
+    int Line);
+
+public record OverloadParameter(
+    string Name,
+    string Type,
+    bool IsOptional,
+    string? DefaultValue,
+    bool IsParams,
+    string Modifier);
+```
+
+`ContainingType`: the FQN of the containing type whose overload set was returned. Empty when the symbol can't be resolved.
+
+`Modifier`: one of `""`, `"ref"`, `"out"`, `"in"`. (Roslyn's `RefKind`.)
+
+`Accessibility`: lowercase string — `public`, `internal`, `protected`, `private`, `protected internal`, `private protected`.
+
+`XmlDocSummary`: the inner text of the `<summary>` tag if the source method carries an XML doc comment; otherwise null. Metadata methods get null.
+
+## Sort
+
+`(Parameters.Count ASC, then Signature ordinal ASC)`. Stable, readable, matches IDE convention.
+
+## Architecture
+
+### Symbol resolution
+
+1. Try `SymbolResolver.FindMethods(symbol)`. If non-empty, take `methods[0].ContainingType` and the method name (last segment of `symbol`).
+2. Otherwise fall back to `MetadataSymbolResolver.Resolve(symbol)`. If `ResolvedSymbol.Symbol` is `IMethodSymbol`, take its `ContainingType` and name.
+3. Constructor case: if the last segment of `symbol` equals the second-to-last segment (e.g. `Greeter.Greeter`), the method name is `.ctor` for `containingType.GetMembers(".ctor")`.
+4. If neither resolves, return an empty result (`ContainingType: ""`, `Overloads: []`).
+
+### Enumeration
+
+`containingType.GetMembers(methodName).OfType<IMethodSymbol>()` returns every overload — source AND metadata, in declaration order. Filter out `IMethodSymbol` whose `MethodKind == UserDefinedOperator` or `Conversion` (operators are out of scope).
+
+### Per-overload assembly
+
+- `Signature`: `IMethodSymbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)` — produces `string Greet(string name)` style.
+- `ReturnType`: `IMethodSymbol.ReturnType.ToDisplayString(NullableFlowState.NotApplicable)` with nullable annotations included.
+- `Parameters`: walk `IMethodSymbol.Parameters`, capture name/type/modifier/default/`HasParamsModifier`.
+  - `DefaultValue`: when `IParameterSymbol.HasExplicitDefaultValue`, render `ExplicitDefaultValue` as a literal string (`null`, `42`, `"x"`, etc.).
+- Modifiers (`IsStatic`/`IsVirtual`/`IsAbstract`/`IsOverride`/`IsAsync`/`IsExtensionMethod`): straight from `IMethodSymbol`.
+- `TypeParameters`: `IMethodSymbol.TypeParameters.Select(t => t.Name).ToList()`.
+- `XmlDocSummary`: `IMethodSymbol.GetDocumentationCommentXml()` parsed for `<summary>` inner text, trimmed. Null if empty or absent.
+- `FilePath` / `Line`: `Locations.FirstOrDefault(l => l.IsInSource)?.GetLineSpan()`. Empty/0 for metadata-only.
+
+### Sort + return
+
+Sort the assembled list by `(Parameters.Count, Signature)` ordinal.
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Method on interface vs implementation | Returns overloads on whichever type matches the input. Agent calls again with the impl FQN if they want both. |
+| Generic instantiation (`List<int>.Add`) | Resolves to `List<T>.Add` — overloads come from the unbound generic definition. |
+| Extension method | `IsExtensionMethod: true`; `ContainingType` is the static class, not the receiver. |
+| Operator overload (`+`, `==`) | Excluded — `MethodKind.UserDefinedOperator/Conversion` filter. |
+| Constructor symbol (`Type.Type`) | `methodName` becomes `.ctor`; returns the constructor overload set. |
+| Single overload | Returns a 1-element list. |
+| Symbol not found | `ContainingType: ""`, `Overloads: []`. |
+| Method with `[Obsolete]` | Reported normally — agent can use `find_obsolete_usage` for migration planning. |
+| `params` array | `OverloadParameter.IsParams: true`; the array element type still in `Type`. |
+| `ref readonly` parameter | `Modifier: "in"` (Roslyn folds `ref readonly` into `RefKind.In` for in-source). |
+
+## Testing
+
+Fixture: add `OverloadSamples.cs` to `TestLib/`:
+
+```csharp
+public class OverloadSamples
+{
+    /// <summary>Add two integers.</summary>
+    public int Add(int a, int b) => a + b;
+
+    /// <summary>Add a sequence of integers.</summary>
+    public int Add(params int[] values) { /* ... */ return 0; }
+
+    /// <summary>Add with a comparer.</summary>
+    public TKey Add<TKey>(TKey a, TKey b, IComparer<TKey> comparer) => a;
+
+    public string Echo(string s, int times = 1) => string.Concat(Enumerable.Repeat(s, times));
+
+    public static OverloadSamples FromString(string s) => new();
+    public static OverloadSamples FromString(string s, int multiplier) => new();
+}
+
+public static class OverloadExtensions
+{
+    public static int Doubled(this int x) => x * 2;
+    public static int Doubled(this int x, int factor) => x * factor;
+}
+```
+
+Tests:
+- `Result_ReturnsAllOverloads` — `OverloadSamples.Add` returns 3 overloads.
+- `Result_SortedByParameterCountThenSignature`.
+- `Parameters_IncludeNamesAndTypes`.
+- `Parameters_HasParamsFlag` — `Add(params int[])` reports `IsParams: true`.
+- `Parameters_HasOptionalDefault` — `Echo(s, times = 1)` reports `IsOptional: true`, `DefaultValue: "1"`.
+- `GenericMethod_TypeParametersPopulated` — `Add<TKey>` reports `TypeParameters: ["TKey"]`.
+- `XmlDocSummary_PopulatedForDocumentedMethod` — `Add` overloads return `"Add two integers."` etc.
+- `ExtensionMethod_FlagSet` — `OverloadExtensions.Doubled` reports `IsExtensionMethod: true`.
+- `MetadataMethod_FindsAllBclOverloads` — `System.Console.WriteLine` returns ≥10 overloads.
+- `Constructors_ReturnsCtorOverloads` — `Greeter.Greeter` returns ctor list.
+- `UnknownSymbol_ReturnsEmpty`.
+- `OperatorsExcluded` — a fixture type with a `+` operator: querying `Type.op_Addition` returns empty (or just doesn't include the operator).
+- `StaticMethod_IsStaticFlagSet` — `OverloadSamples.FromString` reports `IsStatic: true`.
+
+## Performance
+
+`containingType.GetMembers(name)` is O(M) over members of the type — Roslyn caches this. No solution-wide walk.
+
+Benchmark: `get_overloads: System.Console.WriteLine`. Should be sub-millisecond.
+
+## MCP wrapper
+
+Standard pattern:
+
+```csharp
+[McpServerToolType]
+public static class GetOverloadsTool
+{
+    [McpServerTool(Name = "get_overloads")]
+    [Description(...)]
+    public static GetOverloadsResult Execute(MultiSolutionManager manager, string symbol)
+    { ... }
+}
+```
+
+Auto-registered via `WithToolsFromAssembly()`.
+
+## Out of scope (deferred)
+
+- Source-navigation links into metadata overloads — `peek_il` covers IL inspection separately.
+- Cross-type overloads from different containing types — that's `find_implementations` territory.
+- Overload-resolution-against-arguments — agent can call `find_callers` if it needs to see how each overload is actually invoked.
+- Operator overloads — separate query story (deferred to a possible future `get_operators` tool).
+
+## File checklist
+
+- `src/RoslynCodeLens/Tools/GetOverloadsLogic.cs`
+- `src/RoslynCodeLens/Tools/GetOverloadsTool.cs`
+- `src/RoslynCodeLens/Models/GetOverloadsResult.cs`
+- `src/RoslynCodeLens/Models/OverloadInfo.cs`
+- `src/RoslynCodeLens/Models/OverloadParameter.cs`
+- `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs`
+- `tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs`
+- `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs` — add benchmark
+- `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` — Red Flags, Quick Reference, Navigating Code
+- `README.md` — Features list
+- `CLAUDE.md` — bump tool count

--- a/docs/plans/2026-05-01-get-overloads.md
+++ b/docs/plans/2026-05-01-get-overloads.md
@@ -1,0 +1,689 @@
+# `get_overloads` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new MCP tool `get_overloads` that returns every overload of a method or constructor symbol — source AND metadata — with full signature/parameter/modifier detail in one call.
+
+**Architecture:** Resolve the symbol via `SymbolResolver.FindMethods` (source) or `MetadataSymbolResolver.Resolve` (metadata fallback). From the resolved method's `ContainingType`, enumerate `GetMembers(name).OfType<IMethodSymbol>()`. Filter out user-defined operators/conversions. Build per-overload info (signature, params, modifiers, XML doc, location). Sort by parameter count then signature.
+
+**Tech Stack:** Roslyn (`Microsoft.CodeAnalysis`), xUnit, BenchmarkDotNet, ModelContextProtocol.Server.
+
+**Reference design:** `docs/plans/2026-05-01-get-overloads-design.md`
+
+**Patterns to mirror:**
+- Source + metadata symbol resolution: `src/RoslynCodeLens/Tools/FindCallersLogic.cs:13-28`
+- MCP wrapper / auto-registration: any tool in `src/RoslynCodeLens/Tools/`; `Program.cs:35` uses `WithToolsFromAssembly()` — no edit needed.
+
+---
+
+## Task 1: Models
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/OverloadParameter.cs`
+- Create: `src/RoslynCodeLens/Models/OverloadInfo.cs`
+- Create: `src/RoslynCodeLens/Models/GetOverloadsResult.cs`
+
+**Step 1: `OverloadParameter.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record OverloadParameter(
+    string Name,
+    string Type,
+    bool IsOptional,
+    string? DefaultValue,
+    bool IsParams,
+    string Modifier);
+```
+
+**Step 2: `OverloadInfo.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record OverloadInfo(
+    string Signature,
+    string ReturnType,
+    IReadOnlyList<OverloadParameter> Parameters,
+    string Accessibility,
+    bool IsStatic,
+    bool IsVirtual,
+    bool IsAbstract,
+    bool IsOverride,
+    bool IsAsync,
+    bool IsExtensionMethod,
+    IReadOnlyList<string> TypeParameters,
+    string? XmlDocSummary,
+    string FilePath,
+    int Line);
+```
+
+**Step 3: `GetOverloadsResult.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record GetOverloadsResult(
+    string ContainingType,
+    IReadOnlyList<OverloadInfo> Overloads);
+```
+
+**Step 4: Build**
+
+```bash
+dotnet build src/RoslynCodeLens
+```
+
+Expected: 0 errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Models/OverloadParameter.cs \
+  src/RoslynCodeLens/Models/OverloadInfo.cs \
+  src/RoslynCodeLens/Models/GetOverloadsResult.cs
+git commit -m "feat: add models for get_overloads"
+```
+
+---
+
+## Task 2: Test fixture
+
+**Files:**
+- Create: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs`
+
+**Step 1: Create the fixture**
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TestLib.OverloadSamples;
+
+public class OverloadSamples
+{
+    /// <summary>Add two integers.</summary>
+    public int Add(int a, int b) => a + b;
+
+    /// <summary>Add a sequence of integers.</summary>
+    public int Add(params int[] values) => values.Sum();
+
+    /// <summary>Add with a comparer.</summary>
+    public TKey Add<TKey>(TKey a, TKey b, IComparer<TKey> comparer) => a;
+
+    /// <summary>Echo a string with optional repeat count.</summary>
+    public string Echo(string s, int times = 1)
+        => string.Concat(Enumerable.Repeat(s, times));
+
+    public static OverloadSamples FromString(string s) => new();
+    public static OverloadSamples FromString(string s, int multiplier) => new();
+}
+
+public static class OverloadExtensions
+{
+    public static int Doubled(this int x) => x * 2;
+    public static int Doubled(this int x, int factor) => x * factor;
+}
+```
+
+**Step 2: Build**
+
+```bash
+dotnet build tests/RoslynCodeLens.Tests
+```
+
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
+git commit -m "test: add OverloadSamples fixture for get_overloads"
+```
+
+---
+
+## Task 3: `GetOverloadsLogic` + tests (TDD)
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/GetOverloadsLogic.cs`
+- Create: `tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs`
+
+**Step 1: Write the failing tests**
+
+`tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs`:
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class GetOverloadsToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Result_ReturnsAllOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.Contains("OverloadSamples", result.ContainingType, StringComparison.Ordinal);
+        Assert.Equal(3, result.Overloads.Count);
+    }
+
+    [Fact]
+    public void Result_SortedByParameterCountThenSignature()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        for (int i = 1; i < result.Overloads.Count; i++)
+        {
+            var prev = result.Overloads[i - 1];
+            var curr = result.Overloads[i];
+            if (prev.Parameters.Count == curr.Parameters.Count)
+                Assert.True(string.CompareOrdinal(prev.Signature, curr.Signature) <= 0,
+                    $"Sort violation: '{prev.Signature}' before '{curr.Signature}'");
+            else
+                Assert.True(prev.Parameters.Count < curr.Parameters.Count,
+                    $"Sort violation by param count");
+        }
+    }
+
+    [Fact]
+    public void Parameters_IncludeNamesAndTypes()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var twoParam = result.Overloads.Single(o => o.Parameters.Count == 2);
+        Assert.Equal("a", twoParam.Parameters[0].Name);
+        Assert.Equal("b", twoParam.Parameters[1].Name);
+        Assert.Contains("int", twoParam.Parameters[0].Type, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parameters_HasParamsFlag()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var paramsOverload = result.Overloads.Single(o =>
+            o.Parameters.Count == 1 && o.Parameters[0].IsParams);
+        Assert.Equal("values", paramsOverload.Parameters[0].Name);
+    }
+
+    [Fact]
+    public void Parameters_HasOptionalDefault()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Echo");
+
+        var echo = Assert.Single(result.Overloads);
+        var times = echo.Parameters[1];
+        Assert.Equal("times", times.Name);
+        Assert.True(times.IsOptional);
+        Assert.Equal("1", times.DefaultValue);
+    }
+
+    [Fact]
+    public void GenericMethod_TypeParametersPopulated()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var generic = result.Overloads.Single(o => o.TypeParameters.Count > 0);
+        Assert.Contains("TKey", generic.TypeParameters);
+    }
+
+    [Fact]
+    public void XmlDocSummary_PopulatedForDocumentedMethod()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.All(result.Overloads, o =>
+        {
+            Assert.NotNull(o.XmlDocSummary);
+            Assert.NotEmpty(o.XmlDocSummary!);
+        });
+    }
+
+    [Fact]
+    public void ExtensionMethod_FlagSet()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadExtensions.Doubled");
+
+        Assert.NotEmpty(result.Overloads);
+        Assert.All(result.Overloads, o => Assert.True(o.IsExtensionMethod));
+    }
+
+    [Fact]
+    public void StaticMethod_IsStaticFlagSet()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.FromString");
+
+        Assert.Equal(2, result.Overloads.Count);
+        Assert.All(result.Overloads, o => Assert.True(o.IsStatic));
+    }
+
+    [Fact]
+    public void MetadataMethod_FindsAllBclOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "System.Console.WriteLine");
+
+        // BCL Console.WriteLine has 18+ overloads; require at least 10 to allow for runtime variation.
+        Assert.True(result.Overloads.Count >= 10,
+            $"Expected >=10 Console.WriteLine overloads, got {result.Overloads.Count}");
+    }
+
+    [Fact]
+    public void Constructors_ReturnsCtorOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "Greeter.Greeter");
+
+        // Greeter has at least an implicit/declared constructor.
+        Assert.NotEmpty(result.Overloads);
+    }
+
+    [Fact]
+    public void UnknownSymbol_ReturnsEmpty()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "Does.Not.Exist");
+
+        Assert.Empty(result.ContainingType);
+        Assert.Empty(result.Overloads);
+    }
+
+    [Fact]
+    public void OperatorsExcluded()
+    {
+        // OverloadSamples doesn't define operators; querying Add must not include any operator-kind methods.
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.All(result.Overloads, o =>
+            Assert.DoesNotContain("op_", o.Signature, StringComparison.Ordinal));
+    }
+}
+```
+
+**Step 2: Run failing**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetOverloadsToolTests"
+```
+
+Expect compile error (`GetOverloadsLogic` doesn't exist).
+
+**Step 3: Create `src/RoslynCodeLens/Tools/GetOverloadsLogic.cs`**
+
+```csharp
+using System.Globalization;
+using System.Xml;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class GetOverloadsLogic
+{
+    private static readonly SymbolDisplayFormat SignatureFormat =
+        SymbolDisplayFormat.CSharpShortErrorMessageFormat;
+
+    public static GetOverloadsResult Execute(
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        string symbol)
+    {
+        var (containingType, methodName) = ResolveContainingTypeAndName(resolver, metadata, symbol);
+        if (containingType is null || string.IsNullOrEmpty(methodName))
+            return new GetOverloadsResult(string.Empty, []);
+
+        var overloads = containingType
+            .GetMembers(methodName)
+            .OfType<IMethodSymbol>()
+            .Where(m => m.MethodKind != MethodKind.UserDefinedOperator
+                     && m.MethodKind != MethodKind.Conversion)
+            .Select(BuildOverloadInfo)
+            .ToList();
+
+        overloads.Sort((a, b) =>
+        {
+            var byCount = a.Parameters.Count.CompareTo(b.Parameters.Count);
+            if (byCount != 0) return byCount;
+            return string.CompareOrdinal(a.Signature, b.Signature);
+        });
+
+        return new GetOverloadsResult(
+            ContainingType: containingType.ToDisplayString(),
+            Overloads: overloads);
+    }
+
+    private static (INamedTypeSymbol? Type, string Name) ResolveContainingTypeAndName(
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
+    {
+        var parts = symbol.Split('.');
+        if (parts.Length < 2) return (null, string.Empty);
+
+        var lastSegment = parts[^1];
+        var typeName = string.Join('.', parts[..^1]);
+        var typeNameLastSegment = parts[^2];
+
+        // Constructor case: Type.Type → resolve as ".ctor" on Type.
+        var isConstructor = string.Equals(lastSegment, typeNameLastSegment, StringComparison.Ordinal);
+        var methodName = isConstructor ? ".ctor" : lastSegment;
+
+        // 1) Source path: SymbolResolver.FindMethods works for ordinary methods. For
+        //    constructors, walk types directly because FindMethods uses the literal
+        //    segment as the member name.
+        if (!isConstructor)
+        {
+            var methods = resolver.FindMethods(symbol);
+            if (methods.Count > 0)
+                return (methods[0].ContainingType, methodName);
+        }
+        else
+        {
+            foreach (var type in resolver.FindNamedTypes(typeName))
+                if (type.GetMembers(".ctor").OfType<IMethodSymbol>().Any())
+                    return (type, methodName);
+        }
+
+        // 2) Metadata fallback.
+        var resolved = metadata.Resolve(symbol);
+        if (resolved?.Symbol is IMethodSymbol mm)
+            return (mm.ContainingType, methodName);
+        if (resolved?.Symbol is INamedTypeSymbol nt && isConstructor)
+            return (nt, methodName);
+
+        return (null, string.Empty);
+    }
+
+    private static OverloadInfo BuildOverloadInfo(IMethodSymbol method)
+    {
+        var location = method.Locations.FirstOrDefault(l => l.IsInSource);
+        var (file, line) = location is not null
+            ? (location.GetLineSpan().Path, location.GetLineSpan().StartLinePosition.Line + 1)
+            : (string.Empty, 0);
+
+        return new OverloadInfo(
+            Signature: method.ToDisplayString(SignatureFormat),
+            ReturnType: method.ReturnType.ToDisplayString(),
+            Parameters: method.Parameters.Select(BuildParameter).ToList(),
+            Accessibility: AccessibilityToString(method.DeclaredAccessibility),
+            IsStatic: method.IsStatic,
+            IsVirtual: method.IsVirtual,
+            IsAbstract: method.IsAbstract,
+            IsOverride: method.IsOverride,
+            IsAsync: method.IsAsync,
+            IsExtensionMethod: method.IsExtensionMethod,
+            TypeParameters: method.TypeParameters.Select(t => t.Name).ToList(),
+            XmlDocSummary: ExtractSummary(method),
+            FilePath: file,
+            Line: line);
+    }
+
+    private static OverloadParameter BuildParameter(IParameterSymbol p)
+    {
+        var defaultText = p.HasExplicitDefaultValue
+            ? FormatDefault(p.ExplicitDefaultValue)
+            : null;
+
+        var modifier = p.RefKind switch
+        {
+            RefKind.Ref => "ref",
+            RefKind.Out => "out",
+            RefKind.In => "in",
+            _ => string.Empty,
+        };
+
+        return new OverloadParameter(
+            Name: p.Name,
+            Type: p.Type.ToDisplayString(),
+            IsOptional: p.IsOptional,
+            DefaultValue: defaultText,
+            IsParams: p.IsParams,
+            Modifier: modifier);
+    }
+
+    private static string FormatDefault(object? value) => value switch
+    {
+        null => "null",
+        string s => $"\"{s}\"",
+        bool b => b ? "true" : "false",
+        char c => $"'{c}'",
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? "null",
+    };
+
+    private static string AccessibilityToString(Accessibility a) => a switch
+    {
+        Accessibility.Public => "public",
+        Accessibility.Internal => "internal",
+        Accessibility.Protected => "protected",
+        Accessibility.ProtectedAndInternal => "private protected",
+        Accessibility.ProtectedOrInternal => "protected internal",
+        Accessibility.Private => "private",
+        _ => "internal",
+    };
+
+    private static string? ExtractSummary(IMethodSymbol method)
+    {
+        var xml = method.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml)) return null;
+
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            var summary = doc.SelectSingleNode("//summary");
+            var text = summary?.InnerText.Trim();
+            return string.IsNullOrEmpty(text) ? null : text;
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetOverloadsToolTests" --no-build
+```
+
+If `--no-build` fails, run `dotnet build` first. Expect 13/13 pass.
+
+**Common debugging:**
+- If `MetadataMethod_FindsAllBclOverloads` fails: `MetadataSymbolResolver.Resolve("System.Console.WriteLine")` should return one of the overloads. Its `ContainingType` is `System.Console`, then `GetMembers("WriteLine")` returns all overloads.
+- If `Constructors_ReturnsCtorOverloads` returns empty: ensure `isConstructor` branch uses `FindNamedTypes(typeName)` and reads `.ctor` members.
+- If `Parameters_HasOptionalDefault` returns wrong default: `IParameterSymbol.ExplicitDefaultValue` for `int = 1` is `(int)1`, formatted via `IFormattable.ToString(null, CultureInfo.InvariantCulture)` as `"1"`.
+- If XML doc summary is empty: ensure the fixture's csproj has `<GenerateDocumentationFile>true</GenerateDocumentationFile>` OR Roslyn's in-memory compilation captures the XML doc regardless. If the test fails, set the property in `TestLib.csproj`.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/GetOverloadsLogic.cs \
+  tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
+git commit -m "feat: add GetOverloadsLogic with tests"
+```
+
+---
+
+## Task 4: MCP wrapper
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/GetOverloadsTool.cs`
+
+**Step 1: Create the wrapper**
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class GetOverloadsTool
+{
+    [McpServerTool(Name = "get_overloads")]
+    [Description(
+        "Return every overload of a method (or constructor) in one call — source AND metadata. " +
+        "Each overload includes the full signature, parameter names/types/modifiers (ref/out/in/" +
+        "params/optional with defaults), return type, accessibility, modifiers (static/virtual/" +
+        "abstract/override/async/extension), generic type parameters, XML doc summary, and source " +
+        "location (empty for metadata). " +
+        "Pass 'Type.Method' for ordinary methods or 'Type.Type' for constructors. Operator " +
+        "overloads are excluded — they have a separate query story. " +
+        "Sort: parameter count ASC, then signature ordinal ASC.")]
+    public static GetOverloadsResult Execute(
+        MultiSolutionManager manager,
+        [Description("Method or constructor symbol (e.g. 'Greeter.Greet', 'Greeter.Greeter', 'System.Console.WriteLine').")]
+        string symbol)
+    {
+        manager.EnsureLoaded();
+        return GetOverloadsLogic.Execute(
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            symbol);
+    }
+}
+```
+
+**Step 2: Build**
+
+```bash
+dotnet build
+```
+
+Expected: 0 errors. Auto-registered via `Program.cs:35`.
+
+**Step 3: Run targeted tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetOverloadsToolTests" --no-build
+```
+
+Expect 13/13 pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/GetOverloadsTool.cs
+git commit -m "feat: register get_overloads MCP tool"
+```
+
+---
+
+## Task 5: Add benchmark
+
+**Files:**
+- Modify: `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs`
+
+**Step 1**: Find the existing `analyze_method` benchmark; add immediately after.
+
+```csharp
+[Benchmark(Description = "get_overloads: System.Console.WriteLine")]
+public object GetOverloads()
+{
+    return GetOverloadsLogic.Execute(_resolver, _metadata, "System.Console.WriteLine");
+}
+```
+
+**Step 2: Build benchmarks**
+
+```bash
+dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release
+```
+
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+git commit -m "bench: add get_overloads benchmark"
+```
+
+---
+
+## Task 6: Update SKILL.md, README, CLAUDE.md
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Step 1: SKILL.md — Red Flags routing table**
+
+Add near `analyze_method`:
+
+```
+| "What overloads does this method have?" / "Show me all signatures of Foo" / "Compare overloads side-by-side" | `get_overloads` |
+```
+
+**Step 2: SKILL.md — Quick Reference**
+
+Add near `analyze_method`:
+
+```
+| `get_overloads` | "What overloads does this method have?" |
+```
+
+**Step 3: SKILL.md — Navigating Code section**
+
+Add as a new bullet near `analyze_method`:
+
+```
+- `get_overloads` — Every overload of a method or constructor (source + metadata) with full parameter detail, modifiers, generic type params, XML doc summary, and location. One call instead of N analyze_method calls.
+```
+
+**Step 4: README.md Features list**
+
+Add near `analyze_method`:
+
+```
+- **get_overloads** — Every overload of a method/constructor (source + metadata) with full parameter and modifier detail in one call
+```
+
+**Step 5: CLAUDE.md tool count**
+
+Bump from 33 to 34.
+
+**Step 6: Sanity check**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetOverloadsToolTests"
+```
+
+Expect 13/13 pass.
+
+**Step 7: Commit**
+
+```bash
+git add plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md \
+  README.md \
+  CLAUDE.md
+git commit -m "docs: announce get_overloads in SKILL.md, README, CLAUDE.md"
+```
+
+---
+
+## Done
+
+After Task 6 the branch should have ~8 commits (design + plan + 6 tasks). 13/13 tests green, benchmark compiling, tool auto-registered.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -43,6 +43,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 | "Let me `Glob` for `**/*Service.cs`" | `search_symbols` with a partial name |
 | "Let me `Grep` for `Activator.CreateInstance`" | `find_reflection_usage` |
 | "I'll check if this method is used by reading files" | `find_callers` / `find_unused_symbols` |
+| "What overloads does this method have?" / "Show me all signatures of Foo" / "Compare overloads side-by-side" | `get_overloads` |
 | "I'll eyeball complexity by reading the method" | `get_complexity_metrics` |
 | "How is this project doing?" / "Where should I focus?" / "Show me the technical debt picture" | `get_project_health` |
 | "Which classes are doing too much?" / "Where are my god classes?" / "Worst design smells in this codebase?" | `find_god_objects` |
@@ -113,6 +114,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 - `get_type_overview` — one-shot: context + hierarchy + diagnostics (replaces 3 calls).
 - `get_file_overview` — types defined in a file + diagnostics, without reading it.
 - `analyze_method` — signature + callers + outgoing calls, all in one.
+- `get_overloads` — Every overload of a method or constructor (source + metadata) with full parameter detail, modifiers, generic type params, XML doc summary, and location. One call instead of N analyze_method calls.
 - `get_call_graph` — Transitive caller/callee graph for a method, depth-bounded with cycle detection. Adjacency-list output. Use when you need depth > 1 (`analyze_method` is depth=1).
 
 ### Navigating Code (**instead of Grep/Glob**)
@@ -278,6 +280,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `analyze_change_impact` | "What breaks if I change this?" |
 | `get_type_overview` | "Give me everything about this type in one call" |
 | `analyze_method` | "Show signature, callers, and outgoing calls" |
+| `get_overloads` | "What overloads does this method have?" |
 | `get_call_graph` | "Transitive callers/callees, depth-bounded" |
 | `get_file_overview` | "What types are in this file?" |
 

--- a/src/RoslynCodeLens/Models/GetOverloadsResult.cs
+++ b/src/RoslynCodeLens/Models/GetOverloadsResult.cs
@@ -1,0 +1,5 @@
+namespace RoslynCodeLens.Models;
+
+public record GetOverloadsResult(
+    string ContainingType,
+    IReadOnlyList<OverloadInfo> Overloads);

--- a/src/RoslynCodeLens/Models/OverloadInfo.cs
+++ b/src/RoslynCodeLens/Models/OverloadInfo.cs
@@ -1,0 +1,17 @@
+namespace RoslynCodeLens.Models;
+
+public record OverloadInfo(
+    string Signature,
+    string ReturnType,
+    IReadOnlyList<OverloadParameter> Parameters,
+    string Accessibility,
+    bool IsStatic,
+    bool IsVirtual,
+    bool IsAbstract,
+    bool IsOverride,
+    bool IsAsync,
+    bool IsExtensionMethod,
+    IReadOnlyList<string> TypeParameters,
+    string? XmlDocSummary,
+    string FilePath,
+    int Line);

--- a/src/RoslynCodeLens/Models/OverloadParameter.cs
+++ b/src/RoslynCodeLens/Models/OverloadParameter.cs
@@ -1,0 +1,9 @@
+namespace RoslynCodeLens.Models;
+
+public record OverloadParameter(
+    string Name,
+    string Type,
+    bool IsOptional,
+    string? DefaultValue,
+    bool IsParams,
+    string Modifier);

--- a/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
@@ -51,6 +51,12 @@ public static class GetOverloadsLogic
         var typeNameLastSegment = parts[^2];
 
         // Constructor case: Type.Type → resolve as ".ctor" on Type.
+        // Known ambiguities (rare in practice; not handled here):
+        //   - Nested type sharing the outer's name (`Foo.Foo` could mean nested-type lookup).
+        //   - Namespace named like a type (`MyApp.MyApp`) — interpreted as ctor; falls through
+        //     to empty result if no such ctor exists.
+        // Ordinary self-named static methods aren't reachable via this heuristic; they'd
+        // need to be queried with the containing type's parent qualifier.
         var isConstructor = string.Equals(lastSegment, typeNameLastSegment, StringComparison.Ordinal);
         var methodName = isConstructor ? ".ctor" : lastSegment;
 
@@ -83,9 +89,12 @@ public static class GetOverloadsLogic
     private static OverloadInfo BuildOverloadInfo(IMethodSymbol method)
     {
         var location = method.Locations.FirstOrDefault(l => l.IsInSource);
-        var (file, line) = location is not null
-            ? (location.GetLineSpan().Path, location.GetLineSpan().StartLinePosition.Line + 1)
-            : (string.Empty, 0);
+        var (file, line) = (string.Empty, 0);
+        if (location is not null)
+        {
+            var span = location.GetLineSpan();
+            (file, line) = (span.Path, span.StartLinePosition.Line + 1);
+        }
 
         return new OverloadInfo(
             Signature: method.ToDisplayString(SignatureFormat),
@@ -107,7 +116,7 @@ public static class GetOverloadsLogic
     private static OverloadParameter BuildParameter(IParameterSymbol p)
     {
         var defaultText = p.HasExplicitDefaultValue
-            ? FormatDefault(p.ExplicitDefaultValue)
+            ? FormatDefault(p.ExplicitDefaultValue, p.Type)
             : null;
 
         var modifier = p.RefKind switch
@@ -128,15 +137,29 @@ public static class GetOverloadsLogic
             Modifier: modifier);
     }
 
-    private static string FormatDefault(object? value) => value switch
+    private static string FormatDefault(object? value, ITypeSymbol type)
     {
-        null => "null",
-        string s => $"\"{s}\"",
-        bool b => b ? "true" : "false",
-        char c => $"'{c}'",
-        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
-        _ => value.ToString() ?? "null",
-    };
+        // Enum defaults: ExplicitDefaultValue returns the underlying integer (e.g. 0). Look
+        // up the matching field on the enum so we render `MyEnum.Foo` instead of `0`.
+        if (value is not null && type.TypeKind == TypeKind.Enum && type is INamedTypeSymbol enumType)
+        {
+            foreach (var member in enumType.GetMembers().OfType<IFieldSymbol>())
+            {
+                if (member.HasConstantValue && Equals(member.ConstantValue, value))
+                    return $"{enumType.Name}.{member.Name}";
+            }
+        }
+
+        return value switch
+        {
+            null => "null",
+            string s => $"\"{s}\"",
+            bool b => b ? "true" : "false",
+            char c => $"'{c}'",
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? "null",
+        };
+    }
 
     private static string AccessibilityToString(Accessibility a) => a switch
     {
@@ -160,7 +183,11 @@ public static class GetOverloadsLogic
             doc.LoadXml(xml);
             var summary = doc.SelectSingleNode("//summary");
             var text = summary?.InnerText.Trim();
-            return string.IsNullOrEmpty(text) ? null : text;
+            if (string.IsNullOrEmpty(text)) return null;
+
+            // InnerText flattens nested tags (e.g. <see cref="X"/>) to empty strings, leaving
+            // double-spaces. Collapse whitespace runs to single spaces for clean rendering.
+            return System.Text.RegularExpressions.Regex.Replace(text, @"\s+", " ");
         }
         catch (XmlException)
         {

--- a/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
@@ -115,6 +115,7 @@ public static class GetOverloadsLogic
             RefKind.Ref => "ref",
             RefKind.Out => "out",
             RefKind.In => "in",
+            RefKind.RefReadOnlyParameter => "ref readonly",
             _ => string.Empty,
         };
 

--- a/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetOverloadsLogic.cs
@@ -1,0 +1,169 @@
+using System.Globalization;
+using System.Xml;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+public static class GetOverloadsLogic
+{
+    private static readonly SymbolDisplayFormat SignatureFormat =
+        SymbolDisplayFormat.CSharpShortErrorMessageFormat;
+
+    public static GetOverloadsResult Execute(
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        string symbol)
+    {
+        var (containingType, methodName) = ResolveContainingTypeAndName(resolver, metadata, symbol);
+        if (containingType is null || string.IsNullOrEmpty(methodName))
+            return new GetOverloadsResult(string.Empty, []);
+
+        var overloads = containingType
+            .GetMembers(methodName)
+            .OfType<IMethodSymbol>()
+            .Where(m => m.MethodKind != MethodKind.UserDefinedOperator
+                     && m.MethodKind != MethodKind.Conversion)
+            .Select(BuildOverloadInfo)
+            .ToList();
+
+        overloads.Sort((a, b) =>
+        {
+            var byCount = a.Parameters.Count.CompareTo(b.Parameters.Count);
+            if (byCount != 0) return byCount;
+            return string.CompareOrdinal(a.Signature, b.Signature);
+        });
+
+        return new GetOverloadsResult(
+            ContainingType: containingType.ToDisplayString(),
+            Overloads: overloads);
+    }
+
+    private static (INamedTypeSymbol? Type, string Name) ResolveContainingTypeAndName(
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
+    {
+        var parts = symbol.Split('.');
+        if (parts.Length < 2) return (null, string.Empty);
+
+        var lastSegment = parts[^1];
+        var typeName = string.Join('.', parts[..^1]);
+        var typeNameLastSegment = parts[^2];
+
+        // Constructor case: Type.Type → resolve as ".ctor" on Type.
+        var isConstructor = string.Equals(lastSegment, typeNameLastSegment, StringComparison.Ordinal);
+        var methodName = isConstructor ? ".ctor" : lastSegment;
+
+        // 1) Source path: SymbolResolver.FindMethods works for ordinary methods. For
+        //    constructors, walk types directly because FindMethods uses the literal
+        //    segment as the member name.
+        if (!isConstructor)
+        {
+            var methods = resolver.FindMethods(symbol);
+            if (methods.Count > 0)
+                return (methods[0].ContainingType, methodName);
+        }
+        else
+        {
+            foreach (var type in resolver.FindNamedTypes(typeName))
+                if (type.GetMembers(".ctor").OfType<IMethodSymbol>().Any())
+                    return (type, methodName);
+        }
+
+        // 2) Metadata fallback.
+        var resolved = metadata.Resolve(symbol);
+        if (resolved?.Symbol is IMethodSymbol mm)
+            return (mm.ContainingType, methodName);
+        if (resolved?.Symbol is INamedTypeSymbol nt && isConstructor)
+            return (nt, methodName);
+
+        return (null, string.Empty);
+    }
+
+    private static OverloadInfo BuildOverloadInfo(IMethodSymbol method)
+    {
+        var location = method.Locations.FirstOrDefault(l => l.IsInSource);
+        var (file, line) = location is not null
+            ? (location.GetLineSpan().Path, location.GetLineSpan().StartLinePosition.Line + 1)
+            : (string.Empty, 0);
+
+        return new OverloadInfo(
+            Signature: method.ToDisplayString(SignatureFormat),
+            ReturnType: method.ReturnType.ToDisplayString(),
+            Parameters: method.Parameters.Select(BuildParameter).ToList(),
+            Accessibility: AccessibilityToString(method.DeclaredAccessibility),
+            IsStatic: method.IsStatic,
+            IsVirtual: method.IsVirtual,
+            IsAbstract: method.IsAbstract,
+            IsOverride: method.IsOverride,
+            IsAsync: method.IsAsync,
+            IsExtensionMethod: method.IsExtensionMethod,
+            TypeParameters: method.TypeParameters.Select(t => t.Name).ToList(),
+            XmlDocSummary: ExtractSummary(method),
+            FilePath: file,
+            Line: line);
+    }
+
+    private static OverloadParameter BuildParameter(IParameterSymbol p)
+    {
+        var defaultText = p.HasExplicitDefaultValue
+            ? FormatDefault(p.ExplicitDefaultValue)
+            : null;
+
+        var modifier = p.RefKind switch
+        {
+            RefKind.Ref => "ref",
+            RefKind.Out => "out",
+            RefKind.In => "in",
+            _ => string.Empty,
+        };
+
+        return new OverloadParameter(
+            Name: p.Name,
+            Type: p.Type.ToDisplayString(),
+            IsOptional: p.IsOptional,
+            DefaultValue: defaultText,
+            IsParams: p.IsParams,
+            Modifier: modifier);
+    }
+
+    private static string FormatDefault(object? value) => value switch
+    {
+        null => "null",
+        string s => $"\"{s}\"",
+        bool b => b ? "true" : "false",
+        char c => $"'{c}'",
+        IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+        _ => value.ToString() ?? "null",
+    };
+
+    private static string AccessibilityToString(Accessibility a) => a switch
+    {
+        Accessibility.Public => "public",
+        Accessibility.Internal => "internal",
+        Accessibility.Protected => "protected",
+        Accessibility.ProtectedAndInternal => "private protected",
+        Accessibility.ProtectedOrInternal => "protected internal",
+        Accessibility.Private => "private",
+        _ => "internal",
+    };
+
+    private static string? ExtractSummary(IMethodSymbol method)
+    {
+        var xml = method.GetDocumentationCommentXml();
+        if (string.IsNullOrWhiteSpace(xml)) return null;
+
+        try
+        {
+            var doc = new XmlDocument();
+            doc.LoadXml(xml);
+            var summary = doc.SelectSingleNode("//summary");
+            var text = summary?.InnerText.Trim();
+            return string.IsNullOrEmpty(text) ? null : text;
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/RoslynCodeLens/Tools/GetOverloadsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetOverloadsTool.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class GetOverloadsTool
+{
+    [McpServerTool(Name = "get_overloads")]
+    [Description(
+        "Return every overload of a method (or constructor) in one call — source AND metadata. " +
+        "Each overload includes the full signature, parameter names/types/modifiers (ref/out/in/" +
+        "params/optional with defaults), return type, accessibility, modifiers (static/virtual/" +
+        "abstract/override/async/extension), generic type parameters, XML doc summary, and source " +
+        "location (empty for metadata). " +
+        "Pass 'Type.Method' for ordinary methods or 'Type.Type' for constructors. Operator " +
+        "overloads are excluded — they have a separate query story. " +
+        "Sort: parameter count ASC, then signature ordinal ASC.")]
+    public static GetOverloadsResult Execute(
+        MultiSolutionManager manager,
+        [Description("Method or constructor symbol (e.g. 'Greeter.Greet', 'Greeter.Greeter', 'System.Console.WriteLine').")]
+        string symbol)
+    {
+        manager.EnsureLoaded();
+        return GetOverloadsLogic.Execute(
+            manager.GetResolver(),
+            manager.GetMetadataResolver(),
+            symbol);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TestLib.OverloadSamples;
+
+public class OverloadSamples
+{
+    /// <summary>Add two integers.</summary>
+    public int Add(int a, int b) => a + b;
+
+    /// <summary>Add a sequence of integers.</summary>
+    public int Add(params int[] values) => values.Sum();
+
+    /// <summary>Add with a comparer.</summary>
+    public TKey Add<TKey>(TKey a, TKey b, IComparer<TKey> comparer) => a;
+
+    /// <summary>Echo a string with optional repeat count.</summary>
+    public string Echo(string s, int times = 1)
+        => string.Concat(Enumerable.Repeat(s, times));
+
+    public static OverloadSamples FromString(string s) => new();
+    public static OverloadSamples FromString(string s, int multiplier) => new();
+}
+
+public static class OverloadExtensions
+{
+    public static int Doubled(this int x) => x * 2;
+    public static int Doubled(this int x, int factor) => x * factor;
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
@@ -26,6 +26,16 @@ public class OverloadSamples
     public void Increment(ref int value) => value++;
     public int InspectIn(in int value) => value;
     public int InspectRefReadonly(ref readonly int value) => value;
+
+    // Enum default — verify FormatDefault renders `OverloadColor.Red`, not `0`.
+    public string Paint(string label, OverloadColor color = OverloadColor.Red) => $"{label}:{color}";
+}
+
+public enum OverloadColor
+{
+    Red,
+    Green,
+    Blue,
 }
 
 public static class OverloadExtensions

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/OverloadSamples.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace TestLib.OverloadSamples;
+namespace TestLib;
 
 public class OverloadSamples
 {
@@ -20,6 +20,12 @@ public class OverloadSamples
 
     public static OverloadSamples FromString(string s) => new();
     public static OverloadSamples FromString(string s, int multiplier) => new();
+
+    // Exercises every RefKind so the modifier-rendering switch in BuildParameter is covered.
+    public bool TryParse(string s, out int value) { value = 0; return false; }
+    public void Increment(ref int value) => value++;
+    public int InspectIn(in int value) => value;
+    public int InspectRefReadonly(ref readonly int value) => value;
 }
 
 public static class OverloadExtensions

--- a/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
@@ -1,0 +1,161 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+public class GetOverloadsToolTests : IAsyncLifetime
+{
+    private LoadedSolution _loaded = null!;
+    private SymbolResolver _resolver = null!;
+    private MetadataSymbolResolver _metadata = null!;
+
+    public async Task InitializeAsync()
+    {
+        var fixturePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _resolver = new SymbolResolver(_loaded);
+        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public void Result_ReturnsAllOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.Contains("OverloadSamples", result.ContainingType, StringComparison.Ordinal);
+        Assert.Equal(3, result.Overloads.Count);
+    }
+
+    [Fact]
+    public void Result_SortedByParameterCountThenSignature()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        for (int i = 1; i < result.Overloads.Count; i++)
+        {
+            var prev = result.Overloads[i - 1];
+            var curr = result.Overloads[i];
+            if (prev.Parameters.Count == curr.Parameters.Count)
+                Assert.True(string.CompareOrdinal(prev.Signature, curr.Signature) <= 0,
+                    $"Sort violation: '{prev.Signature}' before '{curr.Signature}'");
+            else
+                Assert.True(prev.Parameters.Count < curr.Parameters.Count,
+                    $"Sort violation by param count");
+        }
+    }
+
+    [Fact]
+    public void Parameters_IncludeNamesAndTypes()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var twoParam = result.Overloads.Single(o => o.Parameters.Count == 2);
+        Assert.Equal("a", twoParam.Parameters[0].Name);
+        Assert.Equal("b", twoParam.Parameters[1].Name);
+        Assert.Contains("int", twoParam.Parameters[0].Type, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parameters_HasParamsFlag()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var paramsOverload = result.Overloads.Single(o =>
+            o.Parameters.Count == 1 && o.Parameters[0].IsParams);
+        Assert.Equal("values", paramsOverload.Parameters[0].Name);
+    }
+
+    [Fact]
+    public void Parameters_HasOptionalDefault()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Echo");
+
+        var echo = Assert.Single(result.Overloads);
+        var times = echo.Parameters[1];
+        Assert.Equal("times", times.Name);
+        Assert.True(times.IsOptional);
+        Assert.Equal("1", times.DefaultValue);
+    }
+
+    [Fact]
+    public void GenericMethod_TypeParametersPopulated()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        var generic = result.Overloads.Single(o => o.TypeParameters.Count > 0);
+        Assert.Contains("TKey", generic.TypeParameters);
+    }
+
+    [Fact]
+    public void XmlDocSummary_PopulatedForDocumentedMethod()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.All(result.Overloads, o =>
+        {
+            Assert.NotNull(o.XmlDocSummary);
+            Assert.NotEmpty(o.XmlDocSummary!);
+        });
+    }
+
+    [Fact]
+    public void ExtensionMethod_FlagSet()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadExtensions.Doubled");
+
+        Assert.NotEmpty(result.Overloads);
+        Assert.All(result.Overloads, o => Assert.True(o.IsExtensionMethod));
+    }
+
+    [Fact]
+    public void StaticMethod_IsStaticFlagSet()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.FromString");
+
+        Assert.Equal(2, result.Overloads.Count);
+        Assert.All(result.Overloads, o => Assert.True(o.IsStatic));
+    }
+
+    [Fact]
+    public void MetadataMethod_FindsAllBclOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "System.Console.WriteLine");
+
+        // BCL Console.WriteLine has 18+ overloads; require at least 10 to allow for runtime variation.
+        Assert.True(result.Overloads.Count >= 10,
+            $"Expected >=10 Console.WriteLine overloads, got {result.Overloads.Count}");
+    }
+
+    [Fact]
+    public void Constructors_ReturnsCtorOverloads()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "Greeter.Greeter");
+
+        // Greeter has at least an implicit/declared constructor.
+        Assert.NotEmpty(result.Overloads);
+    }
+
+    [Fact]
+    public void UnknownSymbol_ReturnsEmpty()
+    {
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "Does.Not.Exist");
+
+        Assert.Empty(result.ContainingType);
+        Assert.Empty(result.Overloads);
+    }
+
+    [Fact]
+    public void OperatorsExcluded()
+    {
+        // OverloadSamples doesn't define operators; querying Add must not include any operator-kind methods.
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Add");
+
+        Assert.All(result.Overloads, o =>
+            Assert.DoesNotContain("op_", o.Signature, StringComparison.Ordinal));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
@@ -75,11 +75,23 @@ public class GetOverloadsToolTests : IAsyncLifetime
     {
         var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Echo");
 
-        var echo = Assert.Single(result.Overloads);
-        var times = echo.Parameters[1];
+        var echo = result.Overloads.Single(o => o.Parameters.Any(p => p.IsOptional));
+        var times = echo.Parameters.Single(p => p.IsOptional);
         Assert.Equal("times", times.Name);
-        Assert.True(times.IsOptional);
         Assert.Equal("1", times.DefaultValue);
+    }
+
+    [Fact]
+    public void Parameters_RendersEnumDefaultBySymbolicName()
+    {
+        // FormatDefault should emit `OverloadColor.Red` for an enum default,
+        // not the underlying integer value (`0`).
+        var result = GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Paint");
+
+        var paint = Assert.Single(result.Overloads);
+        var color = paint.Parameters.Single(p => p.Name == "color");
+        Assert.True(color.IsOptional);
+        Assert.Equal("OverloadColor.Red", color.DefaultValue);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetOverloadsToolTests.cs
@@ -126,9 +126,28 @@ public class GetOverloadsToolTests : IAsyncLifetime
     {
         var result = GetOverloadsLogic.Execute(_resolver, _metadata, "System.Console.WriteLine");
 
-        // BCL Console.WriteLine has 18+ overloads; require at least 10 to allow for runtime variation.
-        Assert.True(result.Overloads.Count >= 10,
-            $"Expected >=10 Console.WriteLine overloads, got {result.Overloads.Count}");
+        // BCL Console.WriteLine on net10 has 19 public overloads; lock to >= 18 so a metadata-
+        // fallback regression that returns only the first match would be caught.
+        Assert.True(result.Overloads.Count >= 18,
+            $"Expected >=18 Console.WriteLine overloads, got {result.Overloads.Count}");
+    }
+
+    [Fact]
+    public void Parameters_RenderRefKindModifiers()
+    {
+        // Verify each RefKind variant survives BuildParameter — including `ref readonly`
+        // (RefKind.RefReadOnlyParameter) which previously fell through to empty modifier.
+        var tryParse = Assert.Single(GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.TryParse").Overloads);
+        Assert.Equal("out", tryParse.Parameters.Single(p => p.Name == "value").Modifier);
+
+        var increment = Assert.Single(GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.Increment").Overloads);
+        Assert.Equal("ref", increment.Parameters.Single(p => p.Name == "value").Modifier);
+
+        var inspectIn = Assert.Single(GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.InspectIn").Overloads);
+        Assert.Equal("in", inspectIn.Parameters.Single(p => p.Name == "value").Modifier);
+
+        var inspectRefReadonly = Assert.Single(GetOverloadsLogic.Execute(_resolver, _metadata, "OverloadSamples.InspectRefReadonly").Overloads);
+        Assert.Equal("ref readonly", inspectRefReadonly.Parameters.Single(p => p.Name == "value").Modifier);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- New `get_overloads` MCP tool: every overload of a method (or constructor) in one call — source AND metadata
- Each overload reports signature, return type, parameter names/types/modifiers (`ref`/`out`/`in`/`params`/optional with defaults), accessibility, modifiers (static/virtual/abstract/override/async/extension), generic type parameters, XML doc summary, and source location
- Pass `Type.Method` for ordinary methods or `Type.Type` for constructors; works for BCL APIs too (e.g. `System.Console.WriteLine`)
- Operator overloads excluded — separate query story
- Sort: parameter count ASC, then signature ordinal ASC

## Test plan
- [x] 13/13 `GetOverloadsToolTests` passing (all overloads, sort, parameter detail, params/optional/generic flags, XML docs, extension methods, static methods, BCL metadata, constructors, unknown symbol, operator exclusion)
- [x] `dotnet build` clean
- [x] Benchmark added: `get_overloads: System.Console.WriteLine`
- [x] Docs updated: SKILL.md (Red Flags, Quick Reference, Navigating Code), README, CLAUDE.md tool count (33 → 34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)