### PR TITLE
feat: uniform ToolListResult<T> envelope for all list-returning tools

### DIFF
--- a/docs/plans/2026-05-21-list-tool-envelope-design.md
+++ b/docs/plans/2026-05-21-list-tool-envelope-design.md
@@ -1,0 +1,135 @@
+# List-Tool Response Envelope — Design
+
+**Date:** 2026-05-21
+**Status:** Approved, ready for implementation plan
+**Motivation:** Reduce LLM token usage on large result sets and prevent context blow-ups by adding a consistent envelope (truncation + optional aggregate summary) to every list-returning MCP tool. Pattern adapted from `jkolo/debug-mcp` (reimplemented; their license is AGPL-3.0).
+
+## Goals
+
+- Bound the size of any single list-tool response by default, so a runaway result set can't fill the model's context.
+- Surface aggregate signal up front (severity counts, by-project breakdown, etc.) so the model can decide whether to drill into the items list.
+- Uniform shape across all ~25 list-returning tools — one mental model in `SKILL.md`, not 25.
+
+## Non-goals
+
+- Single-object tools (`GetTypeOverview`, `GetSymbolContext`, `ApplyCodeAction`, `GoToDefinition` on a unique target, etc.) keep their current shape.
+- No pagination cursors. `limit` is a single-shot cap; if a caller wants more, they raise `limit`.
+- No backwards-compatibility shim. Pre-1.0, Claude is the only consumer, breaking the response shape is acceptable.
+
+## Envelope type
+
+```csharp
+// Models/ToolListResult.cs
+public record ToolListResult<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    bool Truncated,
+    int Limit,
+    object? Summary = null);
+
+public static class ToolListResult
+{
+    public static ToolListResult<T> Create<T>(
+        IReadOnlyList<T> items,
+        int limit,
+        object? summary = null)
+    {
+        var truncated = items.Count > limit;
+        var sliced = truncated ? items.Take(limit).ToList() : items;
+        return new ToolListResult<T>(sliced, items.Count, truncated, limit, summary);
+    }
+}
+```
+
+- `Summary` is intentionally typed as `object?` so each tool emits an anonymous shape suited to its data. JSON serialization handles it; the LLM reads it as a free-form object.
+- Slicing happens at the Tool wrapper layer. `*Logic.cs` keeps returning `IReadOnlyList<T>` so it remains a pure list producer (easy to unit-test, no double-truncation).
+
+## Per-tool defaults
+
+Each tool has a tuned default limit and a defined sort order. Sort order is part of the contract because "top N" only means something useful if the most relevant items come first.
+
+| Tool | Default limit | Sort | Summary |
+|---|---|---|---|
+| `get_diagnostics` | 1000 | severity desc, file, line | `{ error, warning, info, hidden }` |
+| `find_references` | 500 | file, line | `{ byProject: { name: count } }` |
+| `find_callers` | 500 | file, line | `{ byProject: { name: count } }` |
+| `find_implementations` | 200 | file, line | none |
+| `search_symbols` | 200 | match quality (exact → prefix → substring) | `{ byKind: { Class, Method, ... } }` |
+| `goto_definition` | 50 | file, line | none |
+| `find_attribute_usages` | 500 | file, line | `{ byProject: ... }` |
+| `find_event_subscribers` | 500 | file, line | none |
+| `find_reflection_usage` | 500 | severity desc, file | `{ byKind: { GetType, Invoke, ... } }` |
+| `find_unused_symbols` | 500 | project, file | `{ byKind: { Class, Method, Field, ... } }` |
+| `find_naming_violations` | 500 | rule, file | `{ byRule: { ... } }` |
+| `find_large_classes` | 100 | size desc | none |
+| `find_circular_dependencies` | 100 | cycle length desc | none |
+| `get_complexity_metrics` | 100 | complexity desc | `{ max, avg, overThreshold }` |
+| `get_di_registrations` | 200 | service name | none |
+| `get_generated_code` | 200 | project, file | none |
+| `get_source_generators` | 100 | project | none |
+| `list_solutions` | 50 | name | none |
+
+Worst-first tools (large classes, complexity, circular deps) — truncating top N gives the actionable subset; the long tail is rarely useful.
+
+Severity-first tools (diagnostics, reflection usage) — errors before warnings so the truncated set keeps the important items.
+
+## Tool-signature changes
+
+Each Tool layer signature changes from:
+
+```csharp
+public static IReadOnlyList<T> Execute(...)
+```
+
+to:
+
+```csharp
+public static ToolListResult<T> Execute(..., int? limit = null)
+```
+
+with a per-tool default applied when `limit` is null. The `limit` parameter is declared with `[Description("Maximum number of items to return (default: <N>)")]` so it appears in the MCP tool schema.
+
+## Migration order
+
+Five PRs, each green before the next:
+
+1. **Foundations** — `Models/ToolListResult.cs` + helper + unit tests for the helper (empty, below, at, above limit; null/non-null summary passthrough).
+2. **Diagnostics pilot** — convert `get_diagnostics` only. Validate the envelope end-to-end through MCP transport. Update its tests. Confirm SKILL.md still reads correctly.
+3. **High-volume finds** — `find_references`, `find_callers`, `find_implementations`, `search_symbols`, `goto_definition`, `find_attribute_usages`, `find_event_subscribers`, `find_reflection_usage`.
+4. **Quality/metrics** — `find_unused_symbols`, `find_naming_violations`, `find_large_classes`, `find_circular_dependencies`, `get_complexity_metrics`.
+5. **Misc** — `get_di_registrations`, `get_generated_code`, `get_source_generators`, `list_solutions`.
+
+## Test strategy
+
+Existing per-tool tests get updated mechanically to assert on `.Items` instead of the bare list.
+
+Per-tool tests add:
+
+- below-limit → `Truncated == false`, `Items.Count == TotalCount`
+- exactly at-limit → `Truncated == false`
+- above-limit → `Truncated == true`, `Items.Count == Limit`, `TotalCount > Limit`
+- explicit `limit` override is respected
+- for summary-producing tools, summary content matches against a fixed fixture
+
+One integration test per summary-producing tool asserts the summary aggregate is correct end-to-end.
+
+## SKILL.md update
+
+A single new "Response shape" section near the top of [SKILL.md](../../plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md):
+
+> All list-returning tools wrap results in: `{ items, totalCount, truncated, limit, summary? }`. When `truncated: true`, the items are the **top N by the tool's natural sort order** (severity-first, worst-first, etc.) — usually that's what you want. Raise `limit` only if the missing tail items matter.
+
+No per-tool description churn — the envelope is uniform enough that existing descriptions still apply.
+
+## Risks and accepted trade-offs
+
+- **Breaking change to every list-tool response shape.** Accepted — pre-1.0, Claude is the only consumer.
+- **Per-tool sort order is now part of the contract.** Worth a short comment near the final sort in each `*Logic.cs`.
+- **Hard-coded per-tool defaults.** Not configurable at runtime. If a default turns out to be wrong, change the constant — don't add a config system.
+
+## Out of scope (intentionally)
+
+- Pagination / cursors
+- `format: "envelope" | "list"` toggle for backwards compatibility
+- Filter-echo in the envelope (Claude already has its call args in context)
+- Restructuring single-object tool responses

--- a/docs/plans/2026-05-21-list-tool-envelope.md
+++ b/docs/plans/2026-05-21-list-tool-envelope.md
@@ -1,0 +1,533 @@
+# List-Tool Response Envelope Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a uniform `ToolListResult<T>` envelope (items + totalCount + truncated + limit + optional summary) to every list-returning MCP tool, with per-tool sort orders and tuned default limits.
+
+**Architecture:** A single generic `ToolListResult<T>` record in `Models/`, populated by a `ToolListResult.Create()` helper. Each tool's `*Logic.cs` continues to return `IReadOnlyList<T>` (pure list producer, easy to test); the `*Tool.cs` wrapper applies the limit and builds the envelope. Sort order is now part of each logic's contract.
+
+**Tech Stack:** C# / .NET 10, xUnit, MSBuildWorkspace, ModelContextProtocol.Server.
+
+**Design doc:** `docs/plans/2026-05-21-list-tool-envelope-design.md`
+
+---
+
+## Conventions for every task
+
+- **Test first.** Write the failing assertion, run it, see it fail, then implement.
+- **Run:** `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~<TestClass>"` to scope.
+- **Full suite before commit at end of each PR group:** `dotnet test`.
+- **Commit per tool conversion** with message `feat(envelope): wrap <tool_name> in ToolListResult<T>`.
+- **Don't touch SKILL.md until Task 21** — one consolidated edit at the end.
+
+---
+
+## PR Group 1 — Foundations
+
+### Task 1: Add `ToolListResult<T>` record + helper
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/ToolListResult.cs`
+- Create: `tests/RoslynCodeLens.Tests/Models/ToolListResultTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+// tests/RoslynCodeLens.Tests/Models/ToolListResultTests.cs
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests.Models;
+
+public class ToolListResultTests
+{
+    [Fact]
+    public void Create_EmptyList_ReturnsZeroCountNotTruncated()
+    {
+        var result = ToolListResult.Create<int>(Array.Empty<int>(), limit: 10);
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+        Assert.False(result.Truncated);
+        Assert.Equal(10, result.Limit);
+        Assert.Null(result.Summary);
+    }
+
+    [Fact]
+    public void Create_BelowLimit_NotTruncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3 }, limit: 10);
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(3, result.TotalCount);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public void Create_ExactlyAtLimit_NotTruncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3 }, limit: 3);
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(3, result.TotalCount);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public void Create_AboveLimit_Truncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3, 4, 5 }, limit: 2);
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal(new[] { 1, 2 }, result.Items);
+        Assert.Equal(5, result.TotalCount);
+        Assert.True(result.Truncated);
+        Assert.Equal(2, result.Limit);
+    }
+
+    [Fact]
+    public void Create_PreservesSummary()
+    {
+        var summary = new { error = 3, warning = 7 };
+        var result = ToolListResult.Create(new[] { 1, 2 }, limit: 10, summary);
+        Assert.Same(summary, result.Summary);
+    }
+}
+```
+
+**Step 2: Run to verify failure**
+
+`dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~ToolListResultTests"`
+Expected: compile error (type doesn't exist yet).
+
+**Step 3: Implement**
+
+```csharp
+// src/RoslynCodeLens/Models/ToolListResult.cs
+namespace RoslynCodeLens.Models;
+
+public record ToolListResult<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    bool Truncated,
+    int Limit,
+    object? Summary = null);
+
+public static class ToolListResult
+{
+    public static ToolListResult<T> Create<T>(
+        IReadOnlyList<T> items,
+        int limit,
+        object? summary = null)
+    {
+        var truncated = items.Count > limit;
+        var sliced = truncated
+            ? (IReadOnlyList<T>)items.Take(limit).ToList()
+            : items;
+        return new ToolListResult<T>(sliced, items.Count, truncated, limit, summary);
+    }
+}
+```
+
+**Step 4: Run tests, expect PASS**
+
+**Step 5: Commit**
+
+```
+git add src/RoslynCodeLens/Models/ToolListResult.cs tests/RoslynCodeLens.Tests/Models/ToolListResultTests.cs
+git commit -m "feat(envelope): add ToolListResult<T> record + helper"
+```
+
+---
+
+## PR Group 2 — Diagnostics Pilot
+
+### Task 2: Convert `get_diagnostics` to envelope
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs`
+- Modify: `tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs`
+
+Logic file is unchanged (keeps returning `IReadOnlyList<DiagnosticInfo>`). Only the Tool wrapper changes.
+
+**Step 1: Write new failing tests (add to existing test class)**
+
+```csharp
+[Fact]
+public async Task GetDiagnostics_Envelope_IncludesSeveritySummary()
+{
+    using var tempFile = new TempTrustFile();
+    var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
+    var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist("nuget-and-solution-bin",
+        RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot: null);
+
+    var manager = TestManagerFactory.WithLoaded(_loaded, _resolver);
+    var result = await GetDiagnosticsTool.Execute(manager, trustStore, allowlist,
+        project: null, severity: null, includeAnalyzers: false, limit: null, ct: default);
+
+    Assert.NotNull(result);
+    Assert.Equal(result.Items.Count, result.TotalCount); // not truncated by default in a clean fixture
+    Assert.False(result.Truncated);
+    Assert.Equal(1000, result.Limit);
+    Assert.NotNull(result.Summary);
+
+    // Summary must expose error/warning/info/hidden counts
+    var summaryJson = System.Text.Json.JsonSerializer.Serialize(result.Summary);
+    Assert.Contains("error", summaryJson, StringComparison.OrdinalIgnoreCase);
+    Assert.Contains("warning", summaryJson, StringComparison.OrdinalIgnoreCase);
+}
+
+[Fact]
+public async Task GetDiagnostics_LimitOverride_Truncates()
+{
+    using var tempFile = new TempTrustFile();
+    var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
+    var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist("nuget-and-solution-bin",
+        RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot: null);
+
+    var manager = TestManagerFactory.WithLoaded(_loaded, _resolver);
+    var result = await GetDiagnosticsTool.Execute(manager, trustStore, allowlist,
+        project: null, severity: null, includeAnalyzers: false, limit: 1, ct: default);
+
+    Assert.True(result.Items.Count <= 1);
+    if (result.TotalCount > 1)
+        Assert.True(result.Truncated);
+    Assert.Equal(1, result.Limit);
+}
+```
+
+Existing tests that called `GetDiagnosticsLogic.Execute(...)` keep working — they target Logic, not Tool. No churn there.
+
+If `TestManagerFactory` doesn't exist, create it as a thin helper:
+```csharp
+// tests/RoslynCodeLens.Tests/Fixtures/TestManagerFactory.cs
+public static class TestManagerFactory
+{
+    public static MultiSolutionManager WithLoaded(LoadedSolution loaded, SymbolResolver resolver)
+    {
+        // Construct or reuse however the existing test fixtures do — mirror SolutionManagerTests.
+    }
+}
+```
+If a simpler hook exists in the codebase (an `IMultiSolutionManager` interface or test-only constructor), prefer that. Investigate `MultiSolutionManager` usage in existing Tool tests before adding the factory.
+
+**Step 2: Run tests, see failure**
+
+`dotnet test --filter "FullyQualifiedName~GetDiagnosticsToolTests"`
+Expected: compile errors on the new test (Tool signature still returns `IReadOnlyList<DiagnosticInfo>`).
+
+**Step 3: Update tool wrapper**
+
+```csharp
+// src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class GetDiagnosticsTool
+{
+    private const int DefaultLimit = 1000;
+
+    [McpServerTool(Name = "get_diagnostics"),
+     Description("List compiler errors and warnings across the solution, optionally including analyzer diagnostics. " +
+                 "Analyzer diagnostics require the solution to be trusted (see 'trust_solution'). " +
+                 "Returns an envelope with items, totalCount, truncated, limit, and a severity summary.")]
+    public static async Task<ToolListResult<DiagnosticInfo>> Execute(
+        MultiSolutionManager manager,
+        Security.TrustStore trustStore,
+        Security.AnalyzerAllowlist allowlist,
+        [Description("Optional project name filter")] string? project = null,
+        [Description("Minimum severity: 'error' or 'warning' (default: warning)")] string? severity = null,
+        [Description("Include analyzer diagnostics (default: false — requires trust_solution to be called first)")]
+            bool includeAnalyzers = false,
+        [Description("Maximum number of items to return (default: 1000). Items are sorted severity-desc, file, line.")]
+            int? limit = null,
+        CancellationToken ct = default)
+    {
+        manager.EnsureLoaded();
+        var raw = await GetDiagnosticsLogic.ExecuteAsync(
+            manager.GetLoadedSolution(), manager.GetResolver(),
+            project, severity, includeAnalyzers, trustStore, allowlist, ct).ConfigureAwait(false);
+
+        var sorted = SortBySeverityFileLine(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    private static IReadOnlyList<DiagnosticInfo> SortBySeverityFileLine(IReadOnlyList<DiagnosticInfo> items)
+    {
+        // Severity rank: error=0, warning=1, info=2, hidden=3 (lower = more important)
+        return items
+            .OrderBy(d => SeverityRank(d.Severity))
+            .ThenBy(d => d.File, StringComparer.Ordinal)
+            .ThenBy(d => d.Line)
+            .ToList();
+    }
+
+    private static int SeverityRank(string severity) => severity switch
+    {
+        "Error" => 0,
+        "Warning" => 1,
+        "Info" => 2,
+        "Hidden" => 3,
+        _ => 4,
+    };
+
+    private static object BuildSummary(IReadOnlyList<DiagnosticInfo> items)
+    {
+        var error = 0; var warning = 0; var info = 0; var hidden = 0;
+        foreach (var d in items)
+        {
+            switch (d.Severity)
+            {
+                case "Error": error++; break;
+                case "Warning": warning++; break;
+                case "Info": info++; break;
+                case "Hidden": hidden++; break;
+            }
+        }
+        return new { error, warning, info, hidden };
+    }
+}
+```
+
+**Step 4: Run tests, expect PASS**
+
+`dotnet test --filter "FullyQualifiedName~GetDiagnosticsToolTests"`
+
+**Step 5: Sanity-build and run full test suite**
+
+`dotnet build` then `dotnet test`. No other test should break.
+
+**Step 6: Commit**
+
+```
+git commit -am "feat(envelope): wrap get_diagnostics in ToolListResult<T>"
+```
+
+---
+
+## PR Group 3 — High-Volume Find Tools
+
+Each task below follows the **same template** as Task 2:
+1. Add envelope-shape tests (totalCount, truncated, limit, summary if applicable) to existing test file.
+2. See them fail.
+3. Update the Tool wrapper: add `int? limit = null` parameter, return `ToolListResult<T>`, apply sort, build summary (or pass null).
+4. Update existing tests in that file that asserted on raw list — change `Assert.Empty(results)` → `Assert.Empty(results.Items)` etc. Most are 1-2 char edits.
+5. Run scoped tests, then full suite. Commit.
+
+The summary builders below are **complete code** — paste them into the Tool file as private static helpers.
+
+### Task 3: `find_references` → envelope
+
+**Default limit:** 500. **Sort:** file (Ordinal), then line. **Summary:** `{ byProject: Dictionary<string,int> }`.
+
+```csharp
+private static object BuildSummary(IReadOnlyList<SymbolReference> items)
+{
+    var byProject = items
+        .GroupBy(r => r.Project, StringComparer.Ordinal)
+        .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+    return new { byProject };
+}
+
+private static IReadOnlyList<SymbolReference> Sort(IReadOnlyList<SymbolReference> items)
+    => items.OrderBy(r => r.File, StringComparer.Ordinal).ThenBy(r => r.Line).ToList();
+```
+
+Modify `FindReferencesTool.cs`, update `FindReferencesToolTests.cs`. Commit: `feat(envelope): wrap find_references in ToolListResult<T>`.
+
+> **If `SymbolReference` has no `Project` property, check the actual model and either group by file (fallback) or skip the summary.** Verify before writing the summary code.
+
+### Task 4: `find_callers` → envelope
+
+**Default limit:** 500. **Sort:** file, line. **Summary:** `{ byProject }` (same pattern as Task 3, using `CallerInfo.Project` if present — otherwise omit summary).
+
+### Task 5: `find_implementations` → envelope
+
+**Default limit:** 200. **Sort:** file, line. **Summary:** `null`. Items are `SymbolLocation`.
+
+### Task 6: `search_symbols` → envelope
+
+**Default limit:** 200. **Sort:** match quality (exact → prefix → substring); within each bucket, alphabetical by name. **Summary:** `{ byKind: Dictionary<string,int> }` keyed by symbol kind (`Class`, `Method`, ...).
+
+```csharp
+private static IReadOnlyList<SymbolLocation> SortByMatchQuality(string query, IReadOnlyList<SymbolLocation> items)
+{
+    return items
+        .OrderBy(s => MatchRank(s, query))
+        .ThenBy(s => s.Symbol, StringComparer.Ordinal)
+        .ToList();
+}
+
+private static int MatchRank(SymbolLocation s, string query)
+{
+    // Assume SymbolLocation has a Symbol or Name property; verify in source.
+    var name = s.Symbol;
+    if (string.Equals(name, query, StringComparison.OrdinalIgnoreCase)) return 0;
+    if (name.StartsWith(query, StringComparison.OrdinalIgnoreCase)) return 1;
+    return 2;
+}
+```
+
+> Verify `SymbolLocation` field names before pasting. Adjust property accesses to match.
+
+### Task 7: `goto_definition` → envelope
+
+**Default limit:** 50. **Sort:** file, line. **Summary:** `null`. Typically 1-2 items; the limit is a safety cap.
+
+### Task 8: `find_attribute_usages` → envelope
+
+**Default limit:** 500. **Sort:** file, line. **Summary:** `{ byProject }` if `AttributeUsageInfo.Project` exists.
+
+### Task 9: `find_event_subscribers` → envelope
+
+**Default limit:** 500. **Sort:** file, line. **Summary:** `null`.
+
+### Task 10: `find_reflection_usage` → envelope
+
+**Default limit:** 500. **Sort:** severity desc (errors/warnings first if the model has a severity), then file. **Summary:** `{ byKind }` grouped by reflection-call type (e.g. `GetType`, `Invoke`, `GetMethod`) — check `ReflectionUsage` model for the relevant property name.
+
+---
+
+## PR Group 4 — Quality / Metrics Tools
+
+Same template as Group 3.
+
+### Task 11: `find_unused_symbols` → envelope
+
+**Default limit:** 500. **Sort:** project, then file. **Summary:** `{ byKind: Dictionary<string,int> }` (Class, Method, Field, Property, Event).
+
+### Task 12: `find_naming_violations` → envelope
+
+**Default limit:** 500. **Sort:** rule id, then file. **Summary:** `{ byRule: Dictionary<string,int> }`.
+
+### Task 13: `find_large_classes` → envelope
+
+**Default limit:** 100. **Sort:** size desc (worst first — likely member count or line count; check `LargeClassInfo`). **Summary:** `null`.
+
+### Task 14: `find_circular_dependencies` → envelope
+
+**Default limit:** 100. **Sort:** cycle length desc. **Summary:** `null`.
+
+### Task 15: `get_complexity_metrics` → envelope
+
+**Default limit:** 100. **Sort:** complexity desc. **Summary:** `{ max, avg, overThreshold }`.
+
+```csharp
+private static object BuildSummary(IReadOnlyList<ComplexityMetric> items, int threshold)
+{
+    if (items.Count == 0) return new { max = 0, avg = 0.0, overThreshold = 0 };
+    var max = items.Max(m => m.Complexity);    // verify property name
+    var avg = items.Average(m => m.Complexity);
+    var overThreshold = items.Count(m => m.Complexity > threshold);
+    return new { max, avg, overThreshold };
+}
+```
+
+> The `threshold` parameter already exists on this tool. Pass it through to `BuildSummary`.
+
+---
+
+## PR Group 5 — Miscellaneous List Tools
+
+### Task 16: `get_di_registrations` → envelope
+
+**Default limit:** 200. **Sort:** service name (Ordinal). **Summary:** `null`.
+
+### Task 17: `get_generated_code` → envelope
+
+**Default limit:** 200. **Sort:** project, then file. **Summary:** `null`.
+
+### Task 18: `get_source_generators` → envelope
+
+**Default limit:** 100. **Sort:** project (Ordinal). **Summary:** `null`.
+
+### Task 19: `list_solutions` → envelope
+
+**Default limit:** 50. **Sort:** name (Ordinal). **Summary:** `null`. Even though this list is small, conversion keeps the contract uniform.
+
+---
+
+## PR Group 6 — Cleanup
+
+### Task 20: Audit remaining list-returning tools
+
+**Step 1:** Run
+
+```
+grep -rn "IReadOnlyList<" src/RoslynCodeLens/Tools/ | grep -E "Tool\.cs:"
+```
+
+Verify only the converted tools and the explicitly out-of-scope ones (single-object returners) remain. **If any list-returning tool slipped through the plan**, convert it using the same template (200 default, file/line sort, null summary unless an aggregate is obviously useful).
+
+**Step 2:** Run full test suite: `dotnet test`. Expect all green.
+
+**Step 3:** Commit any straggler conversions individually.
+
+---
+
+### Task 21: Update SKILL.md
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+
+**Step 1:** Add a "Response shape" section near the top (after the opening intro / before tool catalog):
+
+```markdown
+## Response shape
+
+All list-returning tools wrap their results in an envelope:
+
+```json
+{
+  "items": [...],           // the actual records
+  "totalCount": 142,        // how many existed before truncation
+  "truncated": false,       // true if items.length < totalCount
+  "limit": 500,             // the cap that was applied
+  "summary": { ... }        // optional aggregate; varies by tool
+}
+```
+
+When `truncated` is `true`, the items are the **top N by the tool's natural sort order**
+(severity-first, worst-first, alphabetical, etc.) — usually that's exactly what you want.
+Raise `limit` only if the truncated tail items matter for the task.
+
+Tools with summary aggregates today: `get_diagnostics` (severity counts),
+`find_references` / `find_callers` / `find_attribute_usages` (by project),
+`search_symbols` / `find_reflection_usage` / `find_unused_symbols` (by kind),
+`find_naming_violations` (by rule), `get_complexity_metrics` (max/avg/overThreshold).
+```
+
+**Step 2:** Verify no other section in SKILL.md describes per-tool response shapes that would now be wrong.
+
+**Step 3:** Commit.
+
+```
+git commit -am "docs(skill): document list-tool envelope response shape"
+```
+
+---
+
+### Task 22: Final verification
+
+**Step 1:** `dotnet build` — must succeed with no warnings introduced.
+
+**Step 2:** `dotnet test` — full suite green.
+
+**Step 3:** Manually smoke-test via the MCP server:
+- Start the server (the existing `.mcp.json` works).
+- Call `get_diagnostics` and visually confirm the envelope shape in the response.
+- Call `find_references` on a popular symbol; confirm `summary.byProject` is populated.
+- Call `get_complexity_metrics` with a low threshold; confirm `summary.overThreshold` is non-zero.
+
+**Step 4:** If everything passes, the work is complete. If anything is off, fix and re-test before declaring done.
+
+---
+
+## Gotchas / things to watch for
+
+- **Test classes use `_loaded` and `_resolver` fields from `TestSolutionFixture`.** Don't break the `[Collection("TestSolution")]` pattern.
+- **The fixture intentionally allows some `CS0246` adapter-restore flakes** (see comment block at top of `GetDiagnosticsToolTests.cs`). Preserve that filter logic when you update the test — it's not unrelated noise.
+- **`Logic.cs` files should remain pure list producers.** Don't push truncation into them — it belongs at the Tool boundary. Doing this twice would double-truncate.
+- **Sort order is a contract.** When you write the sort, leave a one-line comment explaining why: `// Sorted severity-desc so truncated top-N keeps the most important diagnostics.`
+- **Model field names may differ from what I guessed in this plan.** Always read the relevant `Models/*.cs` before pasting summary code. If a property doesn't exist, adapt or drop that summary.
+- **`object?` summaries** — JSON serialization through MCP just works for anonymous types. Don't introduce typed summary classes unless one is reused across tools.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -5,6 +5,32 @@ description: Use when working with any .NET / C# code (.cs/.csproj/.sln/.slnx fi
 
 # Roslyn CodeLens — Semantic .NET Intelligence
 
+## Response shape
+
+All list-returning tools wrap their results in an envelope:
+
+```json
+{
+  "items": [...],
+  "totalCount": 142,
+  "truncated": false,
+  "limit": 500,
+  "summary": { ... }
+}
+```
+
+When `truncated` is `true`, `items` are the **top N by the tool's natural sort order** (severity-first, worst-first, by-project, etc.) — usually that's what you want. Raise `limit` only if the truncated tail matters for the task.
+
+Tools that include a `summary` aggregate:
+
+- `get_diagnostics` — `{ error, warning, info, hidden }` counts
+- `find_references`, `find_callers`, `find_attribute_usages` — `{ byProject: { name: count } }`
+- `search_symbols`, `find_unused_symbols`, `find_reflection_usage` — `{ byKind: {...} }`
+- `find_naming_violations` — `{ byRule: {...} }`
+- `get_complexity_metrics` — `{ max, avg, overThreshold }`
+
+Single-object tools (`get_type_overview`, `get_symbol_context`, `apply_code_action`, etc.) are unchanged — they return their bespoke shape directly.
+
 ## Detection
 
 If `find_implementations` is not available as an MCP tool, this skill is inert — do nothing, no errors.

--- a/src/RoslynCodeLens/Models/ToolListResult.cs
+++ b/src/RoslynCodeLens/Models/ToolListResult.cs
@@ -1,0 +1,23 @@
+namespace RoslynCodeLens.Models;
+
+public record ToolListResult<T>(
+    IReadOnlyList<T> Items,
+    int TotalCount,
+    bool Truncated,
+    int Limit,
+    object? Summary = null);
+
+public static class ToolListResult
+{
+    public static ToolListResult<T> Create<T>(
+        IReadOnlyList<T> items,
+        int limit,
+        object? summary = null)
+    {
+        var truncated = items.Count > limit;
+        var sliced = truncated
+            ? (IReadOnlyList<T>)items.Take(limit).ToList()
+            : items;
+        return new ToolListResult<T>(sliced, items.Count, truncated, limit, summary);
+    }
+}

--- a/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
@@ -7,17 +7,40 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindAttributeUsagesTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_attribute_usages"),
-     Description("Find all types and members decorated with a specific attribute (e.g., Obsolete, Authorize, Serializable)")]
-    public static IReadOnlyList<AttributeUsageInfo> Execute(
+     Description("Find all types and members decorated with a specific attribute (e.g., Obsolete, Authorize, Serializable). " +
+                 "Returns an envelope with items, totalCount, truncated, limit, and a byProject summary.")]
+    public static ToolListResult<AttributeUsageInfo> Execute(
         MultiSolutionManager manager,
-        [Description("Attribute name to search for (with or without 'Attribute' suffix)")] string attribute)
+        [Description("Attribute name to search for (with or without 'Attribute' suffix)")] string attribute,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindAttributeUsagesLogic.Execute(
+        var raw = FindAttributeUsagesLogic.Execute(
             manager.GetLoadedSolution(),
             manager.GetResolver(),
             manager.GetMetadataResolver(),
             attribute);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<AttributeUsageInfo> Sort(IReadOnlyList<AttributeUsageInfo> items)
+        => items
+            .OrderBy(a => a.File, StringComparer.Ordinal)
+            .ThenBy(a => a.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<AttributeUsageInfo> items)
+    {
+        var byProject = items
+            .GroupBy(a => a.Project, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byProject };
     }
 }

--- a/src/RoslynCodeLens/Tools/FindCallersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersTool.cs
@@ -7,13 +7,36 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindCallersTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_callers"),
-     Description("Find every call site for a method")]
-    public static IReadOnlyList<CallerInfo> Execute(
+     Description("Find every call site for a method. " +
+                 "Returns an envelope with items, totalCount, truncated, limit, and a byProject summary.")]
+    public static ToolListResult<CallerInfo> Execute(
         MultiSolutionManager manager,
-        [Description("Method name as Type.Method (simple or fully qualified)")] string symbol)
+        [Description("Method name as Type.Method (simple or fully qualified)")] string symbol,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindCallersLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var raw = FindCallersLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<CallerInfo> Sort(IReadOnlyList<CallerInfo> items)
+        => items
+            .OrderBy(c => c.File, StringComparer.Ordinal)
+            .ThenBy(c => c.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<CallerInfo> items)
+    {
+        var byProject = items
+            .GroupBy(c => c.Project, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byProject };
     }
 }

--- a/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
@@ -7,13 +7,26 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindCircularDependenciesTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "find_circular_dependencies"),
-     Description("Detect circular dependencies in the project reference graph or namespace dependency graph")]
-    public static IReadOnlyList<CircularDependency> Execute(
+     Description("Detect circular dependencies in the project reference graph or namespace dependency graph. " +
+                 "Returns an envelope with items sorted by cycle length desc, totalCount, truncated, and limit (default 100).")]
+    public static ToolListResult<CircularDependency> Execute(
         MultiSolutionManager manager,
-        [Description("Level: 'project' or 'namespace' (default: project)")] string level = "project")
+        [Description("Level: 'project' or 'namespace' (default: project)")] string level = "project",
+        [Description("Maximum number of items to return (default: 100). Items are sorted by cycle length desc.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindCircularDependenciesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), level);
+        var raw = FindCircularDependenciesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), level);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<CircularDependency> Sort(IReadOnlyList<CircularDependency> items)
+        => items
+            .OrderByDescending(c => c.Cycle.Count)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
@@ -7,6 +7,8 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindEventSubscribersTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_event_subscribers")]
     [Description(
         "Find every += and -= site for an event symbol across the solution. " +
@@ -18,17 +20,28 @@ public static class FindEventSubscribersTool
         "Use this for memory-leak audits (compare subscribe/unsubscribe pairs), " +
         "UI event subscriber inspection, or when Grep over '+= EventName' would miss " +
         "qualified or fully-typed subscription sites. " +
-        "Sort: file path ASC then line ASC.")]
-    public static IReadOnlyList<EventSubscriberInfo> Execute(
+        "Returns an envelope with items sorted by file path then line, totalCount, truncated, and limit (default 500).")]
+    public static ToolListResult<EventSubscriberInfo> Execute(
         MultiSolutionManager manager,
         [Description("Event symbol (e.g. 'MyClass.Clicked' or 'System.Diagnostics.Process.Exited')")]
-        string symbol)
+        string symbol,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by file path, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindEventSubscribersLogic.Execute(
+        var raw = FindEventSubscribersLogic.Execute(
             manager.GetLoadedSolution(),
             manager.GetResolver(),
             manager.GetMetadataResolver(),
             symbol);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<EventSubscriberInfo> Sort(IReadOnlyList<EventSubscriberInfo> items)
+        => items
+            .OrderBy(e => e.FilePath, StringComparer.Ordinal)
+            .ThenBy(e => e.Line)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
@@ -7,13 +7,27 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindImplementationsTool
 {
+    private const int DefaultLimit = 200;
+
     [McpServerTool(Name = "find_implementations"),
-     Description("Find all classes/structs implementing an interface or extending a class")]
-    public static IReadOnlyList<SymbolLocation> Execute(
+     Description("Find all classes/structs implementing an interface or extending a class. " +
+                 "Returns an envelope with items, totalCount, truncated, and limit.")]
+    public static ToolListResult<SymbolLocation> Execute(
         MultiSolutionManager manager,
-        [Description("Type name (simple or fully qualified)")] string symbol)
+        [Description("Type name (simple or fully qualified)")] string symbol,
+        [Description("Maximum number of items to return (default: 200). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindImplementationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var raw = FindImplementationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<SymbolLocation> Sort(IReadOnlyList<SymbolLocation> items)
+        => items
+            .OrderBy(s => s.File, StringComparer.Ordinal)
+            .ThenBy(s => s.Line)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
@@ -7,15 +7,29 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindLargeClassesTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "find_large_classes"),
-     Description("Find classes and structs that exceed member count or line count thresholds")]
-    public static IReadOnlyList<LargeClassInfo> Execute(
+     Description("Find classes and structs that exceed member count or line count thresholds. " +
+                 "Returns an envelope with items sorted worst-first (highest size first), totalCount, truncated, and limit (default 100).")]
+    public static ToolListResult<LargeClassInfo> Execute(
         MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Maximum members before flagging (default: 20)")] int maxMembers = 20,
-        [Description("Maximum lines before flagging (default: 500)")] int maxLines = 500)
+        [Description("Maximum lines before flagging (default: 500)")] int maxLines = 500,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by size desc (worst first).")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindLargeClassesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, maxMembers, maxLines);
+        var raw = FindLargeClassesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, maxMembers, maxLines);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<LargeClassInfo> Sort(IReadOnlyList<LargeClassInfo> items)
+        => items
+            .OrderByDescending(c => Math.Max(c.MemberCount, c.LineCount))
+            .ThenBy(c => c.TypeName, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
@@ -7,13 +7,37 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindNamingViolationsTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_naming_violations"),
-     Description("Check .NET naming convention compliance: PascalCase types/methods/properties, camelCase parameters, I-prefix interfaces, _ prefix private fields")]
-    public static IReadOnlyList<NamingViolation> Execute(
+     Description("Check .NET naming convention compliance: PascalCase types/methods/properties, camelCase parameters, I-prefix interfaces, _ prefix private fields. " +
+                 "Returns an envelope with items, totalCount, truncated, limit (default 500), and a byRule summary.")]
+    public static ToolListResult<NamingViolation> Execute(
         MultiSolutionManager manager,
-        [Description("Optional project name filter")] string? project = null)
+        [Description("Optional project name filter")] string? project = null,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by rule, then file.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindNamingViolationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+        var raw = FindNamingViolationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<NamingViolation> Sort(IReadOnlyList<NamingViolation> items)
+        => items
+            .OrderBy(n => n.Rule, StringComparer.Ordinal)
+            .ThenBy(n => n.File, StringComparer.Ordinal)
+            .ThenBy(n => n.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<NamingViolation> items)
+    {
+        var byRule = items
+            .GroupBy(n => n.Rule, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byRule };
     }
 }

--- a/src/RoslynCodeLens/Tools/FindReferencesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesTool.cs
@@ -7,13 +7,36 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindReferencesTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_references"),
-     Description("Find all references to a symbol (type, method, property, field, or event) across the solution")]
-    public static IReadOnlyList<SymbolReference> Execute(
+     Description("Find all references to a symbol (type, method, property, field, or event) across the solution. " +
+                 "Returns an envelope with items, totalCount, truncated, limit, and a byProject summary.")]
+    public static ToolListResult<SymbolReference> Execute(
         MultiSolutionManager manager,
-        [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyProperty)")] string symbol)
+        [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyProperty)")] string symbol,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindReferencesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var raw = FindReferencesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<SymbolReference> Sort(IReadOnlyList<SymbolReference> items)
+        => items
+            .OrderBy(r => r.File, StringComparer.Ordinal)
+            .ThenBy(r => r.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<SymbolReference> items)
+    {
+        var byProject = items
+            .GroupBy(r => r.Project, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byProject };
     }
 }

--- a/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
@@ -7,13 +7,36 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindReflectionUsageTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_reflection_usage"),
-     Description("Detect dynamic/reflection-based usage like Type.GetType, Activator.CreateInstance, MethodInfo.Invoke")]
-    public static IReadOnlyList<ReflectionUsage> Execute(
+     Description("Detect dynamic/reflection-based usage like Type.GetType, Activator.CreateInstance, MethodInfo.Invoke. " +
+                 "Returns an envelope with items, totalCount, truncated, limit (default 500), and a byKind summary.")]
+    public static ToolListResult<ReflectionUsage> Execute(
         MultiSolutionManager manager,
-        [Description("Optional type name to filter results (omit to scan entire solution)")] string? symbol = null)
+        [Description("Optional type name to filter results (omit to scan entire solution)")] string? symbol = null,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindReflectionUsageLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        var raw = FindReflectionUsageLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<ReflectionUsage> Sort(IReadOnlyList<ReflectionUsage> items)
+        => items
+            .OrderBy(r => r.File, StringComparer.Ordinal)
+            .ThenBy(r => r.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<ReflectionUsage> items)
+    {
+        var byKind = items
+            .GroupBy(r => r.Kind, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byKind };
     }
 }

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
@@ -7,14 +7,38 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class FindUnusedSymbolsTool
 {
+    private const int DefaultLimit = 500;
+
     [McpServerTool(Name = "find_unused_symbols"),
-     Description("Find potentially unused types and members (dead code detection). Checks public symbols for references across the solution.")]
-    public static IReadOnlyList<UnusedSymbolInfo> Execute(
+     Description("Find potentially unused types and members (dead code detection). Checks public symbols for references across the solution. " +
+                 "Returns an envelope with items, totalCount, truncated, limit (default 500), and a byKind summary.")]
+    public static ToolListResult<UnusedSymbolInfo> Execute(
         MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
-        [Description("Include internal symbols (default: false)")] bool includeInternal = false)
+        [Description("Include internal symbols (default: false)")] bool includeInternal = false,
+        [Description("Maximum number of items to return (default: 500). Items are sorted by project, then file.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return FindUnusedSymbolsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, includeInternal);
+        var raw = FindUnusedSymbolsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, includeInternal);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<UnusedSymbolInfo> Sort(IReadOnlyList<UnusedSymbolInfo> items)
+        => items
+            .OrderBy(u => u.Project, StringComparer.Ordinal)
+            .ThenBy(u => u.File, StringComparer.Ordinal)
+            .ThenBy(u => u.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<UnusedSymbolInfo> items)
+    {
+        var byKind = items
+            .GroupBy(u => u.SymbolKind, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byKind };
     }
 }

--- a/src/RoslynCodeLens/Tools/GetCodeActionsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeActionsTool.cs
@@ -7,22 +7,36 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetCodeActionsTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "get_code_actions"),
      Description("List available code actions (refactorings and fixes) at a position in a C# file. " +
                  "Optionally specify endLine/endColumn to select a range for extract-method style refactorings. " +
-                 "Returns action titles that can be passed to apply_code_action.")]
-    public static async Task<IReadOnlyList<CodeActionInfo>> Execute(
+                 "Returns action titles that can be passed to apply_code_action. " +
+                 "Returns an envelope with items sorted by kind then title, totalCount, truncated, and limit (default 100).")]
+    public static async Task<ToolListResult<CodeActionInfo>> Execute(
         MultiSolutionManager manager,
         [Description("Full path to the C# source file")] string filePath,
         [Description("Line number (1-based)")] int line,
         [Description("Column number (1-based)")] int column,
         [Description("End line for text selection (1-based, optional)")] int? endLine = null,
         [Description("End column for text selection (1-based, optional)")] int? endColumn = null,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by kind then title.")]
+            int? limit = null,
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
-        return await GetCodeActionsLogic.ExecuteAsync(
+        var raw = await GetCodeActionsLogic.ExecuteAsync(
             manager.GetLoadedSolution(), filePath, line, column,
             endLine, endColumn, ct).ConfigureAwait(false);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<CodeActionInfo> Sort(IReadOnlyList<CodeActionInfo> items)
+        => items
+            .OrderBy(a => a.Kind, StringComparer.Ordinal)
+            .ThenBy(a => a.Title, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
@@ -7,18 +7,31 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetCodeFixesTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "get_code_fixes"),
-     Description("Get available code fixes for a specific diagnostic at a file location. Returns structured text edits that can be reviewed and applied.")]
-    public static async Task<IReadOnlyList<CodeFixSuggestion>> Execute(
+     Description("Get available code fixes for a specific diagnostic at a file location. Returns structured text edits that can be reviewed and applied. " +
+                 "Returns an envelope with items sorted by title, totalCount, truncated, and limit (default 100).")]
+    public static async Task<ToolListResult<CodeFixSuggestion>> Execute(
         MultiSolutionManager manager,
         Security.TrustStore trustStore,
         Security.AnalyzerAllowlist allowlist,
         [Description("Diagnostic ID (e.g., 'CA1822', 'CS0168')")] string diagnosticId,
         [Description("Full path to the source file")] string filePath,
         [Description("Line number where the diagnostic occurs")] int line,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by title.")]
+            int? limit = null,
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
-        return await GetCodeFixesLogic.ExecuteAsync(manager.GetLoadedSolution(), manager.GetResolver(), diagnosticId, filePath, line, trustStore, allowlist, ct).ConfigureAwait(false);
+        var raw = await GetCodeFixesLogic.ExecuteAsync(manager.GetLoadedSolution(), manager.GetResolver(), diagnosticId, filePath, line, trustStore, allowlist, ct).ConfigureAwait(false);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<CodeFixSuggestion> Sort(IReadOnlyList<CodeFixSuggestion> items)
+        => items
+            .OrderBy(f => f.Title, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
@@ -7,14 +7,39 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetComplexityMetricsTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "get_complexity_metrics"),
-     Description("Calculate cyclomatic complexity for methods. Returns methods exceeding the threshold, sorted by complexity.")]
-    public static IReadOnlyList<ComplexityMetric> Execute(
+     Description("Calculate cyclomatic complexity for methods. Returns methods exceeding the threshold. " +
+                 "Returns an envelope with items sorted worst-first, totalCount, truncated, limit (default 100), and a summary with max/avg/overThreshold.")]
+    public static ToolListResult<ComplexityMetric> Execute(
         MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
-        [Description("Minimum complexity threshold (default: 10)")] int threshold = 10)
+        [Description("Minimum complexity threshold (default: 10)")] int threshold = 10,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by complexity desc (worst first).")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return GetComplexityMetricsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, threshold);
+        var raw = GetComplexityMetricsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, threshold);
+
+        var sorted = Sort(raw);
+        var summary = BuildSummary(raw, threshold);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<ComplexityMetric> Sort(IReadOnlyList<ComplexityMetric> items)
+        => items
+            .OrderByDescending(m => m.Complexity)
+            .ThenBy(m => m.File, StringComparer.Ordinal)
+            .ThenBy(m => m.Line)
+            .ToList();
+
+    internal static object BuildSummary(IReadOnlyList<ComplexityMetric> items, int threshold)
+    {
+        if (items.Count == 0) return new { max = 0, avg = 0.0, overThreshold = 0 };
+        var max = items.Max(m => m.Complexity);
+        var avg = items.Average(m => m.Complexity);
+        var overThreshold = items.Count(m => m.Complexity > threshold);
+        return new { max, avg, overThreshold };
     }
 }

--- a/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
@@ -7,13 +7,28 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetDiRegistrationsTool
 {
+    private const int DefaultLimit = 200;
+
     [McpServerTool(Name = "get_di_registrations"),
-     Description("Scan IServiceCollection extension methods for DI registrations of a type")]
-    public static IReadOnlyList<DiRegistration> Execute(
+     Description("Scan IServiceCollection extension methods for DI registrations of a type. " +
+                 "Returns an envelope with items sorted by service name, totalCount, truncated, and limit (default 200).")]
+    public static ToolListResult<DiRegistration> Execute(
         MultiSolutionManager manager,
-        [Description("Type name to search for (simple or fully qualified)")] string symbol)
+        [Description("Type name to search for (simple or fully qualified)")] string symbol,
+        [Description("Maximum number of items to return (default: 200). Items are sorted by service name.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return GetDiRegistrationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        var raw = GetDiRegistrationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<DiRegistration> Sort(IReadOnlyList<DiRegistration> items)
+        => items
+            .OrderBy(d => d.Service, StringComparer.Ordinal)
+            .ThenBy(d => d.File, StringComparer.Ordinal)
+            .ThenBy(d => d.Line)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
@@ -7,10 +7,13 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetDiagnosticsTool
 {
+    private const int DefaultLimit = 1000;
+
     [McpServerTool(Name = "get_diagnostics"),
      Description("List compiler errors and warnings across the solution, optionally including analyzer diagnostics. " +
-                 "Analyzer diagnostics require the solution to be trusted (see 'trust_solution').")]
-    public static async Task<IReadOnlyList<DiagnosticInfo>> Execute(
+                 "Analyzer diagnostics require the solution to be trusted (see 'trust_solution'). " +
+                 "Returns an envelope with items, totalCount, truncated, limit, and a severity summary.")]
+    public static async Task<ToolListResult<DiagnosticInfo>> Execute(
         MultiSolutionManager manager,
         Security.TrustStore trustStore,
         Security.AnalyzerAllowlist allowlist,
@@ -18,9 +21,55 @@ public static class GetDiagnosticsTool
         [Description("Minimum severity: 'error' or 'warning' (default: warning)")] string? severity = null,
         [Description("Include analyzer diagnostics (default: false — requires trust_solution to be called first)")]
             bool includeAnalyzers = false,
+        [Description("Maximum number of items to return (default: 1000). Items are sorted severity-desc, then file, then line.")]
+            int? limit = null,
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
-        return await GetDiagnosticsLogic.ExecuteAsync(manager.GetLoadedSolution(), manager.GetResolver(), project, severity, includeAnalyzers, trustStore, allowlist, ct).ConfigureAwait(false);
+        var raw = await GetDiagnosticsLogic.ExecuteAsync(
+            manager.GetLoadedSolution(), manager.GetResolver(),
+            project, severity, includeAnalyzers, trustStore, allowlist, ct).ConfigureAwait(false);
+
+        // Sort severity-first so truncated top-N keeps the most important diagnostics.
+        var sorted = SortBySeverityFileLine(raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<DiagnosticInfo> SortBySeverityFileLine(IReadOnlyList<DiagnosticInfo> items)
+    {
+        return items
+            .OrderBy(d => SeverityRank(d.Severity))
+            .ThenBy(d => d.File, StringComparer.Ordinal)
+            .ThenBy(d => d.Line)
+            .ToList();
+    }
+
+    private static int SeverityRank(string severity) => severity switch
+    {
+        "Error" => 0,
+        "Warning" => 1,
+        "Info" => 2,
+        "Hidden" => 3,
+        _ => 4,
+    };
+
+    internal static object BuildSummary(IReadOnlyList<DiagnosticInfo> items)
+    {
+        var error = 0;
+        var warning = 0;
+        var info = 0;
+        var hidden = 0;
+        foreach (var d in items)
+        {
+            switch (d.Severity)
+            {
+                case "Error": error++; break;
+                case "Warning": warning++; break;
+                case "Info": info++; break;
+                case "Hidden": hidden++; break;
+            }
+        }
+        return new { error, warning, info, hidden };
     }
 }

--- a/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
+++ b/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
@@ -7,15 +7,29 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetGeneratedCodeTool
 {
+    private const int DefaultLimit = 200;
+
     [McpServerTool(Name = "get_generated_code"),
-     Description("Inspect generated source code from source generators")]
-    public static IReadOnlyList<GeneratedFileInfo> Execute(
+     Description("Inspect generated source code from source generators. " +
+                 "Returns an envelope with items sorted by project then file path, totalCount, truncated, and limit (default 200).")]
+    public static ToolListResult<GeneratedFileInfo> Execute(
         MultiSolutionManager manager,
         [Description("Generator name to filter by")] string? generator = null,
-        [Description("File path (or partial match) to filter by")] string? file = null)
+        [Description("File path (or partial match) to filter by")] string? file = null,
+        [Description("Maximum number of items to return (default: 200). Items are sorted by project, then file path.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return GetGeneratedCodeLogic.Execute(
+        var raw = GetGeneratedCodeLogic.Execute(
             manager.GetLoadedSolution(), manager.GetResolver(), generator, file);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<GeneratedFileInfo> Sort(IReadOnlyList<GeneratedFileInfo> items)
+        => items
+            .OrderBy(g => g.Project, StringComparer.Ordinal)
+            .ThenBy(g => g.FilePath, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
@@ -7,13 +7,27 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GetSourceGeneratorsTool
 {
+    private const int DefaultLimit = 100;
+
     [McpServerTool(Name = "get_source_generators"),
-     Description("List source generators and their output per project")]
-    public static IReadOnlyList<SourceGeneratorInfo> Execute(
+     Description("List source generators and their output per project. " +
+                 "Returns an envelope with items sorted by project then generator name, totalCount, truncated, and limit (default 100).")]
+    public static ToolListResult<SourceGeneratorInfo> Execute(
         MultiSolutionManager manager,
-        [Description("Optional project name filter")] string? project = null)
+        [Description("Optional project name filter")] string? project = null,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by project, then generator name.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return GetSourceGeneratorsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+        var raw = GetSourceGeneratorsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<SourceGeneratorInfo> Sort(IReadOnlyList<SourceGeneratorInfo> items)
+        => items
+            .OrderBy(s => s.Project, StringComparer.Ordinal)
+            .ThenBy(s => s.GeneratorName, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
+++ b/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
@@ -7,13 +7,27 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class GoToDefinitionTool
 {
+    private const int DefaultLimit = 50;
+
     [McpServerTool(Name = "go_to_definition"),
-     Description("Find the source file and line where a symbol is defined")]
-    public static IReadOnlyList<SymbolLocation> Execute(
+     Description("Find the source file and line where a symbol is defined. " +
+                 "Returns an envelope with items, totalCount, truncated, and limit.")]
+    public static ToolListResult<SymbolLocation> Execute(
         MultiSolutionManager manager,
-        [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.DoWork)")] string symbol)
+        [Description("Symbol name: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.DoWork)")] string symbol,
+        [Description("Maximum number of items to return (default: 50). Items are sorted by file, then line.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return GoToDefinitionLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var raw = GoToDefinitionLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<SymbolLocation> Sort(IReadOnlyList<SymbolLocation> items)
+        => items
+            .OrderBy(s => s.File, StringComparer.Ordinal)
+            .ThenBy(s => s.Line)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
+++ b/src/RoslynCodeLens/Tools/ListSolutionsTool.cs
@@ -7,12 +7,25 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class ListSolutionsTool
 {
+    private const int DefaultLimit = 50;
+
     [McpServerTool(Name = "list_solutions"),
      Description("List all solutions loaded by this server, showing which one is currently active. " +
                  "Each entry includes any projects that were skipped during load (e.g. legacy non-SDK-style projects), " +
-                 "with the kind and reason for each skip.")]
-    public static IReadOnlyList<SolutionInfo> Execute(MultiSolutionManager manager)
+                 "with the kind and reason for each skip. " +
+                 "Returns an envelope with items sorted by solution path, totalCount, truncated, and limit (default 50).")]
+    public static ToolListResult<SolutionInfo> Execute(
+        MultiSolutionManager manager,
+        [Description("Maximum number of items to return (default: 50). Items are sorted by solution path.")]
+            int? limit = null)
     {
-        return manager.ListSolutions();
+        var raw = manager.ListSolutions();
+        var sorted = Sort(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit);
     }
+
+    internal static IReadOnlyList<SolutionInfo> Sort(IReadOnlyList<SolutionInfo> items)
+        => items
+            .OrderBy(s => s.Path, StringComparer.Ordinal)
+            .ToList();
 }

--- a/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
@@ -7,13 +7,50 @@ namespace RoslynCodeLens.Tools;
 [McpServerToolType]
 public static class SearchSymbolsTool
 {
+    private const int DefaultLimit = 200;
+
     [McpServerTool(Name = "search_symbols"),
-     Description("Search for types, methods, properties, and fields by name (case-insensitive substring match, max 50 results)")]
-    public static IReadOnlyList<SymbolLocation> Execute(
+     Description("Search for types, methods, properties, and fields by name (case-insensitive substring match). " +
+                 "Returns an envelope with items sorted by match quality (exact → prefix → substring), " +
+                 "totalCount, truncated, limit (default 200), and a byKind summary.")]
+    public static ToolListResult<SymbolLocation> Execute(
         MultiSolutionManager manager,
-        [Description("Search query (substring match against symbol names)")] string query)
+        [Description("Search query (substring match against symbol names)")] string query,
+        [Description("Maximum number of items to return (default: 200). Items are sorted by match quality.")]
+            int? limit = null)
     {
         manager.EnsureLoaded();
-        return SearchSymbolsLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), query);
+        var raw = SearchSymbolsLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), query);
+
+        var sorted = SortByMatchQuality(query, raw);
+        var summary = BuildSummary(raw);
+        return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
+    }
+
+    internal static IReadOnlyList<SymbolLocation> SortByMatchQuality(string query, IReadOnlyList<SymbolLocation> items)
+        => items
+            .OrderBy(s => MatchRank(SimpleName(s.FullName), query))
+            .ThenBy(s => s.FullName, StringComparer.Ordinal)
+            .ToList();
+
+    private static string SimpleName(string fullName)
+    {
+        var lastDot = fullName.LastIndexOf('.');
+        return lastDot < 0 ? fullName : fullName[(lastDot + 1)..];
+    }
+
+    private static int MatchRank(string name, string query)
+    {
+        if (string.Equals(name, query, StringComparison.OrdinalIgnoreCase)) return 0;
+        if (name.StartsWith(query, StringComparison.OrdinalIgnoreCase)) return 1;
+        return 2;
+    }
+
+    internal static object BuildSummary(IReadOnlyList<SymbolLocation> items)
+    {
+        var byKind = items
+            .GroupBy(s => s.Type, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count(), StringComparer.Ordinal);
+        return new { byKind };
     }
 }

--- a/tests/RoslynCodeLens.Tests/Models/ToolListResultTests.cs
+++ b/tests/RoslynCodeLens.Tests/Models/ToolListResultTests.cs
@@ -1,0 +1,54 @@
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests.Models;
+
+public class ToolListResultTests
+{
+    [Fact]
+    public void Create_EmptyList_ReturnsZeroCountNotTruncated()
+    {
+        var result = ToolListResult.Create<int>(Array.Empty<int>(), limit: 10);
+        Assert.Empty(result.Items);
+        Assert.Equal(0, result.TotalCount);
+        Assert.False(result.Truncated);
+        Assert.Equal(10, result.Limit);
+        Assert.Null(result.Summary);
+    }
+
+    [Fact]
+    public void Create_BelowLimit_NotTruncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3 }, limit: 10);
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(3, result.TotalCount);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public void Create_ExactlyAtLimit_NotTruncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3 }, limit: 3);
+        Assert.Equal(3, result.Items.Count);
+        Assert.Equal(3, result.TotalCount);
+        Assert.False(result.Truncated);
+    }
+
+    [Fact]
+    public void Create_AboveLimit_Truncated()
+    {
+        var result = ToolListResult.Create(new[] { 1, 2, 3, 4, 5 }, limit: 2);
+        Assert.Equal(2, result.Items.Count);
+        Assert.Equal(new[] { 1, 2 }, result.Items);
+        Assert.Equal(5, result.TotalCount);
+        Assert.True(result.Truncated);
+        Assert.Equal(2, result.Limit);
+    }
+
+    [Fact]
+    public void Create_PreservesSummary()
+    {
+        var summary = new { error = 3, warning = 7 };
+        var result = ToolListResult.Create(new[] { 1, 2 }, limit: 10, summary);
+        Assert.Same(summary, result.Summary);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindAttributeUsagesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -65,5 +66,40 @@ public class FindAttributeUsagesToolTests
 
         Assert.NotEmpty(results);
         Assert.Contains(results, r => r.TargetName.Contains("OldGreet", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<AttributeUsageInfo>
+        {
+            new("Obsolete", "method", "X", "b.cs", 1, "P"),
+            new("Obsolete", "method", "X", "a.cs", 9, "P"),
+            new("Obsolete", "method", "X", "a.cs", 2, "P"),
+        };
+
+        var sorted = FindAttributeUsagesTool.Sort(input);
+
+        Assert.Collection(sorted,
+            a => { Assert.Equal("a.cs", a.File); Assert.Equal(2, a.Line); },
+            a => { Assert.Equal("a.cs", a.File); Assert.Equal(9, a.Line); },
+            a => { Assert.Equal("b.cs", a.File); Assert.Equal(1, a.Line); });
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByProject()
+    {
+        var input = new List<AttributeUsageInfo>
+        {
+            new("Obsolete", "method", "X", "a.cs", 1, "Foo"),
+            new("Obsolete", "method", "Y", "a.cs", 2, "Foo"),
+            new("Obsolete", "method", "Z", "b.cs", 1, "Bar"),
+        };
+
+        var summary = FindAttributeUsagesTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"Foo\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"Bar\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -35,5 +36,40 @@ public class FindCallersToolTests
             "Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddScoped");
 
         Assert.NotEmpty(results);
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<CallerInfo>
+        {
+            new("Caller", "b.cs", 1, "x", "P"),
+            new("Caller", "a.cs", 9, "x", "P"),
+            new("Caller", "a.cs", 2, "x", "P"),
+        };
+
+        var sorted = FindCallersTool.Sort(input);
+
+        Assert.Collection(sorted,
+            c => { Assert.Equal("a.cs", c.File); Assert.Equal(2, c.Line); },
+            c => { Assert.Equal("a.cs", c.File); Assert.Equal(9, c.Line); },
+            c => { Assert.Equal("b.cs", c.File); Assert.Equal(1, c.Line); });
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByProject()
+    {
+        var input = new List<CallerInfo>
+        {
+            new("Caller", "a.cs", 1, "x", "Foo"),
+            new("Caller", "a.cs", 2, "x", "Foo"),
+            new("Caller", "b.cs", 1, "x", "Bar"),
+        };
+
+        var summary = FindCallersTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"Foo\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"Bar\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindCircularDependenciesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCircularDependenciesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -28,5 +29,23 @@ public class FindCircularDependenciesToolTests
     {
         var results = FindCircularDependenciesLogic.Execute(_loaded, _resolver, "invalid");
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Sort_OrdersByCycleLengthDesc()
+    {
+        var input = new List<CircularDependency>
+        {
+            new("project", new[] { "A", "B" }),
+            new("project", new[] { "A", "B", "C", "D" }),
+            new("project", new[] { "A", "B", "C" }),
+        };
+
+        var sorted = FindCircularDependenciesTool.Sort(input);
+
+        Assert.Collection(sorted,
+            c => Assert.Equal(4, c.Cycle.Count),
+            c => Assert.Equal(3, c.Cycle.Count),
+            c => Assert.Equal(2, c.Cycle.Count));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindEventSubscribersToolTests.cs
@@ -134,4 +134,22 @@ public class FindEventSubscribersToolTests
             Assert.NotEmpty(r.Project);
         }
     }
+
+    [Fact]
+    public void Sort_OrdersByFilePathThenLine()
+    {
+        var input = new List<EventSubscriberInfo>
+        {
+            new("E", "H", SubscriptionKind.Subscribe, "b.cs", 1, "x", "P", false),
+            new("E", "H", SubscriptionKind.Subscribe, "a.cs", 9, "x", "P", false),
+            new("E", "H", SubscriptionKind.Subscribe, "a.cs", 2, "x", "P", false),
+        };
+
+        var sorted = FindEventSubscribersTool.Sort(input);
+
+        Assert.Collection(sorted,
+            e => { Assert.Equal("a.cs", e.FilePath); Assert.Equal(2, e.Line); },
+            e => { Assert.Equal("a.cs", e.FilePath); Assert.Equal(9, e.Line); },
+            e => { Assert.Equal("b.cs", e.FilePath); Assert.Equal(1, e.Line); });
+    }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -43,5 +44,23 @@ public class FindImplementationsToolTests
             _loaded, _resolver, _metadata, "System.IDisposable");
 
         Assert.Contains(results, r => r.FullName.EndsWith("Greeter", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<SymbolLocation>
+        {
+            new("class", "B", "b.cs", 1, "P"),
+            new("class", "A2", "a.cs", 9, "P"),
+            new("class", "A1", "a.cs", 2, "P"),
+        };
+
+        var sorted = FindImplementationsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            s => { Assert.Equal("a.cs", s.File); Assert.Equal(2, s.Line); },
+            s => { Assert.Equal("a.cs", s.File); Assert.Equal(9, s.Line); },
+            s => { Assert.Equal("b.cs", s.File); Assert.Equal(1, s.Line); });
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindLargeClassesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindLargeClassesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -35,5 +36,23 @@ public class FindLargeClassesToolTests
     {
         var results = FindLargeClassesLogic.Execute(_loaded, _resolver, "TestLib2", 1, 1);
         Assert.All(results, r => Assert.Equal("TestLib2", r.Project));
+    }
+
+    [Fact]
+    public void Sort_OrdersBySizeDesc()
+    {
+        var input = new List<LargeClassInfo>
+        {
+            new("Small", 5,   50,   "a.cs", 1, "P"),
+            new("Huge",  100, 1000, "b.cs", 1, "P"),
+            new("Mid",   30,  300,  "c.cs", 1, "P"),
+        };
+
+        var sorted = FindLargeClassesTool.Sort(input);
+
+        Assert.Collection(sorted,
+            c => Assert.Equal("Huge", c.TypeName),
+            c => Assert.Equal("Mid", c.TypeName),
+            c => Assert.Equal("Small", c.TypeName));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindNamingViolationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindNamingViolationsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -28,5 +29,40 @@ public class FindNamingViolationsToolTests
     {
         var filtered = FindNamingViolationsLogic.Execute(_loaded, _resolver, "TestLib");
         Assert.All(filtered, r => Assert.Contains("TestLib", r.Project, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sort_OrdersByRuleThenFile()
+    {
+        var input = new List<NamingViolation>
+        {
+            new("x", "Field", "RuleB", "fix",  "a.cs", 1, "P"),
+            new("y", "Class", "RuleA", "fix",  "b.cs", 1, "P"),
+            new("z", "Class", "RuleA", "fix",  "a.cs", 9, "P"),
+        };
+
+        var sorted = FindNamingViolationsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            n => { Assert.Equal("RuleA", n.Rule); Assert.Equal("a.cs", n.File); },
+            n => { Assert.Equal("RuleA", n.Rule); Assert.Equal("b.cs", n.File); },
+            n => Assert.Equal("RuleB", n.Rule));
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByRule()
+    {
+        var input = new List<NamingViolation>
+        {
+            new("x", "Class", "PascalCase", "fix", "a.cs", 1, "P"),
+            new("y", "Class", "PascalCase", "fix", "a.cs", 2, "P"),
+            new("z", "Field", "underscorePrefix", "fix", "b.cs", 1, "P"),
+        };
+
+        var summary = FindNamingViolationsTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"PascalCase\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"underscorePrefix\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -54,5 +55,40 @@ public class FindReferencesToolTests
 
         Assert.NotEmpty(results);
         Assert.All(results, r => Assert.True(!string.IsNullOrEmpty(r.File)));
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<SymbolReference>
+        {
+            new("Read", "b.cs", 1, "x", "P"),
+            new("Read", "a.cs", 9, "x", "P"),
+            new("Read", "a.cs", 2, "x", "P"),
+        };
+
+        var sorted = FindReferencesTool.Sort(input);
+
+        Assert.Collection(sorted,
+            r => { Assert.Equal("a.cs", r.File); Assert.Equal(2, r.Line); },
+            r => { Assert.Equal("a.cs", r.File); Assert.Equal(9, r.Line); },
+            r => { Assert.Equal("b.cs", r.File); Assert.Equal(1, r.Line); });
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByProject()
+    {
+        var input = new List<SymbolReference>
+        {
+            new("Read", "a.cs", 1, "x", "Foo"),
+            new("Read", "a.cs", 2, "x", "Foo"),
+            new("Read", "b.cs", 1, "x", "Bar"),
+        };
+
+        var summary = FindReferencesTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"Foo\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"Bar\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindReflectionUsageToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReflectionUsageToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -31,5 +32,40 @@ public class FindReflectionUsageToolTests
         var results = FindReflectionUsageLogic.Execute(_loaded, _resolver, null);
 
         Assert.Contains(results, r => r.Snippet.Contains("Type.GetType", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<ReflectionUsage>
+        {
+            new("method_invoke", "X", "b.cs", 1, "x"),
+            new("method_invoke", "X", "a.cs", 9, "x"),
+            new("method_invoke", "X", "a.cs", 2, "x"),
+        };
+
+        var sorted = FindReflectionUsageTool.Sort(input);
+
+        Assert.Collection(sorted,
+            r => { Assert.Equal("a.cs", r.File); Assert.Equal(2, r.Line); },
+            r => { Assert.Equal("a.cs", r.File); Assert.Equal(9, r.Line); },
+            r => { Assert.Equal("b.cs", r.File); Assert.Equal(1, r.Line); });
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByKind()
+    {
+        var input = new List<ReflectionUsage>
+        {
+            new("method_invoke",         "X", "a.cs", 1, "x"),
+            new("method_invoke",         "Y", "a.cs", 2, "x"),
+            new("dynamic_instantiation", "Z", "b.cs", 1, "x"),
+        };
+
+        var summary = FindReflectionUsageTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"method_invoke\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"dynamic_instantiation\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -28,5 +29,40 @@ public class FindUnusedSymbolsToolTests
     {
         var results = FindUnusedSymbolsLogic.Execute(_loaded, _resolver, "TestLib", false);
         Assert.All(results, r => Assert.Contains("TestLib", r.Project, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Sort_OrdersByProjectThenFile()
+    {
+        var input = new List<UnusedSymbolInfo>
+        {
+            new("X", "Class",  "z.cs", 1, "Bar"),
+            new("X", "Class",  "b.cs", 1, "Foo"),
+            new("X", "Method", "a.cs", 9, "Foo"),
+        };
+
+        var sorted = FindUnusedSymbolsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            u => Assert.Equal("Bar", u.Project),
+            u => { Assert.Equal("Foo", u.Project); Assert.Equal("a.cs", u.File); },
+            u => { Assert.Equal("Foo", u.Project); Assert.Equal("b.cs", u.File); });
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByKind()
+    {
+        var input = new List<UnusedSymbolInfo>
+        {
+            new("X", "Class",  "a.cs", 1, "P"),
+            new("Y", "Class",  "a.cs", 2, "P"),
+            new("Z", "Method", "a.cs", 3, "P"),
+        };
+
+        var summary = FindUnusedSymbolsTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"Class\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"Method\":1", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetComplexityMetricsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetComplexityMetricsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -36,5 +37,51 @@ public class GetComplexityMetricsToolTests
         _ = GetComplexityMetricsLogic.Execute(_loaded, _resolver, null, 0);
         var filtered = GetComplexityMetricsLogic.Execute(_loaded, _resolver, "TestLib2", 0);
         Assert.All(filtered, r => Assert.Equal("TestLib2", r.Project));
+    }
+
+    [Fact]
+    public void Sort_OrdersByComplexityDesc()
+    {
+        var input = new List<ComplexityMetric>
+        {
+            new("low",  "T", 3,  "a.cs", 1, "P"),
+            new("high", "T", 20, "b.cs", 1, "P"),
+            new("mid",  "T", 10, "c.cs", 1, "P"),
+        };
+
+        var sorted = GetComplexityMetricsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            m => Assert.Equal("high", m.MethodName),
+            m => Assert.Equal("mid",  m.MethodName),
+            m => Assert.Equal("low",  m.MethodName));
+    }
+
+    [Fact]
+    public void BuildSummary_ReportsMaxAvgOverThreshold()
+    {
+        var input = new List<ComplexityMetric>
+        {
+            new("a", "T", 5,  "a.cs", 1, "P"),
+            new("b", "T", 15, "a.cs", 2, "P"),
+            new("c", "T", 25, "a.cs", 3, "P"),
+        };
+
+        var summary = GetComplexityMetricsTool.BuildSummary(input, threshold: 10);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"max\":25", json, StringComparison.Ordinal);
+        Assert.Contains("\"avg\":15", json, StringComparison.Ordinal);
+        Assert.Contains("\"overThreshold\":2", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSummary_EmptyList_ReturnsZeros()
+    {
+        var summary = GetComplexityMetricsTool.BuildSummary(Array.Empty<ComplexityMetric>(), threshold: 10);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"max\":0", json, StringComparison.Ordinal);
+        Assert.Contains("\"overThreshold\":0", json, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiRegistrationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiRegistrationsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -24,5 +25,23 @@ public class GetDiRegistrationsToolTests
         Assert.Single(results);
         Assert.Equal("Scoped", results[0].Lifetime);
         Assert.Contains("Greeter", results[0].Implementation, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sort_OrdersByServiceName()
+    {
+        var input = new List<DiRegistration>
+        {
+            new("ZService", "Z", "Scoped",  "a.cs", 1),
+            new("AService", "A", "Scoped",  "b.cs", 1),
+            new("MService", "M", "Scoped",  "c.cs", 1),
+        };
+
+        var sorted = GetDiRegistrationsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            d => Assert.Equal("AService", d.Service),
+            d => Assert.Equal("MService", d.Service),
+            d => Assert.Equal("ZService", d.Service));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
@@ -145,6 +145,86 @@ public class GetDiagnosticsToolTests
         Assert.Equal(false, param.DefaultValue);
     }
 
+    [Fact]
+    public void GetDiagnosticsTool_Limit_DefaultsToNull()
+    {
+        var method = typeof(GetDiagnosticsTool).GetMethod(nameof(GetDiagnosticsTool.Execute))!;
+        var param = method.GetParameters().Single(p => p.Name == "limit");
+        Assert.True(param.HasDefaultValue);
+        Assert.Null(param.DefaultValue);
+    }
+
+    [Fact]
+    public void SortBySeverityFileLine_OrdersErrorsBeforeWarningsBeforeInfo()
+    {
+        var input = new List<DiagnosticInfo>
+        {
+            new("CS0001", "Info",    "i", "a.cs", 1, "P"),
+            new("CS0002", "Warning", "w", "a.cs", 1, "P"),
+            new("CS0003", "Error",   "e", "a.cs", 1, "P"),
+        };
+
+        var sorted = GetDiagnosticsTool.SortBySeverityFileLine(input);
+
+        Assert.Collection(sorted,
+            d => Assert.Equal("Error", d.Severity),
+            d => Assert.Equal("Warning", d.Severity),
+            d => Assert.Equal("Info", d.Severity));
+    }
+
+    [Fact]
+    public void SortBySeverityFileLine_TieBreaksByFileThenLine()
+    {
+        var input = new List<DiagnosticInfo>
+        {
+            new("CS", "Error", "x", "b.cs", 5, "P"),
+            new("CS", "Error", "x", "a.cs", 9, "P"),
+            new("CS", "Error", "x", "a.cs", 2, "P"),
+        };
+
+        var sorted = GetDiagnosticsTool.SortBySeverityFileLine(input);
+
+        Assert.Collection(sorted,
+            d => { Assert.Equal("a.cs", d.File); Assert.Equal(2, d.Line); },
+            d => { Assert.Equal("a.cs", d.File); Assert.Equal(9, d.Line); },
+            d => { Assert.Equal("b.cs", d.File); Assert.Equal(5, d.Line); });
+    }
+
+    [Fact]
+    public void BuildSummary_CountsBySeverity()
+    {
+        var input = new List<DiagnosticInfo>
+        {
+            new("CS1", "Error",   "e", "a.cs", 1, "P"),
+            new("CS2", "Error",   "e", "a.cs", 2, "P"),
+            new("CS3", "Warning", "w", "a.cs", 3, "P"),
+            new("CS4", "Info",    "i", "a.cs", 4, "P"),
+            new("CS5", "Info",    "i", "a.cs", 5, "P"),
+            new("CS6", "Info",    "i", "a.cs", 6, "P"),
+            new("CS7", "Hidden",  "h", "a.cs", 7, "P"),
+        };
+
+        var summary = GetDiagnosticsTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"error\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"warning\":1", json, StringComparison.Ordinal);
+        Assert.Contains("\"info\":3", json, StringComparison.Ordinal);
+        Assert.Contains("\"hidden\":1", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildSummary_EmptyList_ReturnsAllZeros()
+    {
+        var summary = GetDiagnosticsTool.BuildSummary(Array.Empty<DiagnosticInfo>());
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"error\":0", json, StringComparison.Ordinal);
+        Assert.Contains("\"warning\":0", json, StringComparison.Ordinal);
+        Assert.Contains("\"info\":0", json, StringComparison.Ordinal);
+        Assert.Contains("\"hidden\":0", json, StringComparison.Ordinal);
+    }
+
     private sealed class TempTrustFile : IDisposable
     {
         public string Path { get; }

--- a/tests/RoslynCodeLens.Tests/Tools/GetGeneratedCodeToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetGeneratedCodeToolTests.cs
@@ -1,3 +1,4 @@
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -27,5 +28,23 @@ public class GetGeneratedCodeToolTests
     {
         var results = GetGeneratedCodeLogic.Execute(_loaded, _resolver, "NonExistentGenerator", null);
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Sort_OrdersByProjectThenFilePath()
+    {
+        var input = new List<GeneratedFileInfo>
+        {
+            new("z.g.cs", "Bar", null, Array.Empty<string>(), ""),
+            new("b.g.cs", "Foo", null, Array.Empty<string>(), ""),
+            new("a.g.cs", "Foo", null, Array.Empty<string>(), ""),
+        };
+
+        var sorted = GetGeneratedCodeTool.Sort(input);
+
+        Assert.Collection(sorted,
+            g => Assert.Equal("Bar", g.Project),
+            g => { Assert.Equal("Foo", g.Project); Assert.Equal("a.g.cs", g.FilePath); },
+            g => { Assert.Equal("Foo", g.Project); Assert.Equal("b.g.cs", g.FilePath); });
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
@@ -1,3 +1,4 @@
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -29,5 +30,23 @@ public class GetSourceGeneratorsToolTests
         var results = GetSourceGeneratorsLogic.Execute(_loaded, _resolver, projectName);
         Assert.NotNull(results);
         Assert.All(results, r => Assert.Equal(projectName, r.Project));
+    }
+
+    [Fact]
+    public void Sort_OrdersByProjectThenGeneratorName()
+    {
+        var input = new List<SourceGeneratorInfo>
+        {
+            new("ZGen", "Foo", 0, Array.Empty<string>()),
+            new("AGen", "Foo", 0, Array.Empty<string>()),
+            new("MGen", "Bar", 0, Array.Empty<string>()),
+        };
+
+        var sorted = GetSourceGeneratorsTool.Sort(input);
+
+        Assert.Collection(sorted,
+            s => { Assert.Equal("Bar", s.Project); Assert.Equal("MGen", s.GeneratorName); },
+            s => { Assert.Equal("Foo", s.Project); Assert.Equal("AGen", s.GeneratorName); },
+            s => { Assert.Equal("Foo", s.Project); Assert.Equal("ZGen", s.GeneratorName); });
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GoToDefinitionToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -68,5 +69,23 @@ public class GoToDefinitionToolTests
         Assert.Equal("metadata", single.Origin!.Kind);
         Assert.Equal("", single.File);
         Assert.Equal(0, single.Line);
+    }
+
+    [Fact]
+    public void Sort_OrdersByFileThenLine()
+    {
+        var input = new List<SymbolLocation>
+        {
+            new("class", "B", "b.cs", 1, "P"),
+            new("class", "A2", "a.cs", 9, "P"),
+            new("class", "A1", "a.cs", 2, "P"),
+        };
+
+        var sorted = GoToDefinitionTool.Sort(input);
+
+        Assert.Collection(sorted,
+            s => { Assert.Equal("a.cs", s.File); Assert.Equal(2, s.Line); },
+            s => { Assert.Equal("a.cs", s.File); Assert.Equal(9, s.Line); },
+            s => { Assert.Equal("b.cs", s.File); Assert.Equal(1, s.Line); });
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/SearchSymbolsToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -61,5 +62,40 @@ public class SearchSymbolsToolTests
             results,
             r => string.Equals(r.Origin?.Kind, "metadata", StringComparison.Ordinal)
               && string.Equals(r.FullName, "Microsoft.Extensions.DependencyInjection.IServiceCollection", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SortByMatchQuality_ExactBeforePrefixBeforeSubstring()
+    {
+        var input = new List<SymbolLocation>
+        {
+            new("class", "Foo.MyBarBaz", "x.cs", 1, "P"),    // substring
+            new("class", "Foo.Bar",      "x.cs", 1, "P"),    // exact
+            new("class", "Foo.BarHelper","x.cs", 1, "P"),    // prefix
+        };
+
+        var sorted = SearchSymbolsTool.SortByMatchQuality("Bar", input);
+
+        Assert.Collection(sorted,
+            s => Assert.Equal("Foo.Bar", s.FullName),
+            s => Assert.Equal("Foo.BarHelper", s.FullName),
+            s => Assert.Equal("Foo.MyBarBaz", s.FullName));
+    }
+
+    [Fact]
+    public void BuildSummary_GroupsByKind()
+    {
+        var input = new List<SymbolLocation>
+        {
+            new("class",  "A", "x.cs", 1, "P"),
+            new("class",  "B", "x.cs", 2, "P"),
+            new("method", "C", "x.cs", 3, "P"),
+        };
+
+        var summary = SearchSymbolsTool.BuildSummary(input);
+        var json = System.Text.Json.JsonSerializer.Serialize(summary);
+
+        Assert.Contains("\"class\":2", json, StringComparison.Ordinal);
+        Assert.Contains("\"method\":1", json, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

Wraps every list-returning MCP tool in a uniform envelope:

```json
{ "items": [...], "totalCount": N, "truncated": bool, "limit": N, "summary": {...} }
```

Pattern adapted from `jkolo/debug-mcp` (reimplemented; their license is AGPL-3.0).

**Motivation:** Bound any single tool's response size by default so a runaway result set (10k+ diagnostics, find_references across a large solution, etc.) can't blow Claude's context. Surface aggregate signal up-front (severity counts, by-project breakdowns) so the model can decide whether to drill into items.

**Tools converted (21):** get_diagnostics · find_references · find_callers · find_implementations · search_symbols · go_to_definition · find_attribute_usages · find_event_subscribers · find_reflection_usage · find_unused_symbols · find_naming_violations · find_large_classes · find_circular_dependencies · get_complexity_metrics · get_di_registrations · get_generated_code · get_source_generators · list_solutions · get_code_actions · get_code_fixes (last two caught by Task 20 audit; not in original plan table)

**Each tool got:**
- Per-tool default limit tuned to typical result size
- Defined sort order (severity-first / worst-first / by-file / by-match-quality / etc.) — truncated top-N now means something useful
- Optional `summary` aggregate where it makes sense (diagnostics by severity, find_references by project, complexity max/avg/overThreshold, etc.)
- Optional `limit` parameter on every tool

**Logic layer untouched** — `*Logic.cs` files still return pure `IReadOnlyList<T>`. Envelope is built in `*Tool.cs` wrapper. Sort/summary helpers are `internal static` and unit-tested directly with manufactured data.

## Breaking change

Every list-tool's MCP response shape changed (raw `[...]` → `{ items, totalCount, ... }`). Acceptable because pre-1.0 and Claude is the only consumer; SKILL.md updated with a "Response shape" section explaining the envelope.

## Documents

- Design: `docs/plans/2026-05-21-list-tool-envelope-design.md`
- Implementation plan: `docs/plans/2026-05-21-list-tool-envelope.md`

## Test plan

- [ ] CI build passes on Linux + macOS + Windows (locally clean, 0 errors, 220 warnings all pre-existing)
- [ ] Full test suite green on CI (locally 439/439 non-flaky tests pass; 16 failures locally are the documented `IsAdapterRestoreFlake` NUnit/MSTest/XUnit fixture package-restore issue — same root cause already filtered in `GetDiagnosticsToolTests`)
- [ ] After merge: smoke-test via `.mcp.json` server — call `get_diagnostics`, `find_references`, `get_complexity_metrics`, verify envelope shape in real client

🤖 Generated with [Claude Code](https://claude.com/claude-code)