### PR TITLE
fix: gracefully handle legacy non-SDK csproj projects (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ Location-returning tools include an `IsGenerated` flag to distinguish source-gen
 - .NET 10 SDK
 - A .NET solution with compilable projects
 
+## Project compatibility
+
+The server analyses every project that MSBuildWorkspace can load under the .NET SDK runtime.
+
+**Supported:** SDK-style projects (`<Project Sdk="...">`), any target framework — `net48`, `net6.0`, `net8.0`, `net10.0`, etc. .NET Framework targets work fine *as long as the csproj uses the SDK-style format*.
+
+**Skipped (with a warning, not a crash):** legacy non-SDK-style projects (`<Project ToolsVersion="..." xmlns="http://schemas.microsoft.com/developer/msbuild/2003">`, typically `.NET Framework` projects authored in older versions of Visual Studio). These rely on `Microsoft.Common.props` imports from the .NET Framework MSBuild that ships with Visual Studio, which is not available in the .NET SDK MSBuild runtime.
+
+When a solution contains legacy projects, the server:
+
+1. Loads every SDK-style project normally — all tools work for those.
+2. Skips each legacy project and records it in `LoadedSolution.SkippedProjects`.
+3. Surfaces the skipped list via `list_solutions` (the `SkippedProjects` array on each `SolutionInfo`) and in the return message of `load_solution`. Each entry includes the project name, kind (`Legacy`), and reason.
+
+**To analyse a legacy project,** convert it to SDK-style format (see [Microsoft's migration guide](https://learn.microsoft.com/en-us/dotnet/core/porting/project-structure)) or open the solution from a Visual Studio Developer Command Prompt so the full Visual Studio MSBuild is on `PATH`.
+
 ## Development
 
 ```bash

--- a/docs/site/docs/faq.md
+++ b/docs/site/docs/faq.md
@@ -35,4 +35,23 @@ Full benchmark results are in the [repository](https://github.com/MarcelRoozekra
 
 ## What .NET versions are supported?
 
-The server targets .NET 10 and can analyse solutions targeting any .NET version (net48, net6.0, net8.0, net10.0, etc.).
+The server targets .NET 10 and can analyse solutions targeting any .NET version (net48, net6.0, net8.0, net10.0, etc.) — **as long as the projects use the SDK-style csproj format** (`<Project Sdk="...">`).
+
+## Are legacy (non-SDK-style) .NET Framework projects supported?
+
+**No, and they will be skipped — but the rest of the solution still loads.**
+
+Legacy projects use the old MSBuild XML format (`<Project ToolsVersion="..." xmlns="http://schemas.microsoft.com/developer/msbuild/2003">`) and rely on the .NET Framework MSBuild that ships with Visual Studio. The .NET SDK does not include those targets, so MSBuildWorkspace cannot load them under `dotnet run`.
+
+What the server does when it encounters them:
+
+- Pre-classifies every `.csproj` in the solution before invoking MSBuild.
+- Loads all SDK-style projects normally — every tool works for those.
+- Records each legacy project in `LoadedSolution.SkippedProjects`.
+- Exposes the skipped list through `list_solutions` (the `SkippedProjects` array, with `Name`, `Path`, `Kind`, and `Reason` per project), and includes a summary in the return message of `load_solution`.
+
+To analyse a legacy project, either convert it to SDK-style csproj format, or run the server from a Visual Studio Developer Command Prompt where the full MSBuild toolchain is on `PATH`.
+
+## Why is `list_solutions` showing `SkippedProjects` for my solution?
+
+Those are projects that couldn't be loaded by MSBuildWorkspace. Each entry tells you the reason — typically `Legacy` (non-SDK-style) or `Missing` (referenced from the `.sln` but the file doesn't exist on disk). All other projects in the solution loaded normally and can be queried by any tool.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -227,11 +227,13 @@ peek_il("Microsoft.Extensions.DependencyInjection.ServiceDescriptor..ctor(System
 Limitations: abstract methods, interface instance members, and properties-as-whole (target the getter/setter accessor instead) are not supported.
 
 ### Solution Management
-- `list_solutions` — loaded solutions, which is active.
+- `list_solutions` — loaded solutions, which is active. Includes a `SkippedProjects` array per solution: projects MSBuildWorkspace could not load (legacy non-SDK-style csproj, missing files), with `Kind` and `Reason`.
 - `set_active_solution` — switch active solution by partial name.
-- `load_solution` — load a `.sln`/`.slnx` at runtime.
+- `load_solution` — load a `.sln`/`.slnx` at runtime. Returns a confirmation; when projects were skipped, the message summarises them and points to `list_solutions` for per-project reasons.
 - `unload_solution` — free memory.
 - `rebuild_solution` — full reload (after `Directory.Build.props` changes, new analyzers/packages, or stale diagnostics).
+
+**Legacy project handling:** when a solution contains non-SDK-style projects (`<Project ToolsVersion="..." xmlns=".../msbuild/2003">`, typically older .NET Framework projects), the server pre-filters them out before MSBuild sees them. Those projects appear in `SkippedProjects` with `Kind: "Legacy"`. The SDK-style projects in the same solution load normally and remain fully queryable — partial load, not all-or-nothing. If a tool returns "no results" for what should be a legacy project, check `list_solutions` first.
 
 ### Planning a Change — standard order
 1. `get_type_overview` — context + hierarchy + diagnostics.

--- a/src/RoslynCodeLens/LoadedSolution.cs
+++ b/src/RoslynCodeLens/LoadedSolution.cs
@@ -7,6 +7,7 @@ public class LoadedSolution
 {
     public required Solution Solution { get; init; }
     public required ConcurrentDictionary<ProjectId, Compilation> Compilations { get; init; }
+    public IReadOnlyList<SkippedProject> SkippedProjects { get; init; } = Array.Empty<SkippedProject>();
     public bool IsEmpty => Compilations.IsEmpty;
 
     public static LoadedSolution Empty { get; } = CreateEmpty();
@@ -21,3 +22,5 @@ public class LoadedSolution
         };
     }
 }
+
+public sealed record SkippedProject(string Path, string Name, string Kind, string Reason);

--- a/src/RoslynCodeLens/Models/SolutionInfo.cs
+++ b/src/RoslynCodeLens/Models/SolutionInfo.cs
@@ -4,4 +4,7 @@ public sealed record SolutionInfo(
     string Path,
     bool IsActive,
     int ProjectCount,
-    string Status);
+    string Status,
+    IReadOnlyList<SkippedProjectInfo> SkippedProjects);
+
+public sealed record SkippedProjectInfo(string Name, string Path, string Kind, string Reason);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -23,15 +23,32 @@ public sealed class MultiSolutionManager : IDisposable
             return CreateEmpty();
 
         var managers = new ConcurrentDictionary<string, SolutionManager>(StringComparer.OrdinalIgnoreCase);
+        string? firstSuccessfulKey = null;
         foreach (var path in solutionPaths)
         {
             var normalised = Path.GetFullPath(path);
-            if (!managers.ContainsKey(normalised))
-                managers[normalised] = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+            if (managers.ContainsKey(normalised))
+                continue;
+
+            SolutionManager manager;
+            try
+            {
+                manager = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                await Console.Error.WriteLineAsync(
+                    $"[roslyn-codelens] Skipping solution '{Path.GetFileName(normalised)}': {ex.Message}").ConfigureAwait(false);
+                continue;
+            }
+
+            managers[normalised] = manager;
+            if (firstSuccessfulKey == null && !manager.HasLoadFailure)
+                firstSuccessfulKey = normalised;
         }
 
-        var firstKey = Path.GetFullPath(solutionPaths[0]);
-        return new MultiSolutionManager(managers, firstKey);
+        var activeKey = firstSuccessfulKey ?? (managers.IsEmpty ? null : Path.GetFullPath(solutionPaths[0]));
+        return new MultiSolutionManager(managers, activeKey);
     }
 
     public static MultiSolutionManager CreateEmpty() =>
@@ -71,20 +88,27 @@ public sealed class MultiSolutionManager : IDisposable
                 var m = kvp.Value;
                 int projectCount = 0;
                 string status;
-                try
-                {
-                    var loaded = m.GetLoadedSolution();
-                    projectCount = loaded.Compilations.Count;
-                    status = loaded.IsEmpty ? "empty" : "ready";
-                }
-                catch (InvalidOperationException ex) when (ex.Message.Contains("warmup failed", StringComparison.OrdinalIgnoreCase))
+                if (m.HasLoadFailure)
                 {
                     status = "error";
                 }
-                catch (Exception ex)
+                else
                 {
-                    Console.Error.WriteLine($"[roslyn-codelens] Error reading solution status ({kvp.Key}): {ex}");
-                    status = "unknown";
+                    try
+                    {
+                        var loaded = m.GetLoadedSolution();
+                        projectCount = loaded.Compilations.Count;
+                        status = loaded.IsEmpty ? "empty" : "ready";
+                    }
+                    catch (InvalidOperationException ex) when (ex.Message.Contains("warmup failed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        status = "error";
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"[roslyn-codelens] Error reading solution status ({kvp.Key}): {ex}");
+                        status = "unknown";
+                    }
                 }
                 return new SolutionInfo(kvp.Key, string.Equals(kvp.Key, activeKey, StringComparison.Ordinal), projectCount, status);
             })
@@ -127,6 +151,13 @@ public sealed class MultiSolutionManager : IDisposable
         }
 
         var manager = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+
+        if (manager.HasLoadFailure)
+        {
+            var message = manager.LoadFailureMessage!;
+            manager.Dispose();
+            throw new InvalidOperationException(message);
+        }
 
         lock (_lock)
         {

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -88,6 +88,7 @@ public sealed class MultiSolutionManager : IDisposable
                 var m = kvp.Value;
                 int projectCount = 0;
                 string status;
+                IReadOnlyList<SkippedProjectInfo> skipped = Array.Empty<SkippedProjectInfo>();
                 if (m.HasLoadFailure)
                 {
                     status = "error";
@@ -99,6 +100,9 @@ public sealed class MultiSolutionManager : IDisposable
                         var loaded = m.GetLoadedSolution();
                         projectCount = loaded.Compilations.Count;
                         status = loaded.IsEmpty ? "empty" : "ready";
+                        skipped = loaded.SkippedProjects
+                            .Select(s => new SkippedProjectInfo(s.Name, s.Path, s.Kind, s.Reason))
+                            .ToList();
                     }
                     catch (InvalidOperationException ex) when (ex.Message.Contains("warmup failed", StringComparison.OrdinalIgnoreCase))
                     {
@@ -110,9 +114,23 @@ public sealed class MultiSolutionManager : IDisposable
                         status = "unknown";
                     }
                 }
-                return new SolutionInfo(kvp.Key, string.Equals(kvp.Key, activeKey, StringComparison.Ordinal), projectCount, status);
+                return new SolutionInfo(kvp.Key, string.Equals(kvp.Key, activeKey, StringComparison.Ordinal), projectCount, status, skipped);
             })
             .ToList();
+    }
+
+    public IReadOnlyList<SkippedProjectInfo> GetActiveSkippedProjects()
+    {
+        try
+        {
+            return Active.GetLoadedSolution().SkippedProjects
+                .Select(s => new SkippedProjectInfo(s.Name, s.Path, s.Kind, s.Reason))
+                .ToList();
+        }
+        catch
+        {
+            return Array.Empty<SkippedProjectInfo>();
+        }
     }
 
     public string SetActiveSolution(string name)

--- a/src/RoslynCodeLens/ProjectClassifier.cs
+++ b/src/RoslynCodeLens/ProjectClassifier.cs
@@ -1,0 +1,112 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace RoslynCodeLens;
+
+internal static class ProjectClassifier
+{
+    public enum ProjectKind
+    {
+        SdkStyle,
+        Legacy,
+        Unknown,
+        Missing,
+    }
+
+    public sealed record ClassifiedProject(string Path, string Name, ProjectKind Kind, string? Reason);
+
+    public static IReadOnlyList<ClassifiedProject> EnumerateProjects(string solutionPath)
+    {
+        var ext = System.IO.Path.GetExtension(solutionPath);
+        var dir = System.IO.Path.GetDirectoryName(System.IO.Path.GetFullPath(solutionPath)) ?? "";
+
+        IReadOnlyList<string> relativePaths;
+        if (string.Equals(ext, ".slnx", StringComparison.OrdinalIgnoreCase))
+            relativePaths = ParseSlnx(solutionPath);
+        else
+            relativePaths = ParseSln(solutionPath);
+
+        var result = new List<ClassifiedProject>(relativePaths.Count);
+        foreach (var rel in relativePaths)
+        {
+            var abs = System.IO.Path.GetFullPath(System.IO.Path.Combine(dir, rel.Replace('\\', System.IO.Path.DirectorySeparatorChar)));
+            result.Add(ClassifyCsproj(abs));
+        }
+        return result;
+    }
+
+    private static IReadOnlyList<string> ParseSlnx(string slnxPath)
+    {
+        try
+        {
+            var doc = XDocument.Load(slnxPath);
+            return doc.Descendants("Project")
+                .Select(e => (string?)e.Attribute("Path"))
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p => p!)
+                .ToList();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static readonly Regex SlnProjectLine = new(
+        @"^Project\([""']\{[0-9A-Fa-f-]+\}[""']\)\s*=\s*[""']([^""']+)[""']\s*,\s*[""']([^""']+)[""']",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private static IReadOnlyList<string> ParseSln(string slnPath)
+    {
+        try
+        {
+            var content = File.ReadAllText(slnPath);
+            var paths = new List<string>();
+            foreach (Match m in SlnProjectLine.Matches(content))
+            {
+                var rel = m.Groups[2].Value;
+                if (rel.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+                    || rel.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase)
+                    || rel.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase))
+                {
+                    paths.Add(rel);
+                }
+            }
+            return paths;
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    private static ClassifiedProject ClassifyCsproj(string absolutePath)
+    {
+        var name = System.IO.Path.GetFileNameWithoutExtension(absolutePath);
+        if (!File.Exists(absolutePath))
+            return new ClassifiedProject(absolutePath, name, ProjectKind.Missing, "Project file not found on disk.");
+
+        try
+        {
+            var doc = XDocument.Load(absolutePath);
+            var root = doc.Root;
+            if (root == null)
+                return new ClassifiedProject(absolutePath, name, ProjectKind.Unknown, "Empty or malformed csproj.");
+
+            if (root.Attribute("Sdk") != null)
+                return new ClassifiedProject(absolutePath, name, ProjectKind.SdkStyle, null);
+
+            var ns = root.Name.NamespaceName;
+            if (string.Equals(ns, "http://schemas.microsoft.com/developer/msbuild/2003", StringComparison.OrdinalIgnoreCase))
+                return new ClassifiedProject(absolutePath, name, ProjectKind.Legacy,
+                    "Legacy (non-SDK-style) project; .NET Framework MSBuild format is not supported under the .NET SDK runtime.");
+
+            return new ClassifiedProject(absolutePath, name, ProjectKind.Unknown,
+                "Unrecognised project format (no Sdk attribute and no legacy MSBuild namespace).");
+        }
+        catch (Exception ex)
+        {
+            return new ClassifiedProject(absolutePath, name, ProjectKind.Unknown, $"Failed to read csproj: {ex.Message}");
+        }
+    }
+}

--- a/src/RoslynCodeLens/SolutionLoadFailure.cs
+++ b/src/RoslynCodeLens/SolutionLoadFailure.cs
@@ -1,0 +1,44 @@
+namespace RoslynCodeLens;
+
+internal static class SolutionLoadFailure
+{
+    public static string Describe(string solutionPath, Exception ex)
+    {
+        var fileName = Path.GetFileName(solutionPath);
+
+        if (LooksLikeLegacyMsBuildFailure(ex))
+        {
+            return $"Failed to load solution '{fileName}': it appears to contain non-SDK-style " +
+                   "(legacy .NET Framework) projects, which MSBuildWorkspace cannot load when " +
+                   "running under the .NET SDK. Convert affected projects to SDK-style csproj, " +
+                   "or run the server from a Visual Studio Developer environment. " +
+                   $"Underlying error: {ex.GetType().Name}: {ex.Message}";
+        }
+
+        return $"Failed to load solution '{fileName}': {ex.GetType().Name}: {ex.Message}";
+    }
+
+    private static bool LooksLikeLegacyMsBuildFailure(Exception ex)
+    {
+        for (var current = ex; current != null; current = current.InnerException)
+        {
+            if (current is FileNotFoundException && MentionsLegacyMsBuildArtifact(current.Message))
+                return true;
+
+            if (current.GetType().FullName == "Microsoft.Build.Exceptions.InvalidProjectFileException"
+                && MentionsLegacyMsBuildArtifact(current.Message))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool MentionsLegacyMsBuildArtifact(string message)
+    {
+        return message.Contains("Microsoft.Common.props", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("Microsoft.Common.targets", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("MSBuildExtensionsPath", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("MSBuildToolsVersion", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("ToolsVersion", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("TargetFrameworkVersion", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -7,19 +7,91 @@ namespace RoslynCodeLens;
 
 public class SolutionLoader
 {
-    public async Task<(Solution Solution, MSBuildWorkspace Workspace)> OpenAsync(string solutionPath)
+    public async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath)
     {
-        var workspace = MSBuildWorkspace.Create();
+        var classified = ProjectClassifier.EnumerateProjects(solutionPath);
+        var legacyOrMissing = classified
+            .Where(p => p.Kind is ProjectClassifier.ProjectKind.Legacy
+                     or ProjectClassifier.ProjectKind.Missing
+                     or ProjectClassifier.ProjectKind.Unknown)
+            .ToList();
 
+        var preFilter = legacyOrMissing.Any(p => p.Kind == ProjectClassifier.ProjectKind.Legacy);
+        if (preFilter)
+        {
+            await Console.Error.WriteLineAsync(
+                $"[roslyn-codelens] Detected {legacyOrMissing.Count(p => p.Kind == ProjectClassifier.ProjectKind.Legacy)} legacy non-SDK project(s) in {Path.GetFileName(solutionPath)}; loading SDK-style projects only.")
+                .ConfigureAwait(false);
+            return await OpenPerProjectAsync(solutionPath, classified).ConfigureAwait(false);
+        }
+
+        var workspace = MSBuildWorkspace.Create();
         workspace.WorkspaceFailed += (_, e) =>
         {
             Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
         };
 
         await Console.Error.WriteLineAsync($"[roslyn-codelens] Loading solution: {Path.GetFileName(solutionPath)}").ConfigureAwait(false);
-        var solution = await workspace.OpenSolutionAsync(solutionPath).ConfigureAwait(false);
 
-        return (solution, workspace);
+        Solution solution;
+        try
+        {
+            solution = await workspace.OpenSolutionAsync(solutionPath).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fallback: solution-level open threw (often a legacy project we did not classify, or
+            // an SDK project with a broken import). Reuse per-project loading so we still surface
+            // whatever can be loaded plus a list of what was skipped.
+            workspace.Dispose();
+            await Console.Error.WriteLineAsync(
+                $"[roslyn-codelens] Solution-level load failed ({ex.GetType().Name}: {ex.Message}); falling back to per-project loading.")
+                .ConfigureAwait(false);
+            return await OpenPerProjectAsync(solutionPath, classified).ConfigureAwait(false);
+        }
+
+        return (solution, workspace, Array.Empty<SkippedProject>());
+    }
+
+    private static async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenPerProjectAsync(
+        string solutionPath,
+        IReadOnlyList<ProjectClassifier.ClassifiedProject> classified)
+    {
+        var workspace = MSBuildWorkspace.Create();
+        var skipped = new List<SkippedProject>();
+
+        workspace.WorkspaceFailed += (_, e) =>
+        {
+            Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
+        };
+
+        foreach (var entry in classified)
+        {
+            if (entry.Kind == ProjectClassifier.ProjectKind.SdkStyle)
+            {
+                try
+                {
+                    await workspace.OpenProjectAsync(entry.Path).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    await Console.Error.WriteLineAsync(
+                        $"[roslyn-codelens] Skipping project {entry.Name}: {ex.GetType().Name}: {ex.Message}").ConfigureAwait(false);
+                    skipped.Add(new SkippedProject(entry.Path, entry.Name, "Failed",
+                        $"{ex.GetType().Name}: {ex.Message}"));
+                }
+            }
+            else
+            {
+                var kind = entry.Kind.ToString();
+                var reason = entry.Reason ?? "Unsupported project format.";
+                await Console.Error.WriteLineAsync(
+                    $"[roslyn-codelens] Skipping {kind} project {entry.Name}: {reason}").ConfigureAwait(false);
+                skipped.Add(new SkippedProject(entry.Path, entry.Name, kind, reason));
+            }
+        }
+
+        return (workspace.CurrentSolution, workspace, skipped);
     }
 
     public async Task<ConcurrentDictionary<ProjectId, Compilation>> CompileAllParallelAsync(Solution solution)
@@ -54,16 +126,17 @@ public class SolutionLoader
 
     public async Task<LoadedSolution> LoadAsync(string solutionPath)
     {
-        var (solution, _) = await OpenAsync(solutionPath).ConfigureAwait(false);
+        var (solution, _, skipped) = await OpenAsync(solutionPath).ConfigureAwait(false);
         var compilations = await CompileAllParallelAsync(solution).ConfigureAwait(false);
 
         await Console.Error.WriteLineAsync(
-            $"[roslyn-codelens] Ready. {compilations.Count} projects compiled.").ConfigureAwait(false);
+            $"[roslyn-codelens] Ready. {compilations.Count} projects compiled, {skipped.Count} skipped.").ConfigureAwait(false);
 
         return new LoadedSolution
         {
             Solution = solution,
-            Compilations = compilations
+            Compilations = compilations,
+            SkippedProjects = skipped
         };
     }
 

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -49,9 +49,10 @@ public sealed class SolutionManager : IDisposable
     {
         var loader = new SolutionLoader();
         Solution solution;
+        IReadOnlyList<SkippedProject> skipped;
         try
         {
-            (solution, _) = await loader.OpenAsync(solutionPath).ConfigureAwait(false);
+            (solution, _, skipped) = await loader.OpenAsync(solutionPath).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -63,11 +64,12 @@ public sealed class SolutionManager : IDisposable
         var emptyLoaded = new LoadedSolution
         {
             Solution = solution,
-            Compilations = new ConcurrentDictionary<ProjectId, Compilation>()
+            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(),
+            SkippedProjects = skipped
         };
 
         var manager = new SolutionManager(emptyLoaded, solutionPath);
-        manager._warmupTask = manager.WarmupAsync(loader, solution);
+        manager._warmupTask = manager.WarmupAsync(loader, solution, skipped);
         return manager;
     }
 
@@ -76,7 +78,7 @@ public sealed class SolutionManager : IDisposable
         return new SolutionManager(LoadedSolution.Empty, null);
     }
 
-    private async Task WarmupAsync(SolutionLoader loader, Solution solution)
+    private async Task WarmupAsync(SolutionLoader loader, Solution solution, IReadOnlyList<SkippedProject> skipped)
     {
         try
         {
@@ -86,7 +88,8 @@ public sealed class SolutionManager : IDisposable
             var newLoaded = new LoadedSolution
             {
                 Solution = solution,
-                Compilations = compilations
+                Compilations = compilations,
+                SkippedProjects = skipped
             };
             var newResolver = new SymbolResolver(newLoaded);
             var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
@@ -209,11 +212,8 @@ public sealed class SolutionManager : IDisposable
 
     private async Task RebuildStaleProjects(IReadOnlySet<ProjectId> staleIds)
     {
-        var workspace = MSBuildWorkspace.Create();
-        workspace.WorkspaceFailed += (_, e) =>
-            Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
-
-        var solution = await workspace.OpenSolutionAsync(_solutionPath!).ConfigureAwait(false);
+        var loader = new SolutionLoader();
+        var (solution, _, skipped) = await loader.OpenAsync(_solutionPath!).ConfigureAwait(false);
         var compilations = new ConcurrentDictionary<ProjectId, Compilation>(_loaded.Compilations);
 
         var staleProjects = solution.Projects.Where(p => staleIds.Contains(p.Id)).ToList();
@@ -229,7 +229,8 @@ public sealed class SolutionManager : IDisposable
         var newLoaded = new LoadedSolution
         {
             Solution = solution,
-            Compilations = compilations
+            Compilations = compilations,
+            SkippedProjects = skipped
         };
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
@@ -255,9 +256,10 @@ public sealed class SolutionManager : IDisposable
 
         var loader = new SolutionLoader();
         Solution solution;
+        IReadOnlyList<SkippedProject> skipped;
         try
         {
-            (solution, _) = await loader.OpenAsync(_solutionPath).ConfigureAwait(false);
+            (solution, _, skipped) = await loader.OpenAsync(_solutionPath).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -268,7 +270,8 @@ public sealed class SolutionManager : IDisposable
         var newLoaded = new LoadedSolution
         {
             Solution = solution,
-            Compilations = compilations
+            Compilations = compilations,
+            SkippedProjects = skipped
         };
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -17,6 +17,8 @@ public sealed class SolutionManager : IDisposable
     private volatile bool _rebuilding;
     private Task? _warmupTask;
     private Exception? _warmupException;
+    private readonly Exception? _loadException;
+    private readonly string? _loadFailureMessage;
     private readonly PEFileCache _peCache = new();
     private readonly IlDisassemblerAdapter _ilAdapter;
 
@@ -29,10 +31,34 @@ public sealed class SolutionManager : IDisposable
         _ilAdapter = new IlDisassemblerAdapter(_peCache);
     }
 
+    private SolutionManager(string solutionPath, Exception loadException)
+    {
+        _loaded = LoadedSolution.Empty;
+        _solutionPath = solutionPath;
+        _resolver = new SymbolResolver(_loaded);
+        _metadataResolver = new MetadataSymbolResolver(_loaded, _resolver);
+        _ilAdapter = new IlDisassemblerAdapter(_peCache);
+        _loadException = loadException;
+        _loadFailureMessage = SolutionLoadFailure.Describe(solutionPath, loadException);
+    }
+
+    public bool HasLoadFailure => _loadException != null;
+    public string? LoadFailureMessage => _loadFailureMessage;
+
     public static async Task<SolutionManager> CreateAsync(string solutionPath)
     {
         var loader = new SolutionLoader();
-        var (solution, _) = await loader.OpenAsync(solutionPath).ConfigureAwait(false);
+        Solution solution;
+        try
+        {
+            (solution, _) = await loader.OpenAsync(solutionPath).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync(
+                $"[roslyn-codelens] {SolutionLoadFailure.Describe(solutionPath, ex)}").ConfigureAwait(false);
+            return new SolutionManager(solutionPath, ex);
+        }
 
         var emptyLoaded = new LoadedSolution
         {
@@ -95,6 +121,7 @@ public sealed class SolutionManager : IDisposable
 
     public LoadedSolution GetLoadedSolution()
     {
+        ThrowIfLoadFailed();
         _warmupTask?.GetAwaiter().GetResult();
         if (_warmupException != null)
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
@@ -104,6 +131,7 @@ public sealed class SolutionManager : IDisposable
 
     public SymbolResolver GetResolver()
     {
+        ThrowIfLoadFailed();
         _warmupTask?.GetAwaiter().GetResult();
         if (_warmupException != null)
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
@@ -113,6 +141,7 @@ public sealed class SolutionManager : IDisposable
 
     public MetadataSymbolResolver GetMetadataResolver()
     {
+        ThrowIfLoadFailed();
         _warmupTask?.GetAwaiter().GetResult();
         if (_warmupException != null)
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
@@ -124,6 +153,7 @@ public sealed class SolutionManager : IDisposable
 
     public void EnsureLoaded()
     {
+        ThrowIfLoadFailed();
         _warmupTask?.GetAwaiter().GetResult();
         if (_warmupException != null)
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
@@ -131,6 +161,12 @@ public sealed class SolutionManager : IDisposable
             throw new InvalidOperationException(
                 "No .sln file found. Either run from a directory containing a .sln/.slnx file, " +
                 "or pass the solution path as argument: roslyn-codelens-mcp /path/to/Solution.sln");
+    }
+
+    private void ThrowIfLoadFailed()
+    {
+        if (_loadException != null)
+            throw new InvalidOperationException(_loadFailureMessage!, _loadException);
     }
 
     private void RebuildIfStale()
@@ -218,7 +254,15 @@ public sealed class SolutionManager : IDisposable
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var loader = new SolutionLoader();
-        var (solution, _) = await loader.OpenAsync(_solutionPath).ConfigureAwait(false);
+        Solution solution;
+        try
+        {
+            (solution, _) = await loader.OpenAsync(_solutionPath).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(SolutionLoadFailure.Describe(_solutionPath, ex), ex);
+        }
         var compilations = await loader.CompileAllParallelAsync(solution).ConfigureAwait(false);
 
         var newLoaded = new LoadedSolution

--- a/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
@@ -8,7 +8,9 @@ namespace RoslynCodeLens.Tools;
 public static class ListSolutionsTool
 {
     [McpServerTool(Name = "list_solutions"),
-     Description("List all solutions loaded by this server, showing which one is currently active.")]
+     Description("List all solutions loaded by this server, showing which one is currently active. " +
+                 "Each entry includes any projects that were skipped during load (e.g. legacy non-SDK-style projects), " +
+                 "with the kind and reason for each skip.")]
     public static IReadOnlyList<SolutionInfo> Execute(MultiSolutionManager manager)
     {
         return manager.ListSolutions();

--- a/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
@@ -19,6 +19,12 @@ public static class LoadSolutionTool
             throw new FileNotFoundException($"Solution file not found: {path}");
 
         var normalised = await manager.LoadSolutionAsync(path).ConfigureAwait(false);
-        return $"Loaded and activated: {normalised}";
+        var skipped = manager.GetActiveSkippedProjects();
+        if (skipped.Count == 0)
+            return $"Loaded and activated: {normalised}";
+
+        var summary = string.Join(", ", skipped.Select(s => $"{s.Name} ({s.Kind})"));
+        return $"Loaded and activated: {normalised}. Skipped {skipped.Count} project(s): {summary}. " +
+               $"Call list_solutions for per-project reason details.";
     }
 }

--- a/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/Legacy.sln
+++ b/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/Legacy.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LegacyLib", "LegacyLib\LegacyLib.csproj", "{B0F4F1C1-1234-5678-9ABC-DEF012345678}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B0F4F1C1-1234-5678-9ABC-DEF012345678}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0F4F1C1-1234-5678-9ABC-DEF012345678}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0F4F1C1-1234-5678-9ABC-DEF012345678}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0F4F1C1-1234-5678-9ABC-DEF012345678}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/LegacyLib/LegacyClass.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/LegacyLib/LegacyClass.cs
@@ -1,0 +1,7 @@
+namespace LegacyLib
+{
+    public class LegacyClass
+    {
+        public string Hello() => "hello";
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/LegacyLib/LegacyLib.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/LegacyLib/LegacyLib.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Deliberately broken legacy (non-SDK-style) csproj used as a fixture.
+    The Import path resolves to a file that does not exist, which causes
+    MSBuild to throw FileNotFoundException during project evaluation.
+    This is the exact failure mode reported in
+    https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/175
+  -->
+  <Import Project="$(MSBuildExtensionsPath)\RoslynCodeLens.LegacyFixture.DoesNotExist\Microsoft.Common.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B0F4F1C1-1234-5678-9ABC-DEF012345678}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>LegacyLib</RootNamespace>
+    <AssemblyName>LegacyLib</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="LegacyClass.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
+++ b/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
@@ -1,0 +1,90 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Verifies graceful handling of legacy (non-SDK-style) .NET Framework projects.
+/// Regression tests for https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/175
+/// </summary>
+public class LegacySolutionHandlingTests
+{
+    private static string LegacySolutionPath => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "LegacySolution", "Legacy.sln"));
+
+    private static string ValidSolutionPath => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+
+    [Fact]
+    public async Task SolutionManager_CreateAsync_DoesNotThrowOnLegacyProject()
+    {
+        var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
+
+        Assert.True(manager.HasLoadFailure);
+        Assert.NotNull(manager.LoadFailureMessage);
+        manager.Dispose();
+    }
+
+    [Fact]
+    public async Task SolutionManager_FailedLoad_SurfacesFriendlyErrorOnAccess()
+    {
+        var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => manager.GetLoadedSolution());
+        Assert.Contains("Failed to load solution", ex.Message, StringComparison.OrdinalIgnoreCase);
+        manager.Dispose();
+    }
+
+    [Fact]
+    public async Task SolutionManager_FailedLoad_FriendlyMessageMentionsLegacyProjects()
+    {
+        var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
+
+        Assert.NotNull(manager.LoadFailureMessage);
+        Assert.Contains("non-SDK-style", manager.LoadFailureMessage!, StringComparison.OrdinalIgnoreCase);
+        manager.Dispose();
+    }
+
+    [Fact]
+    public async Task MultiSolutionManager_CreateAsync_TolerateLegacySolutionAlongsideValidOne()
+    {
+        var manager = await MultiSolutionManager.CreateAsync(new[] { LegacySolutionPath, ValidSolutionPath });
+
+        var solutions = manager.ListSolutions();
+        Assert.Equal(2, solutions.Count);
+        Assert.Contains(solutions, s => s.Status == "error");
+        Assert.Contains(solutions, s => s.Status == "ready" || s.Status == "empty");
+
+        var active = solutions.Single(s => s.IsActive);
+        Assert.NotEqual("error", active.Status);
+
+        manager.Dispose();
+    }
+
+    [Fact]
+    public async Task MultiSolutionManager_CreateAsync_OnlyLegacySolution_DoesNotThrow()
+    {
+        var manager = await MultiSolutionManager.CreateAsync(new[] { LegacySolutionPath });
+
+        var solutions = manager.ListSolutions();
+        Assert.Single(solutions);
+        Assert.Equal("error", solutions[0].Status);
+
+        manager.Dispose();
+    }
+
+    [Fact]
+    public async Task LoadSolutionTool_LegacySolution_ReturnsFriendlyError()
+    {
+        var manager = MultiSolutionManager.CreateEmpty();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => LoadSolutionTool.Execute(manager, LegacySolutionPath));
+
+        Assert.Contains("Failed to load solution", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        // The failed solution must not have been retained.
+        Assert.Empty(manager.ListSolutions());
+        manager.Dispose();
+    }
+}

--- a/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
+++ b/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
@@ -19,72 +19,77 @@ public class LegacySolutionHandlingTests
     public async Task SolutionManager_CreateAsync_DoesNotThrowOnLegacyProject()
     {
         var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
-
-        Assert.True(manager.HasLoadFailure);
-        Assert.NotNull(manager.LoadFailureMessage);
         manager.Dispose();
     }
 
     [Fact]
-    public async Task SolutionManager_FailedLoad_SurfacesFriendlyErrorOnAccess()
+    public async Task SolutionManager_LegacyProject_PopulatesSkippedList()
     {
         var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
+        await manager.WaitForWarmupAsync();
 
-        var ex = Assert.Throws<InvalidOperationException>(() => manager.GetLoadedSolution());
-        Assert.Contains("Failed to load solution", ex.Message, StringComparison.OrdinalIgnoreCase);
+        var loaded = manager.GetLoadedSolution();
+        Assert.NotEmpty(loaded.SkippedProjects);
+        Assert.Contains(loaded.SkippedProjects, p => string.Equals(p.Kind, "Legacy", StringComparison.Ordinal));
+        Assert.Contains(loaded.SkippedProjects, p => p.Reason.Contains("non-SDK", StringComparison.OrdinalIgnoreCase));
+
         manager.Dispose();
     }
 
     [Fact]
-    public async Task SolutionManager_FailedLoad_FriendlyMessageMentionsLegacyProjects()
+    public async Task MultiSolutionManager_LegacyOnly_LoadsWithSkippedReported()
     {
-        var manager = await SolutionManager.CreateAsync(LegacySolutionPath);
+        var manager = await MultiSolutionManager.CreateAsync(new[] { LegacySolutionPath });
 
-        Assert.NotNull(manager.LoadFailureMessage);
-        Assert.Contains("non-SDK-style", manager.LoadFailureMessage!, StringComparison.OrdinalIgnoreCase);
+        var solutions = manager.ListSolutions();
+        var solution = Assert.Single(solutions);
+        Assert.NotEmpty(solution.SkippedProjects);
+        Assert.Contains(solution.SkippedProjects, p => string.Equals(p.Kind, "Legacy", StringComparison.Ordinal));
+
         manager.Dispose();
     }
 
     [Fact]
-    public async Task MultiSolutionManager_CreateAsync_TolerateLegacySolutionAlongsideValidOne()
+    public async Task MultiSolutionManager_MixedSolutions_LoadsValidAndReportsLegacySkipped()
     {
         var manager = await MultiSolutionManager.CreateAsync(new[] { LegacySolutionPath, ValidSolutionPath });
 
         var solutions = manager.ListSolutions();
         Assert.Equal(2, solutions.Count);
-        Assert.Contains(solutions, s => s.Status == "error");
-        Assert.Contains(solutions, s => s.Status == "ready" || s.Status == "empty");
 
-        var active = solutions.Single(s => s.IsActive);
-        Assert.NotEqual("error", active.Status);
+        var legacy = solutions.Single(s => s.Path.EndsWith("Legacy.sln", StringComparison.OrdinalIgnoreCase));
+        Assert.NotEmpty(legacy.SkippedProjects);
 
-        manager.Dispose();
-    }
-
-    [Fact]
-    public async Task MultiSolutionManager_CreateAsync_OnlyLegacySolution_DoesNotThrow()
-    {
-        var manager = await MultiSolutionManager.CreateAsync(new[] { LegacySolutionPath });
-
-        var solutions = manager.ListSolutions();
-        Assert.Single(solutions);
-        Assert.Equal("error", solutions[0].Status);
+        var valid = solutions.Single(s => s.Path.EndsWith("TestSolution.slnx", StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(valid.SkippedProjects);
+        Assert.Equal("ready", valid.Status);
 
         manager.Dispose();
     }
 
     [Fact]
-    public async Task LoadSolutionTool_LegacySolution_ReturnsFriendlyError()
+    public async Task LoadSolutionTool_LegacySolution_ReturnsSkippedSummary()
     {
         var manager = MultiSolutionManager.CreateEmpty();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => LoadSolutionTool.Execute(manager, LegacySolutionPath));
+        var result = await LoadSolutionTool.Execute(manager, LegacySolutionPath);
 
-        Assert.Contains("Failed to load solution", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Loaded and activated", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Skipped", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Legacy", result, StringComparison.OrdinalIgnoreCase);
 
-        // The failed solution must not have been retained.
-        Assert.Empty(manager.ListSolutions());
         manager.Dispose();
+    }
+
+    [Fact]
+    public void ProjectClassifier_DetectsLegacyAndSdkStyle()
+    {
+        var classified = ProjectClassifier.EnumerateProjects(LegacySolutionPath);
+        Assert.NotEmpty(classified);
+        Assert.Contains(classified, c => c.Kind == ProjectClassifier.ProjectKind.Legacy);
+
+        var validClassified = ProjectClassifier.EnumerateProjects(ValidSolutionPath);
+        Assert.NotEmpty(validClassified);
+        Assert.All(validClassified, c => Assert.Equal(ProjectClassifier.ProjectKind.SdkStyle, c.Kind));
     }
 }

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -21,8 +21,10 @@
   <ItemGroup>
     <Compile Remove="Fixtures\TestSolution\**" />
     <Compile Remove="Fixtures\TestSolutionAlt\**" />
+    <Compile Remove="Fixtures\LegacySolution\**" />
     <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/SolutionLoaderTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionLoaderTests.cs
@@ -26,7 +26,7 @@ public class SolutionLoaderTests
         fixturePath = Path.GetFullPath(fixturePath);
 
         var loader = new SolutionLoader();
-        var (solution, workspace) = await loader.OpenAsync(fixturePath);
+        var (solution, workspace, _) = await loader.OpenAsync(fixturePath);
 
         Assert.NotNull(solution);
         Assert.True(solution.Projects.Count() >= 2);
@@ -40,7 +40,7 @@ public class SolutionLoaderTests
         fixturePath = Path.GetFullPath(fixturePath);
 
         var loader = new SolutionLoader();
-        var (solution, workspace) = await loader.OpenAsync(fixturePath);
+        var (solution, workspace, _) = await loader.OpenAsync(fixturePath);
         var compilations = await loader.CompileAllParallelAsync(solution);
 
         Assert.True(compilations.Count >= 2);


### PR DESCRIPTION
## Summary

Pre-filters legacy non-SDK-style projects out of MSBuildWorkspace so they never trigger the unhandled `FileNotFoundException` that killed the server, and surfaces the skipped projects in the **tool results** (not just stderr) so MCP clients can show them to users.

Fixes #175.

## Approach (revised after review)

The first version of this PR detected the crash and returned a friendly error. The user pointed out that MCP clients don't surface server stderr, so we now do a real partial load instead:

1. **`ProjectClassifier`** parses `.sln` (text) / `.slnx` (XML) directly and inspects each `.csproj` root element. `Sdk="..."` → `SdkStyle`; `xmlns=".../msbuild/2003"` → `Legacy`. Never invokes MSBuild — so classification cannot fail for the same reason MSBuildWorkspace would.
2. **`SolutionLoader.OpenAsync`** uses the fast `OpenSolutionAsync` path when no legacy projects are detected. When legacy projects are present (or the fast path throws), it falls back to per-project loading via `MSBuildWorkspace.OpenProjectAsync` for each SDK-style project. Legacy projects are recorded as `SkippedProject` entries and never handed to MSBuild.
3. **`LoadedSolution.SkippedProjects`** flows the list through to `MultiSolutionManager`. `list_solutions` exposes them via a new `SkippedProjects` field on `SolutionInfo` (kind + reason per project). `load_solution` summarises them inline in its return string: *"Loaded and activated: …. Skipped 2 project(s): LegacyLib (Legacy), OldStuff (Legacy). Call list_solutions for per-project reason details."*

End state: SDK-style projects in a mostly-legacy solution are fully queryable; the MCP client gets a structured list of what was skipped and why.

## Files
- `src/RoslynCodeLens/ProjectClassifier.cs` (new) — `.sln`/`.slnx` enumeration + per-csproj root-element classification.
- `src/RoslynCodeLens/SolutionLoader.cs` — two-phase loader (fast path + per-project fallback); returns skipped list.
- `src/RoslynCodeLens/LoadedSolution.cs` — adds `SkippedProjects` + `SkippedProject` record.
- `src/RoslynCodeLens/Models/SolutionInfo.cs` — adds `SkippedProjects` and `SkippedProjectInfo`.
- `src/RoslynCodeLens/SolutionManager.cs` — threads skipped list; the `_loadException` failed-manager path is preserved as a safety net for truly catastrophic failures (corrupt `.sln`, missing file).
- `src/RoslynCodeLens/MultiSolutionManager.cs` — exposes skipped via `ListSolutions` + new `GetActiveSkippedProjects`.
- `src/RoslynCodeLens/Tools/LoadSolutionTool.cs` — embeds skipped summary in the result string.
- `src/RoslynCodeLens/Tools/ListSolutionsTool.cs` — description updated to advertise the skipped-project field.
- `src/RoslynCodeLens/SolutionLoadFailure.cs` — friendly error helper, kept for catastrophic fallback.
- `tests/RoslynCodeLens.Tests/Fixtures/LegacySolution/` — non-SDK csproj fixture + .sln.
- `tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs` — six regression tests covering partial-load behaviour and classifier output.

## Test plan
- [ ] `dotnet build`
- [ ] `dotnet test --filter "FullyQualifiedName~LegacySolutionHandling"`:
  - `SolutionManager.CreateAsync` does not throw on a legacy project
  - `LoadedSolution.SkippedProjects` is populated with kind=`Legacy`
  - Legacy-only `MultiSolutionManager` reports skipped via `list_solutions`
  - Mixed legacy + valid: valid loads as `ready` with empty skipped; legacy reports skipped
  - `load_solution` return string contains `Skipped …` and `Legacy`
  - `ProjectClassifier` distinguishes legacy from SDK-style fixtures
- [ ] `dotnet test` — full suite still green.
- [ ] Manual: from a directory whose only nearby `.sln` is legacy, confirm the server starts; `list_solutions` shows the skipped projects with their reasons; SDK-style projects in mixed solutions are queryable via other tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)