### PR TITLE
feat: add get_test_summary MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 34 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 35 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **find_callers** — Find every call site for a method, property, or constructor
 - **find_event_subscribers** — Every += / -= site for an event symbol, with resolved handler and subscribe/unsubscribe tag
 - **find_tests_for_symbol** — List xUnit/NUnit/MSTest methods that exercise a production symbol; opt-in transitive walk through helpers
+- **get_test_summary** — Per-project inventory of test methods with framework, attribute kind, data-row count, location, and production symbols referenced
 - **find_uncovered_symbols** — Public methods and properties no test transitively reaches; sorted by cyclomatic complexity for prioritization
 - **get_type_hierarchy** — Walk base classes, interfaces, and derived types
 - **get_di_registrations** — Scan for DI service registrations

--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -116,6 +116,12 @@ public class CodeGraphBenchmarks
             _loaded, _resolver, "IGreeter.Greet", transitive: true, maxDepth: 3);
     }
 
+    [Benchmark(Description = "get_test_summary: whole solution")]
+    public object GetTestSummary()
+    {
+        return GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+    }
+
     [Benchmark(Description = "get_type_hierarchy: Greeter")]
     public object GetTypeHierarchy()
     {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -84,3 +84,9 @@ Items considered during design of shipped features and consciously punted on. Re
 - **Return-type changes** — `PublicApiEntry` schema doesn't capture them.
 - **Sealed-ness changes** — same.
 - **Nullable-annotation changes** — same.
+
+### From `get_test_summary` (designed 2026-05-01)
+- **Async-test flagging** — `IsAsync` could surface as a per-test field; not included now.
+- **Skip-reason surface** for `[Fact(Skip = "…")]` / `[Ignore("…")]` — agent can compose via `find_attribute_usages` if needed.
+- **`[MemberData]` / `[ClassData]` row tracking** — only inline `[InlineData]`/`[TestCase]`/`[DataRow]` are counted; data-source attributes don't expose row count without runtime evaluation.
+- **Cross-project test→production coverage map** — that's `find_tests_for_symbol` territory in reverse.

--- a/docs/plans/2026-05-01-get-test-summary-design.md
+++ b/docs/plans/2026-05-01-get-test-summary-design.md
@@ -1,0 +1,158 @@
+# `get_test_summary` Design
+
+**Status:** Approved 2026-05-01
+
+## Goal
+
+Per-project inventory of test methods. Each test reports framework, attribute kind, data-driven row count, location, and the production symbols it references. Complements `find_tests_for_symbol` (test → production); this goes project → tests.
+
+## Use cases
+
+- "What does this test suite cover?" — see referenced production symbols across all tests in a project.
+- "How is the test framework distribution split?" — `ByFramework` counts tell you "45 xUnit, 12 NUnit, 8 MSTest."
+- "Show me all `[Theory]` tests with row counts" — agent filters by attribute + sorts by `InlineDataRowCount`.
+
+## API
+
+```csharp
+GetTestSummaryResult Execute(string? project = null)
+```
+
+`project` filters to a single test project (case-insensitive). Default = all test projects in the solution.
+
+## Output
+
+```csharp
+public record GetTestSummaryResult(
+    IReadOnlyList<ProjectTestSummary> Projects);
+
+public record ProjectTestSummary(
+    string Project,
+    int TotalTests,
+    IReadOnlyDictionary<string, int> ByFramework,   // "XUnit" → 45, ...
+    IReadOnlyDictionary<string, int> ByAttribute,   // "Fact" → 30, "Theory" → 15, ...
+    IReadOnlyList<TestMethodSummary> Tests);
+
+public record TestMethodSummary(
+    string MethodName,                // fully-qualified
+    string Framework,                 // "XUnit" / "NUnit" / "MSTest"
+    string AttributeShortName,        // "Fact" / "Theory" / "Test" / "TestCase" / "TestMethod" / "DataTestMethod"
+    int InlineDataRowCount,           // 0 for non-data-driven; N for [InlineData]/[TestCase]/[DataRow]
+    IReadOnlyList<string> ReferencedSymbols,
+    string FilePath,
+    int Line);
+```
+
+## What counts as a "referenced symbol"
+
+Walk the test method body. For each `InvocationExpressionSyntax` / `ObjectCreationExpressionSyntax` / `MemberAccessExpressionSyntax`:
+- Resolve via `SemanticModel.GetSymbolInfo` to `IMethodSymbol` / `IPropertySymbol` / `IFieldSymbol`.
+- **Exclude** anything in framework or BCL namespaces:
+  - `Xunit.*`
+  - `NUnit.Framework.*`
+  - `Microsoft.VisualStudio.TestTools.UnitTesting.*`
+  - `System.*` and `Microsoft.*` (BCL)
+- Distinct, sorted ordinal — keeps output stable.
+
+Surface form: `IMethodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)` minus `global::`.
+
+## InlineData / TestCase / DataRow row count
+
+Count attributes on the test method whose name matches the framework's data-row attribute:
+- xUnit: `[InlineData]`
+- NUnit: `[TestCase]`
+- MSTest: `[DataRow]`
+
+For non-data-driven tests, `InlineDataRowCount: 0`.
+
+## Architecture
+
+1. **Detect test projects** — `TestProjectDetector.GetTestProjectIds(loaded.Solution)`. If `project` argument is non-null, narrow to that one (case-insensitive `Project.Name` match).
+2. **Walk methods** — for each test project's compilation, recursively enumerate types (`compilation.GlobalNamespace`), find methods, filter by `TestMethodClassifier.IsTestMethod`.
+3. **Classify** — `TestMethodClassifier.Classify(method)` returns the framework + attribute short name.
+4. **Count data rows** — walk attributes again, count those whose attribute-class short name matches the framework's data-row attribute.
+5. **Resolve referenced symbols** — get the method's body syntax, walk descendants, resolve symbols via `SemanticModel`, filter framework/BCL.
+6. **Group + sort + build counts** — sort tests within project by `(FilePath, Line)` ordinal; sort projects by name ASC; build `ByFramework`/`ByAttribute` dictionaries.
+
+## Scope decisions
+
+| Concern | Decision |
+|---|---|
+| Production projects | Excluded — only test projects scanned |
+| Test fixtures (`MSTestFixture`, etc.) | Included — they're test-shaped projects with declared test methods |
+| Generated code | Skipped (consistent with other audit tools) |
+| Inherited tests | Counted at the inheriting type only if it declares the attribute locally |
+| Async tests | Same handling as sync — async-ness not surfaced |
+| Disabled tests (`[Fact(Skip = "…")]`) | Counted normally — agent can filter client-side |
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| Test method calling another test method | Production-symbol filter excludes it (other test methods are in same test project, so `IsTestMethod` true → not a production reference). Or: include if not classified as a test method itself. Choose: exclude — they're test scaffolding. |
+| Method with no body (interface declaration / abstract) | Skipped (not a runnable test) |
+| Test with `[InlineData]` count = 0 (parameterless `[Theory]`) | `InlineDataRowCount: 0` (degenerate) |
+| Symbol resolves to a delegate-typed field/property | Counted; the field's FQN is recorded |
+
+## Performance
+
+`TestProjectDetector.GetTestProjectIds` is cached and O(P). Per-test-method body walks are bounded by method size; symbol resolution is the dominant cost. Comparable to `find_tests_for_symbol` (transitive mode) per project.
+
+Benchmark: `get_test_summary: whole solution`.
+
+## MCP wrapper
+
+Standard pattern matching `find_uncovered_symbols` (whole-solution audit composite):
+
+```csharp
+[McpServerToolType]
+public static class GetTestSummaryTool
+{
+    [McpServerTool(Name = "get_test_summary")]
+    [Description(...)]
+    public static GetTestSummaryResult Execute(MultiSolutionManager manager, string? project = null)
+    { ... }
+}
+```
+
+Auto-registered via `WithToolsFromAssembly()`.
+
+## Testing
+
+Use existing `XUnitFixture` / `NUnitFixture` / `MSTestFixture` projects. They already have `SampleTests.cs` with `[Fact]`/`[Theory]`/`[Test]`/`[TestCase]`/`[TestMethod]`/`[DataRow]` patterns calling `Greeter.Greet`.
+
+Tests:
+- `Result_FindsXUnitTests`
+- `Result_FindsNUnitTests`
+- `Result_FindsMSTestTests`
+- `InlineDataRowCount_PopulatedForXUnitTheory`
+- `InlineDataRowCount_ZeroForFact`
+- `ReferencedSymbols_IncludeProductionCalls`
+- `ReferencedSymbols_ExcludesFrameworkAndBcl`
+- `ProjectFilter_OnlyReturnsRequestedProject`
+- `Result_OmitsProductionProjects` (TestLib / TestLib2 absent)
+- `ByFramework_CountsAreCorrect`
+- `ByAttribute_CountsAreCorrect`
+- `Tests_SortedByFileLine`
+- `UnknownProject_ReturnsEmptyList`
+
+## Out of scope (deferred — append to BACKLOG.md)
+
+- **Async-test flagging** — `IsAsync` could surface but isn't included now.
+- **Skip-reason surface** for `[Fact(Skip = "…")]` / `[Ignore]` — agent can compute via `find_attribute_usages` if needed.
+- **`[MemberData]` / `[ClassData]` row tracking** — only inline rows are counted; theory data-source attributes don't expose row count without runtime evaluation.
+- **Cross-project test→production coverage map** — that's `find_tests_for_symbol` territory, used in reverse.
+
+## File checklist
+
+- `src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs`
+- `src/RoslynCodeLens/Tools/GetTestSummaryTool.cs`
+- `src/RoslynCodeLens/Models/GetTestSummaryResult.cs`
+- `src/RoslynCodeLens/Models/ProjectTestSummary.cs`
+- `src/RoslynCodeLens/Models/TestMethodSummary.cs`
+- `tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs`
+- `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs` — add benchmark
+- `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` — Red Flags, Quick Reference, Test-aware
+- `README.md` — Features list
+- `CLAUDE.md` — bump tool count
+- `docs/BACKLOG.md` — append deferred items

--- a/docs/plans/2026-05-01-get-test-summary-design.md
+++ b/docs/plans/2026-05-01-get-test-summary-design.md
@@ -48,13 +48,14 @@ public record TestMethodSummary(
 Walk the test method body. For each `InvocationExpressionSyntax` / `ObjectCreationExpressionSyntax` / `MemberAccessExpressionSyntax`:
 - Resolve via `SemanticModel.GetSymbolInfo` to `IMethodSymbol` / `IPropertySymbol` / `IFieldSymbol`.
 - **Exclude** anything in framework or BCL namespaces:
-  - `Xunit.*`
+  - `Xunit.*` (covers `Xunit.Sdk.*`, `Xunit.Abstractions.*` too)
   - `NUnit.Framework.*`
   - `Microsoft.VisualStudio.TestTools.UnitTesting.*`
-  - `System.*` and `Microsoft.*` (BCL)
+  - `System.*`
+  - Narrow `Microsoft.*` BCL/SDK subtrees only: `Microsoft.CSharp.*`, `Microsoft.VisualBasic.*`, `Microsoft.Win32.*`. `Microsoft.Extensions.*`, `Microsoft.AspNetCore.*`, `Microsoft.EntityFrameworkCore`, etc. are NOT excluded — they're legitimate production references.
 - Distinct, sorted ordinal — keeps output stable.
 
-Surface form: `IMethodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)` minus `global::`.
+Surface form: `IMethodSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType))` minus `global::`. The `IncludeContainingType` member option is required — the bare `FullyQualifiedFormat` strips containing-type info from members and produces just the bare member name (`Greet` instead of `TestLib.Greeter.Greet`).
 
 ## InlineData / TestCase / DataRow row count
 

--- a/docs/plans/2026-05-01-get-test-summary.md
+++ b/docs/plans/2026-05-01-get-test-summary.md
@@ -1,0 +1,666 @@
+# `get_test_summary` Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a new MCP tool `get_test_summary` that returns a per-project inventory of test methods, including framework/attribute kind, data-row count, source location, and the production symbols each test references.
+
+**Architecture:** Walk all test projects (via `TestProjectDetector.GetTestProjectIds`). For each project's compilation, recursively enumerate types and methods, filter via `TestMethodClassifier.IsTestMethod`. Per test method, capture classification (framework + attribute short name), count data-row attributes, walk method body for production-symbol references (excluding framework + BCL namespaces). Group by project, build counts, sort.
+
+**Tech Stack:** Roslyn (`Microsoft.CodeAnalysis`, `Microsoft.CodeAnalysis.CSharp.Syntax`), xUnit, BenchmarkDotNet, ModelContextProtocol.Server.
+
+**Reference design:** `docs/plans/2026-05-01-get-test-summary-design.md`
+
+**Patterns to mirror:**
+- Test-project filter: `RoslynCodeLens.TestDiscovery.TestProjectDetector.GetTestProjectIds(loaded.Solution)` (returns ImmutableHashSet<ProjectId>)
+- Test-method classification: `RoslynCodeLens.TestDiscovery.TestMethodClassifier.Classify(method)` returns `TestMethodClassification?` with `Framework` (`TestFramework` enum: XUnit/NUnit/MSTest) and `AttributeShortName`
+- Composite tool pattern: `src/RoslynCodeLens/Tools/GetProjectHealthLogic.cs`
+- MCP wrapper auto-registration: `Program.cs:35` uses `WithToolsFromAssembly()` — no edit needed.
+
+---
+
+## Task 1: Models
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/TestMethodSummary.cs`
+- Create: `src/RoslynCodeLens/Models/ProjectTestSummary.cs`
+- Create: `src/RoslynCodeLens/Models/GetTestSummaryResult.cs`
+
+**Step 1: `TestMethodSummary.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record TestMethodSummary(
+    string MethodName,
+    string Framework,
+    string AttributeShortName,
+    int InlineDataRowCount,
+    IReadOnlyList<string> ReferencedSymbols,
+    string FilePath,
+    int Line);
+```
+
+**Step 2: `ProjectTestSummary.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record ProjectTestSummary(
+    string Project,
+    int TotalTests,
+    IReadOnlyDictionary<string, int> ByFramework,
+    IReadOnlyDictionary<string, int> ByAttribute,
+    IReadOnlyList<TestMethodSummary> Tests);
+```
+
+**Step 3: `GetTestSummaryResult.cs`**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record GetTestSummaryResult(
+    IReadOnlyList<ProjectTestSummary> Projects);
+```
+
+**Step 4: Build**
+
+```bash
+dotnet build src/RoslynCodeLens
+```
+
+Expected: 0 errors.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Models/TestMethodSummary.cs \
+  src/RoslynCodeLens/Models/ProjectTestSummary.cs \
+  src/RoslynCodeLens/Models/GetTestSummaryResult.cs
+git commit -m "feat: add models for get_test_summary"
+```
+
+---
+
+## Task 2: `GetTestSummaryLogic` + tests (TDD)
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs`
+- Create: `tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs`
+
+**Step 1: Write the failing tests**
+
+`tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs`:
+
+```csharp
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+[Collection("TestSolution")]
+public class GetTestSummaryToolTests
+{
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+
+    public GetTestSummaryToolTests(TestSolutionFixture fixture)
+    {
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+    }
+
+    [Fact]
+    public void Result_FindsXUnitTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var xUnitProject = Assert.Single(result.Projects, p => p.Project == "XUnitFixture");
+        Assert.True(xUnitProject.TotalTests > 0);
+        Assert.Contains("XUnit", xUnitProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void Result_FindsNUnitTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var nUnitProject = Assert.Single(result.Projects, p => p.Project == "NUnitFixture");
+        Assert.True(nUnitProject.TotalTests > 0);
+        Assert.Contains("NUnit", nUnitProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void Result_FindsMSTestTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var msTestProject = Assert.Single(result.Projects, p => p.Project == "MSTestFixture");
+        Assert.True(msTestProject.TotalTests > 0);
+        Assert.Contains("MSTest", msTestProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void InlineDataRowCount_PopulatedForXUnitTheory()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        // SampleTests has a [Theory] with [InlineData] rows — count must be > 0.
+        var theory = project.Tests.FirstOrDefault(t =>
+            string.Equals(t.AttributeShortName, "Theory", StringComparison.Ordinal));
+        Assert.NotNull(theory);
+        Assert.True(theory!.InlineDataRowCount > 0,
+            $"Expected InlineDataRowCount > 0 for theory {theory.MethodName}, got {theory.InlineDataRowCount}");
+    }
+
+    [Fact]
+    public void InlineDataRowCount_ZeroForFact()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        var fact = project.Tests.FirstOrDefault(t =>
+            string.Equals(t.AttributeShortName, "Fact", StringComparison.Ordinal));
+        Assert.NotNull(fact);
+        Assert.Equal(0, fact!.InlineDataRowCount);
+    }
+
+    [Fact]
+    public void ReferencedSymbols_IncludeProductionCalls()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        // SampleTests calls Greeter.Greet — every test should list a TestLib production symbol.
+        Assert.Contains(project.Tests, t =>
+            t.ReferencedSymbols.Any(s => s.Contains("TestLib", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ReferencedSymbols_ExcludesFrameworkAndBcl()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        foreach (var test in project.Tests)
+        {
+            foreach (var symbol in test.ReferencedSymbols)
+            {
+                Assert.False(symbol.StartsWith("Xunit", StringComparison.Ordinal),
+                    $"Test {test.MethodName} referenced framework symbol {symbol}");
+                Assert.False(symbol.StartsWith("System.", StringComparison.Ordinal) || symbol == "System",
+                    $"Test {test.MethodName} referenced BCL symbol {symbol}");
+                Assert.False(symbol.StartsWith("Microsoft.", StringComparison.Ordinal) || symbol == "Microsoft",
+                    $"Test {test.MethodName} referenced Microsoft.* symbol {symbol}");
+                Assert.False(symbol.StartsWith("NUnit.Framework", StringComparison.Ordinal),
+                    $"Test {test.MethodName} referenced NUnit framework symbol {symbol}");
+            }
+        }
+    }
+
+    [Fact]
+    public void ProjectFilter_OnlyReturnsRequestedProject()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        Assert.Equal("XUnitFixture", project.Project);
+    }
+
+    [Fact]
+    public void Result_OmitsProductionProjects()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        Assert.DoesNotContain(result.Projects, p => p.Project == "TestLib");
+        Assert.DoesNotContain(result.Projects, p => p.Project == "TestLib2");
+    }
+
+    [Fact]
+    public void ByFramework_CountsAreCorrect()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            foreach (var (frameworkName, count) in project.ByFramework)
+            {
+                var actual = project.Tests.Count(t =>
+                    string.Equals(t.Framework, frameworkName, StringComparison.Ordinal));
+                Assert.Equal(actual, count);
+            }
+        }
+    }
+
+    [Fact]
+    public void ByAttribute_CountsAreCorrect()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            foreach (var (attrName, count) in project.ByAttribute)
+            {
+                var actual = project.Tests.Count(t =>
+                    string.Equals(t.AttributeShortName, attrName, StringComparison.Ordinal));
+                Assert.Equal(actual, count);
+            }
+        }
+    }
+
+    [Fact]
+    public void Tests_SortedByFileLine()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            for (int i = 1; i < project.Tests.Count; i++)
+            {
+                var prev = project.Tests[i - 1];
+                var curr = project.Tests[i];
+                var fileCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+                Assert.True(fileCmp < 0 || (fileCmp == 0 && prev.Line <= curr.Line),
+                    $"Sort violation in {project.Project} at index {i}: '{prev.FilePath}:{prev.Line}' before '{curr.FilePath}:{curr.Line}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void UnknownProject_ReturnsEmptyList()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "DoesNotExist");
+
+        Assert.Empty(result.Projects);
+    }
+
+    [Fact]
+    public void Tests_PopulatedWithMethodNameAndLocation()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        Assert.NotEmpty(result.Projects);
+        foreach (var project in result.Projects)
+        {
+            Assert.All(project.Tests, t =>
+            {
+                Assert.NotEmpty(t.MethodName);
+                Assert.NotEmpty(t.Framework);
+                Assert.NotEmpty(t.AttributeShortName);
+                Assert.NotEmpty(t.FilePath);
+                Assert.True(t.Line > 0);
+            });
+        }
+    }
+}
+```
+
+**Step 2: Run failing**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetTestSummaryToolTests"
+```
+
+Expect compile error (`GetTestSummaryLogic` doesn't exist).
+
+**Step 3: Create `src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs`**
+
+```csharp
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.TestDiscovery;
+
+namespace RoslynCodeLens.Tools;
+
+public static class GetTestSummaryLogic
+{
+    private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat;
+
+    public static GetTestSummaryResult Execute(
+        LoadedSolution loaded, SymbolResolver resolver, string? project)
+    {
+        var testProjectIds = TestProjectDetector.GetTestProjectIds(loaded.Solution);
+        var entries = new List<ProjectTestSummary>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            if (!testProjectIds.Contains(projectId)) continue;
+
+            var projectName = resolver.GetProjectName(projectId);
+            if (project is not null && !string.Equals(projectName, project, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var tests = new List<TestMethodSummary>();
+
+            foreach (var type in EnumerateTypes(compilation.Assembly.GlobalNamespace))
+            {
+                if (!type.Locations.Any(l => l.IsInSource)) continue;
+
+                foreach (var member in type.GetMembers().OfType<IMethodSymbol>())
+                {
+                    var classification = TestMethodClassifier.Classify(member);
+                    if (classification is null) continue;
+
+                    var (file, line) = GetFileAndLine(member);
+                    if (string.IsNullOrEmpty(file)) continue;
+
+                    var rowCount = CountInlineDataRows(member, classification.Framework);
+                    var referenced = CollectReferencedSymbols(member, compilation);
+
+                    tests.Add(new TestMethodSummary(
+                        MethodName: member.ToDisplayString(FqnFormat).Replace("global::", string.Empty, StringComparison.Ordinal),
+                        Framework: classification.Framework.ToString(),
+                        AttributeShortName: classification.AttributeShortName,
+                        InlineDataRowCount: rowCount,
+                        ReferencedSymbols: referenced,
+                        FilePath: file,
+                        Line: line));
+                }
+            }
+
+            tests.Sort((a, b) =>
+            {
+                var fileCmp = string.CompareOrdinal(a.FilePath, b.FilePath);
+                return fileCmp != 0 ? fileCmp : a.Line.CompareTo(b.Line);
+            });
+
+            var byFramework = tests
+                .GroupBy(t => t.Framework, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+            var byAttribute = tests
+                .GroupBy(t => t.AttributeShortName, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+            entries.Add(new ProjectTestSummary(
+                Project: projectName,
+                TotalTests: tests.Count,
+                ByFramework: byFramework,
+                ByAttribute: byAttribute,
+                Tests: tests));
+        }
+
+        entries.Sort((a, b) => string.CompareOrdinal(a.Project, b.Project));
+        return new GetTestSummaryResult(entries);
+    }
+
+    private static int CountInlineDataRows(IMethodSymbol method, TestFramework framework)
+    {
+        var dataAttributeName = framework switch
+        {
+            TestFramework.XUnit => "InlineDataAttribute",
+            TestFramework.NUnit => "TestCaseAttribute",
+            TestFramework.MSTest => "DataRowAttribute",
+            _ => null,
+        };
+        if (dataAttributeName is null) return 0;
+
+        return method.GetAttributes().Count(a =>
+            string.Equals(a.AttributeClass?.Name, dataAttributeName, StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<string> CollectReferencedSymbols(IMethodSymbol method, Compilation compilation)
+    {
+        var location = method.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location?.SourceTree is null) return [];
+
+        var semanticModel = compilation.GetSemanticModel(location.SourceTree);
+        var bodyNode = location.SourceTree.GetRoot().FindNode(location.SourceSpan);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var node in bodyNode.DescendantNodesAndSelf())
+        {
+            var symbol = semanticModel.GetSymbolInfo(node).Symbol;
+            if (symbol is null) continue;
+            if (symbol is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)) continue;
+
+            var ns = symbol.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            // Containing-type's namespace for members:
+            if (symbol is not INamedTypeSymbol)
+                ns = symbol.ContainingType?.ContainingNamespace?.ToDisplayString() ?? ns;
+
+            if (IsExcludedNamespace(ns)) continue;
+
+            var fqn = symbol.ToDisplayString(FqnFormat).Replace("global::", string.Empty, StringComparison.Ordinal);
+            seen.Add(fqn);
+        }
+
+        return seen.OrderBy(x => x, StringComparer.Ordinal).ToList();
+    }
+
+    private static bool IsExcludedNamespace(string ns)
+    {
+        if (string.IsNullOrEmpty(ns)) return false;
+        return ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)
+            || ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)
+            || ns == "Microsoft.VisualStudio.TestTools.UnitTesting" || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)
+            || ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)
+            || ns == "Microsoft" || ns.StartsWith("Microsoft.", StringComparison.Ordinal);
+    }
+
+    private static (string File, int Line) GetFileAndLine(ISymbol symbol)
+    {
+        var location = symbol.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location is null) return (string.Empty, 0);
+        var span = location.GetLineSpan();
+        return (span.Path, span.StartLinePosition.Line + 1);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol ns)
+    {
+        foreach (var type in ns.GetTypeMembers())
+        {
+            yield return type;
+            foreach (var nested in EnumerateNestedTypes(type))
+                yield return nested;
+        }
+        foreach (var nested in ns.GetNamespaceMembers())
+            foreach (var type in EnumerateTypes(nested))
+                yield return type;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (var nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (var deeper in EnumerateNestedTypes(nested))
+                yield return deeper;
+        }
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetTestSummaryToolTests"
+```
+
+Expect 13/13 pass.
+
+**Common debugging:**
+- If `Result_FindsXUnitTests` fails: ensure `EnumerateTypes` walks all nested namespaces correctly. If `XUnitFixture` is missing, the project filter is wrong — check `TestProjectDetector.GetTestProjectIds` includes it.
+- If `ReferencedSymbols_ExcludesFrameworkAndBcl` fails: the `IsExcludedNamespace` check needs to match all framework/BCL prefixes. Double-check the exact namespaces (some xUnit symbols are in `Xunit.Sdk`, etc.).
+- If `InlineDataRowCount_PopulatedForXUnitTheory` reports 0: ensure the attribute-class name comparison matches `"InlineDataAttribute"` exactly (with the `Attribute` suffix, since Roslyn's `AttributeClass.Name` includes it).
+- If `Tests_PopulatedWithMethodNameAndLocation` fails on `MethodName`: ensure `FullyQualifiedFormat` strips `global::` correctly.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs \
+  tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs
+git commit -m "feat: add GetTestSummaryLogic with tests"
+```
+
+---
+
+## Task 3: MCP wrapper
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/GetTestSummaryTool.cs`
+
+**Step 1: Create the wrapper**
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class GetTestSummaryTool
+{
+    [McpServerTool(Name = "get_test_summary")]
+    [Description(
+        "Per-project inventory of test methods. Each test reports framework " +
+        "(xUnit/NUnit/MSTest), attribute kind ([Fact]/[Theory]/[Test]/[TestCase]/" +
+        "[TestMethod]/[DataTestMethod]), data-driven row count, location, and the " +
+        "production symbols it references. " +
+        "Complements find_tests_for_symbol (which goes test → production); this goes " +
+        "project → tests. Use to answer 'what does this test suite cover?' or to break " +
+        "down test counts by framework/attribute. " +
+        "Production projects, generated code, and BCL/framework calls are filtered out " +
+        "of the per-test referenced-symbols list. Project filter is case-insensitive. " +
+        "Sort: tests by (file, line); projects by name ASC.")]
+    public static GetTestSummaryResult Execute(
+        MultiSolutionManager manager,
+        [Description("Optional: restrict to a single test project by name (case-insensitive).")]
+        string? project = null)
+    {
+        manager.EnsureLoaded();
+        return GetTestSummaryLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            project);
+    }
+}
+```
+
+**Step 2: Build**
+
+```bash
+dotnet build
+```
+
+Expected: 0 errors. Auto-registered via `Program.cs:35`.
+
+**Step 3: Run targeted tests**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetTestSummaryToolTests"
+```
+
+Expect 13/13 pass.
+
+**Step 4: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/GetTestSummaryTool.cs
+git commit -m "feat: register get_test_summary MCP tool"
+```
+
+---
+
+## Task 4: Add benchmark
+
+**Files:**
+- Modify: `benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs`
+
+**Step 1**: Find the `find_tests_for_symbol` benchmarks; add the new one immediately after.
+
+```csharp
+[Benchmark(Description = "get_test_summary: whole solution")]
+public object GetTestSummary()
+{
+    return GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+}
+```
+
+**Step 2: Build benchmarks**
+
+```bash
+dotnet build benchmarks/RoslynCodeLens.Benchmarks -c Release
+```
+
+Expected: 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+git commit -m "bench: add get_test_summary benchmark"
+```
+
+---
+
+## Task 5: Update SKILL.md, README, CLAUDE.md
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Step 1: SKILL.md — Red Flags routing table**
+
+Add near `find_tests_for_symbol`:
+
+```
+| "What does this test suite cover?" / "List all tests in MyProj.Tests" / "How many xUnit Theory tests do we have?" | `get_test_summary` |
+```
+
+**Step 2: SKILL.md — Quick Reference**
+
+Add near `find_tests_for_symbol`:
+
+```
+| `get_test_summary` | "What does this test suite cover?" |
+```
+
+**Step 3: SKILL.md — Test-aware section**
+
+Add a new bullet:
+
+```
+- `get_test_summary` — Per-project inventory of test methods with framework, attribute kind, [InlineData]/[TestCase]/[DataRow] row count, location, and production symbols referenced. Project → tests direction; complements `find_tests_for_symbol` (test → production).
+```
+
+**Step 4: README.md Features list**
+
+Add near `find_tests_for_symbol`:
+
+```
+- **get_test_summary** — Per-project inventory of test methods with framework, attribute kind, data-row count, location, and production symbols referenced
+```
+
+**Step 5: CLAUDE.md tool count**
+
+Bump from 34 to 35.
+
+**Step 6: Sanity check**
+
+```bash
+dotnet test tests/RoslynCodeLens.Tests --filter "GetTestSummaryToolTests"
+```
+
+Expect 13/13 pass.
+
+**Step 7: Commit**
+
+```bash
+git add plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md \
+  README.md \
+  CLAUDE.md
+git commit -m "docs: announce get_test_summary in SKILL.md, README, CLAUDE.md"
+```
+
+---
+
+## Done
+
+After Task 5 the branch should have ~7 commits (design + plan + 5 tasks). 13/13 tests green, benchmark compiling, tool auto-registered.

--- a/docs/plans/2026-05-01-get-test-summary.md
+++ b/docs/plans/2026-05-01-get-test-summary.md
@@ -318,7 +318,8 @@ namespace RoslynCodeLens.Tools;
 
 public static class GetTestSummaryLogic
 {
-    private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat;
+    private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat
+        .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType);
 
     public static GetTestSummaryResult Execute(
         LoadedSolution loaded, SymbolResolver resolver, string? project)
@@ -344,6 +345,10 @@ public static class GetTestSummaryLogic
                 {
                     var classification = TestMethodClassifier.Classify(member);
                     if (classification is null) continue;
+
+                    var location = member.Locations.FirstOrDefault(l => l.IsInSource);
+                    if (location?.SourceTree is null) continue;
+                    if (GeneratedCodeDetector.IsGenerated(location.SourceTree)) continue;
 
                     var (file, line) = GetFileAndLine(member);
                     if (string.IsNullOrEmpty(file)) continue;
@@ -435,11 +440,23 @@ public static class GetTestSummaryLogic
     private static bool IsExcludedNamespace(string ns)
     {
         if (string.IsNullOrEmpty(ns)) return false;
-        return ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)
-            || ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)
-            || ns == "Microsoft.VisualStudio.TestTools.UnitTesting" || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)
-            || ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)
-            || ns == "Microsoft" || ns.StartsWith("Microsoft.", StringComparison.Ordinal);
+
+        // Test framework infrastructure — excluded from production-coverage signal.
+        if (ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)) return true;
+        if (ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.VisualStudio.TestTools.UnitTesting"
+            || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)) return true;
+
+        // BCL — excluded because every test references string/int/Task/etc. NOTE: deliberately
+        // narrow under Microsoft.* — only language and runtime support namespaces, NOT consumer
+        // frameworks like Microsoft.Extensions.*, Microsoft.AspNetCore.*, Microsoft.EntityFrameworkCore.*
+        // which are legitimate production-code references in real test suites.
+        if (ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.CSharp" || ns.StartsWith("Microsoft.CSharp.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.VisualBasic" || ns.StartsWith("Microsoft.VisualBasic.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.Win32" || ns.StartsWith("Microsoft.Win32.", StringComparison.Ordinal)) return true;
+
+        return false;
     }
 
     private static (string File, int Line) GetFileAndLine(ISymbol symbol)

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -49,6 +49,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 | "Which classes are doing too much?" / "Where are my god classes?" / "Worst design smells in this codebase?" | `find_god_objects` |
 | "Let me `Grep` for tests that call this method" | `find_tests_for_symbol` |
 | "Which tests will break if I change this?" | `find_tests_for_symbol` |
+| "What does this test suite cover?" / "List all tests in MyProj.Tests" / "How many xUnit Theory tests do we have?" | `get_test_summary` |
 | "What should I write tests for?" / "Where's our testing debt?" / "Show me untested public methods" | `find_uncovered_symbols` |
 | "What's the public API of this library?" / "Show me the API surface" / "I need a PublicAPI.txt-style snapshot" | `get_public_api_surface` |
 | "Will this break consumers?" / "Show me breaking changes vs the previous release" / "Diff this build's API against baseline" | `find_breaking_changes` |
@@ -127,6 +128,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 - `find_event_subscribers` — every += / -= site for an event symbol, with resolved handler name and subscribe/unsubscribe tag. Use for UI-event audits or memory-leak hunts (compare subscribe/unsubscribe pairs).
 - `find_implementations` — all implementors of an interface / extenders of a class.
 - `find_tests_for_symbol` — xUnit/NUnit/MSTest methods that exercise a production symbol; opt-in transitive walk through helpers.
+- `get_test_summary` — Per-project inventory of test methods with framework, attribute kind, [InlineData]/[TestCase]/[DataRow] row count, location, and production symbols referenced. Project → tests direction; complements `find_tests_for_symbol` (test → production).
 - `find_uncovered_symbols` — Public methods and properties no test transitively reaches (≤ 3 helper hops); sorted by cyclomatic complexity for prioritization. Strict reference-based: an override is not marked covered just because its base or interface declaration is reached — a test calling `IFoo.Bar` does not cover `Foo.Bar`.
 - `get_di_registrations` — DI wiring and lifetimes.
 - `find_reflection_usage` — hidden/dynamic coupling (`Activator.CreateInstance`, `MethodInfo.Invoke`, assembly scanning).
@@ -240,6 +242,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `find_event_subscribers` | "Who subscribes to this event?" |
 | `find_references` | "Where is this symbol used?" / "Show all references" |
 | `find_tests_for_symbol` | "What tests cover this method?" / "Which tests will break if I change X?" |
+| `get_test_summary` | "What does this test suite cover?" |
 | `find_uncovered_symbols` | "What should I write tests for?" / "Where's our testing debt?" |
 | `go_to_definition` | "Where is this defined?" / "Jump to source" |
 | `search_symbols` | "Find types/methods matching this name" |

--- a/src/RoslynCodeLens/Models/GetTestSummaryResult.cs
+++ b/src/RoslynCodeLens/Models/GetTestSummaryResult.cs
@@ -1,0 +1,4 @@
+namespace RoslynCodeLens.Models;
+
+public record GetTestSummaryResult(
+    IReadOnlyList<ProjectTestSummary> Projects);

--- a/src/RoslynCodeLens/Models/ProjectTestSummary.cs
+++ b/src/RoslynCodeLens/Models/ProjectTestSummary.cs
@@ -1,0 +1,8 @@
+namespace RoslynCodeLens.Models;
+
+public record ProjectTestSummary(
+    string Project,
+    int TotalTests,
+    IReadOnlyDictionary<string, int> ByFramework,
+    IReadOnlyDictionary<string, int> ByAttribute,
+    IReadOnlyList<TestMethodSummary> Tests);

--- a/src/RoslynCodeLens/Models/TestMethodSummary.cs
+++ b/src/RoslynCodeLens/Models/TestMethodSummary.cs
@@ -1,0 +1,10 @@
+namespace RoslynCodeLens.Models;
+
+public record TestMethodSummary(
+    string MethodName,
+    string Framework,
+    string AttributeShortName,
+    int InlineDataRowCount,
+    IReadOnlyList<string> ReferencedSymbols,
+    string FilePath,
+    int Line);

--- a/src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs
@@ -1,0 +1,165 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.TestDiscovery;
+
+namespace RoslynCodeLens.Tools;
+
+public static class GetTestSummaryLogic
+{
+    private static readonly SymbolDisplayFormat FqnFormat = SymbolDisplayFormat.FullyQualifiedFormat
+        .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType);
+
+    public static GetTestSummaryResult Execute(
+        LoadedSolution loaded, SymbolResolver resolver, string? project)
+    {
+        var testProjectIds = TestProjectDetector.GetTestProjectIds(loaded.Solution);
+        var entries = new List<ProjectTestSummary>();
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            if (!testProjectIds.Contains(projectId)) continue;
+
+            var projectName = resolver.GetProjectName(projectId);
+            if (project is not null && !string.Equals(projectName, project, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var tests = new List<TestMethodSummary>();
+
+            foreach (var type in EnumerateTypes(compilation.Assembly.GlobalNamespace))
+            {
+                if (!type.Locations.Any(l => l.IsInSource)) continue;
+
+                foreach (var member in type.GetMembers().OfType<IMethodSymbol>())
+                {
+                    var classification = TestMethodClassifier.Classify(member);
+                    if (classification is null) continue;
+
+                    var (file, line) = GetFileAndLine(member);
+                    if (string.IsNullOrEmpty(file)) continue;
+
+                    var rowCount = CountInlineDataRows(member, classification.Framework);
+                    var referenced = CollectReferencedSymbols(member, compilation);
+
+                    tests.Add(new TestMethodSummary(
+                        MethodName: member.ToDisplayString(FqnFormat).Replace("global::", string.Empty, StringComparison.Ordinal),
+                        Framework: classification.Framework.ToString(),
+                        AttributeShortName: classification.AttributeShortName,
+                        InlineDataRowCount: rowCount,
+                        ReferencedSymbols: referenced,
+                        FilePath: file,
+                        Line: line));
+                }
+            }
+
+            tests.Sort((a, b) =>
+            {
+                var fileCmp = string.CompareOrdinal(a.FilePath, b.FilePath);
+                return fileCmp != 0 ? fileCmp : a.Line.CompareTo(b.Line);
+            });
+
+            var byFramework = tests
+                .GroupBy(t => t.Framework, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+            var byAttribute = tests
+                .GroupBy(t => t.AttributeShortName, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+
+            entries.Add(new ProjectTestSummary(
+                Project: projectName,
+                TotalTests: tests.Count,
+                ByFramework: byFramework,
+                ByAttribute: byAttribute,
+                Tests: tests));
+        }
+
+        entries.Sort((a, b) => string.CompareOrdinal(a.Project, b.Project));
+        return new GetTestSummaryResult(entries);
+    }
+
+    private static int CountInlineDataRows(IMethodSymbol method, TestFramework framework)
+    {
+        var dataAttributeName = framework switch
+        {
+            TestFramework.XUnit => "InlineDataAttribute",
+            TestFramework.NUnit => "TestCaseAttribute",
+            TestFramework.MSTest => "DataRowAttribute",
+            _ => null,
+        };
+        if (dataAttributeName is null) return 0;
+
+        return method.GetAttributes().Count(a =>
+            string.Equals(a.AttributeClass?.Name, dataAttributeName, StringComparison.Ordinal));
+    }
+
+    private static IReadOnlyList<string> CollectReferencedSymbols(IMethodSymbol method, Compilation compilation)
+    {
+        var location = method.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location?.SourceTree is null) return [];
+
+        var semanticModel = compilation.GetSemanticModel(location.SourceTree);
+        var bodyNode = location.SourceTree.GetRoot().FindNode(location.SourceSpan);
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var node in bodyNode.DescendantNodesAndSelf())
+        {
+            var symbol = semanticModel.GetSymbolInfo(node).Symbol;
+            if (symbol is null) continue;
+            if (symbol is not (IMethodSymbol or IPropertySymbol or IFieldSymbol)) continue;
+
+            var ns = symbol.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            // Containing-type's namespace for members:
+            if (symbol is not INamedTypeSymbol)
+                ns = symbol.ContainingType?.ContainingNamespace?.ToDisplayString() ?? ns;
+
+            if (IsExcludedNamespace(ns)) continue;
+
+            var fqn = symbol.ToDisplayString(FqnFormat).Replace("global::", string.Empty, StringComparison.Ordinal);
+            seen.Add(fqn);
+        }
+
+        return seen.OrderBy(x => x, StringComparer.Ordinal).ToList();
+    }
+
+    private static bool IsExcludedNamespace(string ns)
+    {
+        if (string.IsNullOrEmpty(ns)) return false;
+        return ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)
+            || ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)
+            || ns == "Microsoft.VisualStudio.TestTools.UnitTesting" || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)
+            || ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)
+            || ns == "Microsoft" || ns.StartsWith("Microsoft.", StringComparison.Ordinal);
+    }
+
+    private static (string File, int Line) GetFileAndLine(ISymbol symbol)
+    {
+        var location = symbol.Locations.FirstOrDefault(l => l.IsInSource);
+        if (location is null) return (string.Empty, 0);
+        var span = location.GetLineSpan();
+        return (span.Path, span.StartLinePosition.Line + 1);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol ns)
+    {
+        foreach (var type in ns.GetTypeMembers())
+        {
+            yield return type;
+            foreach (var nested in EnumerateNestedTypes(type))
+                yield return nested;
+        }
+        foreach (var nested in ns.GetNamespaceMembers())
+            foreach (var type in EnumerateTypes(nested))
+                yield return type;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (var nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (var deeper in EnumerateNestedTypes(nested))
+                yield return deeper;
+        }
+    }
+}

--- a/src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTestSummaryLogic.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Analysis;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.TestDiscovery;
@@ -34,6 +35,10 @@ public static class GetTestSummaryLogic
                 {
                     var classification = TestMethodClassifier.Classify(member);
                     if (classification is null) continue;
+
+                    var location = member.Locations.FirstOrDefault(l => l.IsInSource);
+                    if (location?.SourceTree is null) continue;
+                    if (GeneratedCodeDetector.IsGenerated(location.SourceTree)) continue;
 
                     var (file, line) = GetFileAndLine(member);
                     if (string.IsNullOrEmpty(file)) continue;
@@ -125,11 +130,23 @@ public static class GetTestSummaryLogic
     private static bool IsExcludedNamespace(string ns)
     {
         if (string.IsNullOrEmpty(ns)) return false;
-        return ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)
-            || ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)
-            || ns == "Microsoft.VisualStudio.TestTools.UnitTesting" || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)
-            || ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)
-            || ns == "Microsoft" || ns.StartsWith("Microsoft.", StringComparison.Ordinal);
+
+        // Test framework infrastructure — excluded from production-coverage signal.
+        if (ns == "Xunit" || ns.StartsWith("Xunit.", StringComparison.Ordinal)) return true;
+        if (ns == "NUnit.Framework" || ns.StartsWith("NUnit.Framework.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.VisualStudio.TestTools.UnitTesting"
+            || ns.StartsWith("Microsoft.VisualStudio.TestTools.UnitTesting.", StringComparison.Ordinal)) return true;
+
+        // BCL — excluded because every test references string/int/Task/etc. NOTE: deliberately
+        // narrow under Microsoft.* — only language and runtime support namespaces, NOT consumer
+        // frameworks like Microsoft.Extensions.*, Microsoft.AspNetCore.*, Microsoft.EntityFrameworkCore.*
+        // which are legitimate production-code references in real test suites.
+        if (ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.CSharp" || ns.StartsWith("Microsoft.CSharp.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.VisualBasic" || ns.StartsWith("Microsoft.VisualBasic.", StringComparison.Ordinal)) return true;
+        if (ns == "Microsoft.Win32" || ns.StartsWith("Microsoft.Win32.", StringComparison.Ordinal)) return true;
+
+        return false;
     }
 
     private static (string File, int Line) GetFileAndLine(ISymbol symbol)

--- a/src/RoslynCodeLens/Tools/GetTestSummaryTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTestSummaryTool.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class GetTestSummaryTool
+{
+    [McpServerTool(Name = "get_test_summary")]
+    [Description(
+        "Per-project inventory of test methods. Each test reports framework " +
+        "(xUnit/NUnit/MSTest), attribute kind ([Fact]/[Theory]/[Test]/[TestCase]/" +
+        "[TestMethod]/[DataTestMethod]), data-driven row count, location, and the " +
+        "production symbols it references. " +
+        "Complements find_tests_for_symbol (which goes test → production); this goes " +
+        "project → tests. Use to answer 'what does this test suite cover?' or to break " +
+        "down test counts by framework/attribute. " +
+        "Production projects, generated code, and BCL/framework calls are filtered out " +
+        "of the per-test referenced-symbols list. Project filter is case-insensitive. " +
+        "Sort: tests by (file, line); projects by name ASC.")]
+    public static GetTestSummaryResult Execute(
+        MultiSolutionManager manager,
+        [Description("Optional: restrict to a single test project by name (case-insensitive).")]
+        string? project = null)
+    {
+        manager.EnsureLoaded();
+        return GetTestSummaryLogic.Execute(
+            manager.GetLoadedSolution(),
+            manager.GetResolver(),
+            project);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTestSummaryToolTests.cs
@@ -1,0 +1,204 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+[Collection("TestSolution")]
+public class GetTestSummaryToolTests
+{
+    private readonly LoadedSolution _loaded;
+    private readonly SymbolResolver _resolver;
+
+    public GetTestSummaryToolTests(TestSolutionFixture fixture)
+    {
+        _loaded = fixture.Loaded;
+        _resolver = fixture.Resolver;
+    }
+
+    [Fact]
+    public void Result_FindsXUnitTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var xUnitProject = Assert.Single(result.Projects, p => p.Project == "XUnitFixture");
+        Assert.True(xUnitProject.TotalTests > 0);
+        Assert.Contains("XUnit", xUnitProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void Result_FindsNUnitTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var nUnitProject = Assert.Single(result.Projects, p => p.Project == "NUnitFixture");
+        Assert.True(nUnitProject.TotalTests > 0);
+        Assert.Contains("NUnit", nUnitProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void Result_FindsMSTestTests()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        var msTestProject = Assert.Single(result.Projects, p => p.Project == "MSTestFixture");
+        Assert.True(msTestProject.TotalTests > 0);
+        Assert.Contains("MSTest", msTestProject.ByFramework.Keys);
+    }
+
+    [Fact]
+    public void InlineDataRowCount_PopulatedForXUnitTheory()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        // SampleTests has a [Theory] with [InlineData] rows — count must be > 0.
+        var theory = project.Tests.FirstOrDefault(t =>
+            string.Equals(t.AttributeShortName, "Theory", StringComparison.Ordinal));
+        Assert.NotNull(theory);
+        Assert.True(theory!.InlineDataRowCount > 0,
+            $"Expected InlineDataRowCount > 0 for theory {theory.MethodName}, got {theory.InlineDataRowCount}");
+    }
+
+    [Fact]
+    public void InlineDataRowCount_ZeroForFact()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        var fact = project.Tests.FirstOrDefault(t =>
+            string.Equals(t.AttributeShortName, "Fact", StringComparison.Ordinal));
+        Assert.NotNull(fact);
+        Assert.Equal(0, fact!.InlineDataRowCount);
+    }
+
+    [Fact]
+    public void ReferencedSymbols_IncludeProductionCalls()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        // SampleTests calls Greeter.Greet — every test should list a TestLib production symbol.
+        Assert.Contains(project.Tests, t =>
+            t.ReferencedSymbols.Any(s => s.Contains("TestLib", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void ReferencedSymbols_ExcludesFrameworkAndBcl()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        foreach (var test in project.Tests)
+        {
+            foreach (var symbol in test.ReferencedSymbols)
+            {
+                Assert.False(symbol.StartsWith("Xunit", StringComparison.Ordinal),
+                    $"Test {test.MethodName} referenced framework symbol {symbol}");
+                Assert.False(symbol.StartsWith("System.", StringComparison.Ordinal) || symbol == "System",
+                    $"Test {test.MethodName} referenced BCL symbol {symbol}");
+                Assert.False(symbol.StartsWith("Microsoft.", StringComparison.Ordinal) || symbol == "Microsoft",
+                    $"Test {test.MethodName} referenced Microsoft.* symbol {symbol}");
+                Assert.False(symbol.StartsWith("NUnit.Framework", StringComparison.Ordinal),
+                    $"Test {test.MethodName} referenced NUnit framework symbol {symbol}");
+            }
+        }
+    }
+
+    [Fact]
+    public void ProjectFilter_OnlyReturnsRequestedProject()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "XUnitFixture");
+
+        var project = Assert.Single(result.Projects);
+        Assert.Equal("XUnitFixture", project.Project);
+    }
+
+    [Fact]
+    public void Result_OmitsProductionProjects()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        Assert.DoesNotContain(result.Projects, p => p.Project == "TestLib");
+        Assert.DoesNotContain(result.Projects, p => p.Project == "TestLib2");
+    }
+
+    [Fact]
+    public void ByFramework_CountsAreCorrect()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            foreach (var (frameworkName, count) in project.ByFramework)
+            {
+                var actual = project.Tests.Count(t =>
+                    string.Equals(t.Framework, frameworkName, StringComparison.Ordinal));
+                Assert.Equal(actual, count);
+            }
+        }
+    }
+
+    [Fact]
+    public void ByAttribute_CountsAreCorrect()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            foreach (var (attrName, count) in project.ByAttribute)
+            {
+                var actual = project.Tests.Count(t =>
+                    string.Equals(t.AttributeShortName, attrName, StringComparison.Ordinal));
+                Assert.Equal(actual, count);
+            }
+        }
+    }
+
+    [Fact]
+    public void Tests_SortedByFileLine()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        foreach (var project in result.Projects)
+        {
+            for (int i = 1; i < project.Tests.Count; i++)
+            {
+                var prev = project.Tests[i - 1];
+                var curr = project.Tests[i];
+                var fileCmp = string.CompareOrdinal(prev.FilePath, curr.FilePath);
+                Assert.True(fileCmp < 0 || (fileCmp == 0 && prev.Line <= curr.Line),
+                    $"Sort violation in {project.Project} at index {i}: '{prev.FilePath}:{prev.Line}' before '{curr.FilePath}:{curr.Line}'");
+            }
+        }
+    }
+
+    [Fact]
+    public void UnknownProject_ReturnsEmptyList()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: "DoesNotExist");
+
+        Assert.Empty(result.Projects);
+    }
+
+    [Fact]
+    public void Tests_PopulatedWithMethodNameAndLocation()
+    {
+        var result = GetTestSummaryLogic.Execute(_loaded, _resolver, project: null);
+
+        Assert.NotEmpty(result.Projects);
+        foreach (var project in result.Projects)
+        {
+            Assert.All(project.Tests, t =>
+            {
+                Assert.NotEmpty(t.MethodName);
+                Assert.NotEmpty(t.Framework);
+                Assert.NotEmpty(t.AttributeShortName);
+                Assert.NotEmpty(t.FilePath);
+                Assert.True(t.Line > 0);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `get_test_summary` MCP tool: per-project inventory of test methods
- Each test reports framework (xUnit/NUnit/MSTest), attribute kind (`[Fact]`/`[Theory]`/`[Test]`/`[TestCase]`/`[TestMethod]`/`[DataTestMethod]`), data-driven row count, source location, and the production symbols it references
- Complements `find_tests_for_symbol`: that goes test → production; this goes project → tests
- Production projects, generated code, and BCL/framework calls (Xunit.*, NUnit.Framework.*, Microsoft.VisualStudio.TestTools.UnitTesting.*, System.*, Microsoft.*) filtered out of the per-test referenced-symbols list
- Optional `project` filter (case-insensitive); defaults to all test projects
- Sort: tests by `(file, line)`; projects by name ASC

## Test plan
- [x] 14/14 `GetTestSummaryToolTests` passing — covers framework detection, [Theory]/[Fact] row counts, production-symbol filtering, project filter, sort invariants, production-project exclusion, count buckets
- [x] `dotnet build` clean
- [x] Benchmark added: `get_test_summary: whole solution`
- [x] Docs updated: SKILL.md (Red Flags, Quick Reference, Test-aware section), README, CLAUDE.md tool count (34 → 35)
- [x] Out-of-scope items appended to `docs/BACKLOG.md` "Deferred from shipped features"

🤖 Generated with [Claude Code](https://claude.com/claude-code)