### PR TITLE
test: disable parallel test execution to stabilize MSBuildWorkspace tests

### DIFF
--- a/tests/RoslynCodeLens.Tests/AssemblyInfo.cs
+++ b/tests/RoslynCodeLens.Tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// xunit.runner.json sets parallelizeTestCollections=false, but this attribute
+// codifies the intent in source and forces strict no-parallel at the xUnit
+// attribute level. The *ToolTests classes share a TestSolutionFixture that wraps
+// an MSBuildWorkspace; intermittent FindReferences/FindCallers/FindImplementations
+// failures on cold CI runners cluster on cross-project symbol lookups (metadata
+// references whose first resolution races test-time queries). Running fully serial
+// matches the EventSourcing.Telemetry.Tests fix that's been stable for weeks.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Problem

The `*ToolTests` family (`FindReferencesToolTests`, `FindCallersToolTests`, `FindImplementationsToolTests`, `FindAttributeUsagesToolTests`) flakes intermittently on cold CI runners. Failures cluster on cross-project / metadata symbol lookups — e.g., `FindReferences_ForInterface_ReturnsUsages`, `FindImplementations_MetadataInterface_FindsSourceImplementors`.

All affected tests share a single `TestSolutionFixture` via `[Collection("TestSolution")]`. The fixture loads an `MSBuildWorkspace` once. The flake pattern (asserting non-empty results, sometimes failing) matches a known Roslyn race: metadata reference resolution is lazy on first symbol lookup, and on cold CI runners the first resolution can race against the test-time query.

## Fix

Add `[assembly: CollectionBehavior(DisableTestParallelization = true)]` to `tests/RoslynCodeLens.Tests/AssemblyInfo.cs`.

`xunit.runner.json` already has `"parallelizeTestCollections": false`, but the attribute is the canonical xUnit way to declare "no parallelism in this assembly". Belt-and-suspenders, and it matches the [EventSourcing.Telemetry.Tests fix](https://github.com/ZeroAlloc-Net/ZeroAlloc.EventSourcing/pull/132) that's been stable for weeks.

## What this does NOT fix

If the underlying cause is a Roslyn workspace caching race rather than test-level parallelism, this won't be enough on its own. In that case, the next step would be to warm up the fixture by pre-resolving the canonical test symbols (`IGreeter`, `Greeter`, etc.) right after `LoadAsync` so test-time lookups don't hit the first-resolution path. That's a follow-up if we still see flakes after this lands.
