### PR TITLE
docs: catch up README/SKILL/features after envelope + filter changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **find_disposable_misuse** — `IDisposable`/`IAsyncDisposable` instances not wrapped in `using`/`await using`/returned/assigned to field; severity error/warning per violation.
 - **find_large_classes** — Find oversized types by member or line count
 - **find_god_objects** — Types combining high size with high cross-namespace coupling; sharper signal than raw size for SRP violations
-- **find_unused_symbols** — Dead code detection via reference analysis
+- **find_unused_symbols** — Dead code detection via reference analysis. Auto-filters test methods (xUnit/NUnit/MSTest), MCP tool entry points, source-generator output, MEF-composed services, and interop-laid-out fields; filter counts surface in `summary.filteredOut`
 - **get_project_health** — Composite audit aggregating 7 quality dimensions per project (complexity, large classes, naming, unused symbols, reflection, async violations, disposable misuse) with counts and top-N hotspots inline
 - **get_source_generators** — List source generators and their output per project
 - **get_generated_code** — Inspect generated source code from source generators
@@ -65,6 +65,9 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **load_solution** — Load an additional .sln/.slnx at runtime and make it the active solution
 - **unload_solution** — Unload a loaded solution to free memory
 - **rebuild_solution** — Force a full reload of the analyzed solution
+- **trust_solution** — Authorize a solution to run Roslyn analyzers (required before `get_diagnostics` with `includeAnalyzers: true`)
+- **list_trusted_paths** — Inspect the persistent trust store + session-trusted solutions
+- **revoke_trust** — Revoke a previously-granted trust for a solution path
 - **analyze_data_flow** — Variable read/write/capture analysis within a statement range (declared, read, written, always assigned, captured, flows in/out)
 - **analyze_control_flow** — Branch/loop reachability analysis within a statement range (start/end reachability, return statements, exit points)
 - **analyze_change_impact** — Show all files, projects, and call sites affected by changing a symbol — combines find_references and find_callers
@@ -74,6 +77,33 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **get_operators** — Every user-defined operator and conversion operator on a type (source + metadata) with kind, signature, parameters, and source location. Includes synthesized record equality and .NET 7+ checked variants
 - **get_call_graph** — Transitive caller/callee graph for a method, depth-bounded with cycle detection
 - **get_file_overview** — Compound tool: types defined in a file + file-scoped diagnostics in one call
+
+## Response shape
+
+All list-returning tools wrap their results in a uniform envelope:
+
+```json
+{
+  "items": [ ... ],
+  "totalCount": 142,
+  "truncated": false,
+  "limit": 500,
+  "summary": { ... }
+}
+```
+
+When `truncated` is `true`, the items are the **top N by the tool's natural sort order** (severity-first, worst-first, by-project, etc.) — usually that's exactly what you want. Raise `limit` only if the missing tail items matter for the task.
+
+Tools that include a `summary` aggregate today:
+
+- `get_diagnostics` — `{ error, warning, info, hidden }` counts
+- `find_references`, `find_callers`, `find_attribute_usages` — `{ byProject: { name: count } }`
+- `search_symbols`, `find_reflection_usage` — `{ byKind: {...} }`
+- `find_unused_symbols` — `{ byKind, filteredOut: { testMethod, testContainer, mcpTool, generated, composition, interop } }`
+- `find_naming_violations` — `{ byRule: {...} }`
+- `get_complexity_metrics` — `{ max, avg, overThreshold }`
+
+Single-object tools (`get_type_overview`, `get_symbol_context`, `apply_code_action`, etc.) return their bespoke shape directly — the envelope only wraps list-returning tools.
 
 ## External Assemblies
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,7 @@
 
 | Dimension | sharplens-mcp | roslyn-codelens-mcp |
 |-----------|---------------|----------------------|
-| Tools | ~58 | 36 |
+| Tools | ~58 | 54 |
 | Architecture | Monolithic `RoslynService.cs` (~5 000 lines) | Modular Tool + Logic split per feature |
 | API paradigm | Position-based `(filePath, line, col)` | Symbol-name-based (`"IGreeter.Greet"`) |
 | Refactoring | 13 dedicated write/mutate tools | `get_code_actions` + `apply_code_action` (generic engine) |

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -40,3 +40,13 @@ Then add to your `.mcp.json`:
 ```
 
 See [Installation](getting-started/installation) for full setup details.
+
+## Working with results
+
+List-returning tools (everything that produces "all X" or "every Y") cap their items at a per-tool default and wrap them in an envelope:
+
+```json
+{ "items": [ ... ], "totalCount": 142, "truncated": false, "limit": 500, "summary": { ... } }
+```
+
+If `truncated` is `true`, `items` is the top N by the tool's natural sort order (errors first, worst-first, most-relevant-first). Raise `limit` only if the tail matters for what you're doing — usually it won't.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -381,8 +381,27 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_di_registrations` | No — source only | | |
 | `get_nuget_dependencies` | Partial — lists referenced packages, not assemblies directly | Use `inspect_external_assembly` for assembly API | |
 | `find_reflection_usage` | No — source only | | |
+| `find_async_violations` | No — source only | | |
+| `find_disposable_misuse` | No — source only | | |
+| `find_obsolete_usage` | No — source only — but `[Obsolete]` source/metadata attribute type both detected | | |
+| `find_god_objects` | No — source only | | |
+| `find_breaking_changes` | Partial — current side is source; baseline can be a `.dll` from metadata | | |
+| `find_event_subscribers` | Yes — accepts metadata event symbols (e.g. `System.Diagnostics.Process.Exited`); reports source `+=`/`-=` sites | | |
+| `find_tests_for_symbol` | No — production symbol must be source (test methods are source too) | | |
+| `find_uncovered_symbols` | No — source only | | |
+| `generate_test_skeleton` | No — source only | | |
+| `get_call_graph` | No — source only | | |
+| `get_overloads` | Yes — source + metadata overloads, full parameter detail | | |
+| `get_operators` | Yes — source + metadata operators and conversions | | |
+| `get_project_dependencies` | N/A — project-level graph | | |
+| `get_project_health` | No — source only | | |
+| `get_public_api_surface` | No — source only (production projects) | | Use `inspect_external_assembly` for external assembly surfaces |
+| `get_test_summary` | No — source only (test projects) | | |
 | `list_solutions` | N/A | | |
 | `set_active_solution` | N/A | | |
 | `load_solution` | N/A | | |
 | `unload_solution` | N/A | | |
 | `rebuild_solution` | N/A | | |
+| `trust_solution` | N/A — security/lifecycle | | |
+| `list_trusted_paths` | N/A — security/lifecycle | | |
+| `revoke_trust` | N/A — security/lifecycle | | |


### PR DESCRIPTION
## Summary

Documentation has drifted since PR #189 (uniform list-tool envelope) and PR #191 (dead-code filters). This catches it up:

- **README.md** — adds a Response shape section explaining the envelope; expands the `find_unused_symbols` bullet to mention auto-filtering; adds the three trust tools (`trust_solution`, `list_trusted_paths`, `revoke_trust`) to the Features list.
- **plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md** — extends the Metadata Support table with 18 tools that were missing from it (find_async_violations, find_disposable_misuse, find_obsolete_usage, find_god_objects, find_breaking_changes, find_event_subscribers, find_tests_for_symbol, find_uncovered_symbols, generate_test_skeleton, get_call_graph, get_overloads, get_operators, get_project_dependencies, get_project_health, get_public_api_surface, get_test_summary, trust_solution, list_trusted_paths, revoke_trust).
- **docs/features.md** — stale tool-count line: 36 → 54.
- **docs/site/docs/index.md** — short "Working with results" callout on envelope truncation behavior.

No code changes, no schema changes. Pure documentation.

## Test plan

- [ ] CI green
- [ ] Visual diff against rendered Docusaurus site (overview page gains one new section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)