### PR TITLE
test: shared TestSolutionFixture eliminates per-test load flake + dramatic CI speedup

### DIFF
--- a/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
@@ -2,21 +2,19 @@ using Microsoft.CodeAnalysis;
 using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests;
 
-public class ApplyCodeActionLogicTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class ApplyCodeActionLogicTests
 {
-    private LoadedSolution _loaded = null!;
+    private readonly LoadedSolution _loaded;
 
-    public async Task InitializeAsync()
+    public ApplyCodeActionLogicTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task ExecuteAsync_WithPreview_ReturnsDiffWithoutWriting()

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
@@ -1,0 +1,35 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tests.Fixtures;
+
+/// <summary>
+/// Shared fixture that loads the test solution once per assembly. Used by tests via
+/// [Collection("TestSolution")]. Loading once eliminates per-test MSBuildWorkspace
+/// flakiness on Linux CI and dramatically speeds up the test suite.
+/// </summary>
+public class TestSolutionFixture : IAsyncLifetime
+{
+    public string SolutionPath { get; private set; } = null!;
+    public LoadedSolution Loaded { get; private set; } = null!;
+    public SymbolResolver Resolver { get; private set; } = null!;
+    public MetadataSymbolResolver Metadata { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        SolutionPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+        Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
+        Resolver = new SymbolResolver(Loaded);
+        Metadata = new MetadataSymbolResolver(Loaded, Resolver);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+/// <summary>
+/// xUnit collection definition that binds TestSolutionFixture to the "TestSolution"
+/// collection name. Tests opt in via [Collection("TestSolution")].
+/// </summary>
+[CollectionDefinition("TestSolution")]
+public class TestSolutionCollection : ICollectionFixture<TestSolutionFixture> { }

--- a/tests/RoslynCodeLens.Tests/GetCodeActionsLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/GetCodeActionsLogicTests.cs
@@ -2,21 +2,19 @@ using Microsoft.CodeAnalysis;
 using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests;
 
-public class GetCodeActionsLogicTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetCodeActionsLogicTests
 {
-    private LoadedSolution _loaded = null!;
+    private readonly LoadedSolution _loaded;
 
-    public async Task InitializeAsync()
+    public GetCodeActionsLogicTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task ExecuteAsync_AtMethodPosition_ReturnsCodeActions()

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -19,8 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Fixtures\**" />
-    <None Include="Fixtures\**" CopyToOutputDirectory="Never" />
+    <Compile Remove="Fixtures\TestSolution\**" />
+    <Compile Remove="Fixtures\TestSolutionAlt\**" />
+    <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs
+++ b/tests/RoslynCodeLens.Tests/Symbols/MetadataSymbolResolverTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Symbols;
 
-public class MetadataSymbolResolverTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class MetadataSymbolResolverTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _sourceResolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _sourceResolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public MetadataSymbolResolverTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _sourceResolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _sourceResolver);
+        _loaded = fixture.Loaded;
+        _sourceResolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Resolve_MetadataType_ReturnsMetadataSymbol()

--- a/tests/RoslynCodeLens.Tests/TestDiscovery/TestMethodClassifierTests.cs
+++ b/tests/RoslynCodeLens.Tests/TestDiscovery/TestMethodClassifierTests.cs
@@ -2,23 +2,21 @@ using Microsoft.CodeAnalysis;
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.TestDiscovery;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.TestDiscovery;
 
-public class TestMethodClassifierTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class TestMethodClassifierTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public TestMethodClassifierTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Classify_XUnitFactMethod_ReturnsXUnit()

--- a/tests/RoslynCodeLens.Tests/TestDiscovery/TestProjectDetectorTests.cs
+++ b/tests/RoslynCodeLens.Tests/TestDiscovery/TestProjectDetectorTests.cs
@@ -1,20 +1,18 @@
 using RoslynCodeLens;
 using RoslynCodeLens.TestDiscovery;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.TestDiscovery;
 
-public class TestProjectDetectorTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class TestProjectDetectorTests
 {
-    private LoadedSolution _loaded = null!;
+    private readonly LoadedSolution _loaded;
 
-    public async Task InitializeAsync()
+    public TestProjectDetectorTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetTestProjectIds_DetectsXUnitNUnitAndMSTest()

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeChangeImpactToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeChangeImpactToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class AnalyzeChangeImpactToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class AnalyzeChangeImpactToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public AnalyzeChangeImpactToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Execute_ForInterfaceMethod_ReturnsImpact()

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeControlFlowToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeControlFlowToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class AnalyzeControlFlowToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class AnalyzeControlFlowToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private string _diSetupPath = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly string _diSetupPath;
 
-    public async Task InitializeAsync()
+    public AnalyzeControlFlowToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
         _diSetupPath = _loaded.Solution.Projects
             .First(p => string.Equals(p.Name, "TestLib2", StringComparison.Ordinal))
             .Documents.First(d => string.Equals(d.Name, "DiSetup.cs", StringComparison.Ordinal))
             .FilePath!;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task ExecuteAsync_OnBlockBodyWithReturn_ReturnsSucceededFlowInfo()

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeDataFlowToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeDataFlowToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class AnalyzeDataFlowToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class AnalyzeDataFlowToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private string _greeterConsumerPath = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly string _greeterConsumerPath;
 
-    public async Task InitializeAsync()
+    public AnalyzeDataFlowToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
         _greeterConsumerPath = _loaded.Solution.Projects
             .First(p => string.Equals(p.Name, "TestLib2", StringComparison.Ordinal))
             .Documents.First(d => string.Equals(d.Name, "GreeterConsumer.cs", StringComparison.Ordinal))
             .FilePath!;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task ExecuteAsync_OnBlockBodyStatement_ReturnsFlowInfo()

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class AnalyzeMethodToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class AnalyzeMethodToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public AnalyzeMethodToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Execute_ForGreeterGreet_ReturnsAnalysis()

--- a/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAsyncViolationsToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindAsyncViolationsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindAsyncViolationsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindAsyncViolationsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Theory]
     [InlineData(AsyncViolationPattern.SyncOverAsyncResult, "GetResultViolation")]

--- a/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindAttributeUsagesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindAttributeUsagesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public FindAttributeUsagesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindAttributeUsages_Obsolete_FindsMarkedMember()

--- a/tests/RoslynCodeLens.Tests/Tools/FindBreakingChangesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindBreakingChangesToolTests.cs
@@ -6,25 +6,23 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindBreakingChangesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindBreakingChangesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private IReadOnlyList<PublicApiEntry> _currentSurface = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly IReadOnlyList<PublicApiEntry> _currentSurface;
 
-    public async Task InitializeAsync()
+    public FindBreakingChangesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
         _currentSurface = GetPublicApiSurfaceLogic.Execute(_loaded, _resolver).Entries;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Diff_NoChanges_ReturnsEmpty()

--- a/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindCallersToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindCallersToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public FindCallersToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindCallers_ForMethod_ReturnsCallSites()

--- a/tests/RoslynCodeLens.Tests/Tools/FindCircularDependenciesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCircularDependenciesToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindCircularDependenciesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindCircularDependenciesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindCircularDependenciesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindCircularDependencies_NoCycles_ReturnsEmpty()

--- a/tests/RoslynCodeLens.Tests/Tools/FindDisposableMisuseToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindDisposableMisuseToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindDisposableMisuseToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindDisposableMisuseToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindDisposableMisuseToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Theory]
     [InlineData(DisposableMisusePattern.DisposableNotDisposed, "NotDisposedFromConstructor")]

--- a/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
@@ -2,25 +2,23 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindEventSubscribersToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindEventSubscribersToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public FindEventSubscribersToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void UnknownSymbol_ReturnsEmpty()

--- a/tests/RoslynCodeLens.Tests/Tools/FindGodObjectsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindGodObjectsToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindGodObjectsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindGodObjectsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindGodObjectsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Result_FindsKnownGodObject()

--- a/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindImplementationsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindImplementationsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public FindImplementationsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindImplementations_ForInterface_ReturnsImplementors()

--- a/tests/RoslynCodeLens.Tests/Tools/FindLargeClassesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindLargeClassesToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindLargeClassesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindLargeClassesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindLargeClassesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindLargeClasses_LowThreshold_ReturnsResults()

--- a/tests/RoslynCodeLens.Tests/Tools/FindNamingViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindNamingViolationsToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindNamingViolationsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindNamingViolationsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindNamingViolationsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindNamingViolations_CleanCode_NoViolations()

--- a/tests/RoslynCodeLens.Tests/Tools/FindObsoleteUsageToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindObsoleteUsageToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindObsoleteUsageToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindObsoleteUsageToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindObsoleteUsageToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Result_FindsObsoleteWithMessage()

--- a/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindReferencesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindReferencesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public FindReferencesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindReferences_ForInterface_ReturnsUsages()

--- a/tests/RoslynCodeLens.Tests/Tools/FindReflectionUsageToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReflectionUsageToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindReflectionUsageToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindReflectionUsageToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindReflectionUsageToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindReflection_DetectsActivatorCreateInstance()

--- a/tests/RoslynCodeLens.Tests/Tools/FindTestsForSymbolToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindTestsForSymbolToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.TestDiscovery;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindTestsForSymbolToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindTestsForSymbolToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindTestsForSymbolToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Direct_FindsXUnitNUnitAndMSTestTestsForGreeter()

--- a/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
@@ -3,23 +3,21 @@ using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.TestDiscovery;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindUncoveredSymbolsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindUncoveredSymbolsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindUncoveredSymbolsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Result_GreetFormal_AppearsAsUncovered()

--- a/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class FindUnusedSymbolsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class FindUnusedSymbolsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public FindUnusedSymbolsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindUnusedSymbols_ReturnsResults()

--- a/tests/RoslynCodeLens.Tests/Tools/GetCallGraphToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetCallGraphToolTests.cs
@@ -2,25 +2,23 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetCallGraphToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetCallGraphToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public GetCallGraphToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task UnknownSymbol_ReturnsNull()

--- a/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetCodeFixesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetCodeFixesToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetCodeFixesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task GetCodeFixes_NoMatchingDiagnostic_ReturnsEmpty()

--- a/tests/RoslynCodeLens.Tests/Tools/GetComplexityMetricsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetComplexityMetricsToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetComplexityMetricsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetComplexityMetricsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetComplexityMetricsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetComplexityMetrics_AllMethods_ReturnsResults()

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiRegistrationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiRegistrationsToolTests.cs
@@ -1,22 +1,20 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetDiRegistrationsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetDiRegistrationsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetDiRegistrationsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void FindDiRegistrations_ForIGreeter_ReturnsRegistration()

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
@@ -1,10 +1,12 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetDiagnosticsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetDiagnosticsToolTests
 {
     // The three test-framework adapter sub-projects depend on PackageReferences for
     // MSTest.TestFramework / NUnit / xunit. Those packages intermittently fail to resolve
@@ -16,18 +18,14 @@ public class GetDiagnosticsToolTests : IAsyncLifetime
     private static readonly string[] AdapterProjects =
         ["NUnitFixture", "MSTestFixture", "XUnitFixture"];
 
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetDiagnosticsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetDiagnostics_CleanSolution_ReturnsNoErrors()

--- a/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
@@ -1,27 +1,25 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetFileOverviewToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetFileOverviewToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private string _greeterPath = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly string _greeterPath;
 
-    public async Task InitializeAsync()
+    public GetFileOverviewToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
         _greeterPath = _loaded.Solution.Projects
             .First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal))
             .Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal))
             .FilePath!;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public async Task ExecuteAsync_ForGreeterFile_ReturnsOverview()

--- a/tests/RoslynCodeLens.Tests/Tools/GetGeneratedCodeToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetGeneratedCodeToolTests.cs
@@ -1,21 +1,19 @@
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetGeneratedCodeToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetGeneratedCodeToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetGeneratedCodeToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Execute_ReturnsEmpty_WhenFileNotFound()

--- a/tests/RoslynCodeLens.Tests/Tools/GetNugetDependenciesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetNugetDependenciesToolTests.cs
@@ -1,20 +1,18 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetNugetDependenciesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetNugetDependenciesToolTests
 {
-    private LoadedSolution _loaded = null!;
+    private readonly LoadedSolution _loaded;
 
-    public async Task InitializeAsync()
+    public GetNugetDependenciesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetNugetDependencies_AllProjects_ReturnsPackages()

--- a/tests/RoslynCodeLens.Tests/Tools/GetProjectDependenciesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetProjectDependenciesToolTests.cs
@@ -1,20 +1,18 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetProjectDependenciesToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetProjectDependenciesToolTests
 {
-    private LoadedSolution _loaded = null!;
+    private readonly LoadedSolution _loaded;
 
-    public async Task InitializeAsync()
+    public GetProjectDependenciesToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
+        _loaded = fixture.Loaded;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetDependencies_ForTestLib2_ReturnsTestLib()

--- a/tests/RoslynCodeLens.Tests/Tools/GetProjectHealthToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetProjectHealthToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetProjectHealthToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetProjectHealthToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetProjectHealthToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Result_HasOneEntryPerProductionProject()

--- a/tests/RoslynCodeLens.Tests/Tools/GetPublicApiSurfaceToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetPublicApiSurfaceToolTests.cs
@@ -2,23 +2,21 @@ using RoslynCodeLens;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetPublicApiSurfaceToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetPublicApiSurfaceToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetPublicApiSurfaceToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Theory]
     [InlineData(PublicApiKind.Class)]

--- a/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
@@ -1,21 +1,19 @@
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetSourceGeneratorsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetSourceGeneratorsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
 
-    public async Task InitializeAsync()
+    public GetSourceGeneratorsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Execute_ReturnsEmptyList_WhenNoGenerators()

--- a/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetSymbolContextToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetSymbolContextToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public GetSymbolContextToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetContext_ForGreeterConsumer_ShowsInjectedDeps()

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetTypeHierarchyToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetTypeHierarchyToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public GetTypeHierarchyToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GetHierarchy_ForGreeter_ShowsBaseAndDerived()

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GetTypeOverviewToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GetTypeOverviewToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public GetTypeOverviewToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Execute_ForGreeter_ReturnsFullOverview()

--- a/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class GoToDefinitionToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class GoToDefinitionToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public GoToDefinitionToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void GoToDefinition_ForType_ReturnsLocation()

--- a/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/InspectExternalAssemblyToolTests.cs
@@ -1,23 +1,21 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class InspectExternalAssemblyToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class InspectExternalAssemblyToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public InspectExternalAssemblyToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _metadata = new MetadataSymbolResolver(_loaded, new SymbolResolver(_loaded));
+        _loaded = fixture.Loaded;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void Summary_ListsNamespacesAndCounts()

--- a/tests/RoslynCodeLens.Tests/Tools/PeekIlToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/PeekIlToolTests.cs
@@ -2,29 +2,29 @@ using RoslynCodeLens;
 using RoslynCodeLens.Metadata;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class PeekIlToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class PeekIlToolTests : IDisposable
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
-    private IlDisassemblerAdapter _adapter = null!;
-    private PEFileCache _peCache = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
+    private readonly IlDisassemblerAdapter _adapter;
+    private readonly PEFileCache _peCache;
 
-    public async Task InitializeAsync()
+    public PeekIlToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
         _peCache = new PEFileCache();
         _adapter = new IlDisassemblerAdapter(_peCache);
     }
 
-    public Task DisposeAsync() { _peCache.Dispose(); return Task.CompletedTask; }
+    public void Dispose() { _peCache.Dispose(); GC.SuppressFinalize(this); }
 
     [Fact]
     public void Peek_MetadataCtor_ReturnsIlText()

--- a/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
@@ -1,25 +1,23 @@
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests.Tools;
 
-public class SearchSymbolsToolTests : IAsyncLifetime
+[Collection("TestSolution")]
+public class SearchSymbolsToolTests
 {
-    private LoadedSolution _loaded = null!;
-    private SymbolResolver _resolver = null!;
-    private MetadataSymbolResolver _metadata = null!;
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+    private readonly MetadataSymbolResolver _metadata;
 
-    public async Task InitializeAsync()
+    public SearchSymbolsToolTests(TestSolutionFixture fixture)
     {
-        var fixturePath = Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        _loaded = await new SolutionLoader().LoadAsync(fixturePath).ConfigureAwait(false);
-        _resolver = new SymbolResolver(_loaded);
-        _metadata = new MetadataSymbolResolver(_loaded, _resolver);
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+        _metadata = fixture.Metadata;
     }
-
-    public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
     public void SearchSymbols_ByTypeName_FindsTypes()


### PR DESCRIPTION
## Summary
- New `TestSolutionFixture` + `[CollectionDefinition(\"TestSolution\")]` — fixture solution loads ONCE per assembly via xUnit's collection-fixture pattern
- 45 read-only test classes migrated to `[Collection(\"TestSolution\")]` + constructor-injected fixture
- Tests that need per-test fresh state (FileChangeTracker, MultiSolutionManager, runner tests) deliberately left as-is

## Why
Every `IAsyncLifetime`-based test class re-loaded the fixture from scratch via MSBuildWorkspace in `InitializeAsync`. With ~50 such classes, each test paid the full load cost AND ~30% of those loads on Linux CI returned partially-populated compilations — surfacing as **different empty-result test failures on every CI run** (`TwoSubscriptionsOnSameLine`, `Result_FindsKnownGodObject`, `FindAttributeUsages_FullyQualifiedMetadata`, etc.). The flake has been blocking every PR all session.

## Result
- **346/346 tests pass** (same count as before; behavior preserved)
- **Test time: 4m37s** for the full suite (vs ~12-15min before, when each class re-loaded)
- **Flake source eliminated**: the load happens exactly once per assembly run

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — 346/346 pass
- [ ] CI Build & Test confirms green on first run (no re-runs needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)