### PR TITLE
feat(errors)!: structured tool errors + cancellation pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ Tools that include a `summary` aggregate today:
 
 Single-object tools (`get_type_overview`, `get_symbol_context`, `apply_code_action`, etc.) return their bespoke shape directly — the envelope only wraps list-returning tools.
 
+## Error responses
+
+When a tool can't proceed (symbol not resolved, solution not trusted, file not found, ambiguous match, etc.), the response is an `isError: true` content block carrying a structured JSON body:
+
+```json
+{
+  "code": "SolutionNotTrusted",
+  "message": "Solution 'Foo.sln' is not trusted for analyzer execution. ...",
+  "details": { "solutionPath": "C:\\Foo.sln" }
+}
+```
+
+Error codes (switch on `code` to handle each):
+
+- `SymbolNotFound` — type / method / property could not be resolved.
+- `SolutionNotTrusted` — `get_diagnostics` or `get_code_fixes` requested analyzers but the solution hasn't been authorized via `trust_solution`.
+- `AmbiguousMatch` — `set_active_solution` / `unload_solution` matched multiple solutions; `details.matches` lists them.
+- `FileNotFound` — file path or baseline doesn't exist (or isn't in any loaded project).
+- `ProjectNotFound` — solution name didn't match any loaded solution.
+- `InvalidArgument` — caller-supplied input was malformed, unsupported, or out of range.
+- `Internal` — unexpected error not modeled above; `message` carries the underlying exception text.
+
+**Cancellation:** the MCP framework's native cancellation is honored. Cancelling a `tools/call` request mid-flight terminates the operation; long-running tools (`get_diagnostics` with analyzers, `get_code_actions`, `apply_code_action`, `get_code_fixes`) check the token at hot-loop boundaries.
+
 ## External Assemblies
 
 Metadata-origin symbols (from NuGet packages and referenced assemblies) are first-class citizens:

--- a/docs/plans/2026-05-26-structured-tool-errors-design.md
+++ b/docs/plans/2026-05-26-structured-tool-errors-design.md
@@ -1,0 +1,154 @@
+# Structured Tool Errors + Cancellation Pass-Through — Design
+
+**Date:** 2026-05-26
+**Status:** Approved, ready for implementation plan
+
+**Motivation:** Two related defects in the MCP server's contract with LLM consumers:
+
+1. **Error shape is inconsistent.** Some tools throw (`LoadSolution`, `SetActiveSolution`, the analyzer-trust path in `GetDiagnostics`), some return bespoke `Success: bool` types (`apply_code_action`, `find_async_violations`), some return nullable (`analyze_method`, `get_type_overview`). When an LLM hits an error, it has no predictable `code` to switch on — it's parsing exception messages or remembering per-tool conventions.
+
+2. **Cancellation is half-wired.** The MCP framework injects `CancellationToken` into async tool signatures, but only 8 of ~24 async Logic implementations thread it through to Roslyn. Long-running calls (`find_references`, `find_unused_symbols`, `get_diagnostics --includeAnalyzers`) can't be cancelled mid-flight.
+
+## Goals
+
+- Give LLM consumers a **prescribed error-code enum** so they can switch on `error.code` instead of parsing free-form messages.
+- Make every async tool **actually honor** the `CancellationToken` it already accepts.
+- Keep the change minimal: don't churn the success path of any tool that already works.
+
+## Non-goals
+
+- No `ToolResult<T>` universal envelope. The existing `Success: bool` result types (`CodeActionResult`, `FindAsyncViolationsResult`, etc.) stay — they encode tool-specific "ran but reports failure" semantics that don't fit a generic error envelope.
+- No `CancellationToken` parameter on sync tools. They can't be cancelled mid-computation without thread interrupts; adding the param would be performative.
+- No retry / backoff policies. That's client-side concern.
+- No converting `OperationCanceledException` to a structured error. MCP has well-defined cancellation semantics; let the framework handle it.
+
+## Architecture
+
+### Two new types
+
+```csharp
+// src/RoslynCodeLens/Models/ToolErrorCode.cs
+namespace RoslynCodeLens.Models;
+
+public enum ToolErrorCode
+{
+    SymbolNotFound,
+    SolutionNotTrusted,
+    AmbiguousMatch,
+    FileNotFound,
+    ProjectNotFound,
+    InvalidArgument,
+    Internal,
+}
+```
+
+```csharp
+// src/RoslynCodeLens/McpToolException.cs
+namespace RoslynCodeLens;
+
+public sealed class McpToolException : Exception
+{
+    public ToolErrorCode Code { get; }
+    public object? Details { get; }
+
+    public McpToolException(ToolErrorCode code, string message, object? details = null)
+        : base(message)
+    {
+        Code = code;
+        Details = details;
+    }
+}
+```
+
+### Exception filter in the host
+
+`Program.cs` registers an exception-to-content filter on the MCP server host. When a tool invocation throws:
+
+- `McpToolException` → emit `{ isError: true, content: [{ type: "text", text: <JSON{code,message,details}> }] }`
+- `OperationCanceledException` → propagate unchanged (framework handles cancellation natively)
+- Any other `Exception` → emit `{ isError: true, content: [{ type: "text", text: <JSON{code:"Internal", message: ex.Message}> }] }`
+
+The filter is a single integration point — no per-tool changes for surfacing. JSON serialization uses `System.Text.Json` with camelCase naming, matching the existing envelope shape.
+
+### Cancellation flow
+
+No tool signatures change. The MCP framework already injects `CancellationToken` into async `Execute(...)` methods that declare it. The work is auditing the **Logic layer**:
+
+- Every async `ExecuteAsync` must take `CancellationToken` as its final parameter and pass it to every awaited Roslyn call.
+- Hot loops (per-project, per-syntax-tree, per-analyzer) get `ct.ThrowIfCancellationRequested()` at the top of the iteration body.
+- Sync tools that wrap async via `.GetAwaiter().GetResult()` stay sync; cancellation doesn't apply.
+
+### What changes per tool
+
+**Group A — Convert existing throws to `McpToolException`:**
+
+| Tool / Logic | Today | New |
+|---|---|---|
+| `LoadSolution` | `throw new InvalidOperationException("file not found")` | `McpToolException(FileNotFound, ..., { path })` |
+| `SetActiveSolution` (ambiguous) | `throw new InvalidOperationException("ambiguous")` | `McpToolException(AmbiguousMatch, ..., { matches: [...] })` |
+| `SetActiveSolution` (no match) | throw | `McpToolException(ProjectNotFound, ...)` |
+| `UnloadSolution` (no match) | throw | `McpToolException(ProjectNotFound, ...)` |
+| `GetDiagnosticsLogic` (untrusted+analyzers) | `throw new InvalidOperationException("not trusted")` | `McpToolException(SolutionNotTrusted, ..., { solutionPath })` |
+| `GetCodeFixesLogic` (untrusted+analyzers) | same | same |
+| `MultiSolutionManager.EnsureLoaded` (no solution) | `throw new InvalidOperationException` | `McpToolException(InvalidArgument, "no solution loaded")` |
+
+**Group B — Replace nullable-as-error with `McpToolException`:**
+
+| Tool | Today | New |
+|---|---|---|
+| `analyze_method` | returns `MethodAnalysis?` (null = not found) | throws `SymbolNotFound`; non-nullable return |
+| `get_type_overview` | returns `TypeOverview?` | throws `SymbolNotFound` |
+| `get_type_hierarchy` | returns `TypeHierarchy?` | throws `SymbolNotFound` |
+| `get_symbol_context` | returns `SymbolContext?` | throws `SymbolNotFound` |
+| `get_file_overview` | returns `FileOverview?` (null = file not in solution) | throws `FileNotFound` |
+
+**Group C — Cancellation pass-through audit:**
+
+These tools have typical latency > 100 ms per the README benchmark; honoring CT matters here.
+
+- `find_references` · `find_callers` · `find_tests_for_symbol`
+- `find_unused_symbols` (loops over `resolver.AllTypes`)
+- `analyze_change_impact` (delegates to find_references + find_callers)
+- `find_naming_violations` · `find_async_violations` · `find_disposable_misuse`
+- `get_diagnostics` with `includeAnalyzers: true` (the `AnalyzerRunner.RunAnalyzersAsync` per-analyzer loop is the hot path)
+- `rebuild_solution`
+- `peek_il` (IL decompilation on huge methods can take seconds)
+
+For each: ensure the `CancellationToken` parameter exists on `ExecuteAsync`, is passed to every awaited Roslyn API, and at least one `ct.ThrowIfCancellationRequested()` sits at the top of the outermost hot loop.
+
+**Group D — Host wiring:**
+
+- `Program.cs` registers the `McpToolException` filter on the server-host pipeline.
+- One new test class (`McpToolExceptionFilterTests`) verifies the JSON shape of an error response end-to-end (using a minimal in-process MCP transport mock).
+
+## Migration ordering
+
+Single PR, multiple commits:
+
+1. Foundations — `ToolErrorCode`, `McpToolException`, filter wiring, filter test. (1 commit. No tool changes; all green.)
+2. Group A — convert existing throws. ~3-4 commits (cluster by file).
+3. Group B — nullable → throw. 1 commit. **This is the only breaking behavior change in the PR** (callers expecting null now get an exception).
+4. Group C — cancellation honoring. ~3-4 commits (one per tool family).
+5. Docs catch-up: README & SKILL.md note on error codes + breaking-change callout for nullable returns. 1 commit.
+
+Total: ~10 commits, single PR titled `feat: structured tool errors + cancellation pass-through`.
+
+## Test strategy
+
+- **Foundations test:** `McpToolExceptionFilterTests` — assert the filter produces the documented JSON content for a thrown `McpToolException`, an `OperationCanceledException`, and a generic `Exception`.
+- **Per-tool error tests:** for each Group A and Group B tool, add (or update) one test that asserts the right `ToolErrorCode` is raised on the error path. Most can extend existing `*ToolTests.cs` files.
+- **Cancellation tests:** for Group C, add a test that pre-cancels a token, invokes the Logic method, and asserts `OperationCanceledException`. Don't test mid-flight cancellation — too race-prone for unit tests.
+
+## Risks and accepted trade-offs
+
+- **Breaking change for callers that depended on nullable returns.** Acceptable: there are no production consumers other than Claude, and the new throw with a specific code is strictly more informative than `null`. Noted in the PR body.
+- **Error-code enum is closed-set.** Adding a new code requires a code change to the enum. Acceptable — that's the whole point of giving LLMs a switchable surface. If a tool needs to communicate something not in the enum, that's a signal the enum should grow, not that the tool should invent a free-form string.
+- **The filter introduces one global try-catch around tool calls.** That's already how the MCP framework handles thrown exceptions; we're just replacing the default `ex.Message` projection with a structured projection for our exception type. No new failure modes.
+
+## Out of scope (intentional)
+
+- Logging / telemetry hooks (#7 from the enhancement audit) — separate work.
+- Progress callbacks for long ops (#4) — separate work.
+- Stale-tolerance parameter (#8) — separate work.
+- Bespoke `Success: bool` result types — they stay as-is.
+- Sync-tool cancellation — sync stays sync.

--- a/docs/plans/2026-05-26-structured-tool-errors.md
+++ b/docs/plans/2026-05-26-structured-tool-errors.md
@@ -1,0 +1,739 @@
+# Structured Tool Errors + Cancellation Pass-Through Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace ad-hoc throws and nullable-as-error returns across the tool surface with a structured `McpToolException` carrying a prescribed `ToolErrorCode` enum, surfaced to MCP clients as `{ isError: true, content: [{ type: "text", text: "{\"code\":\"…\",\"message\":\"…\",\"details\":…}" }] }`. Audit ~11 high-latency async tools to honor the `CancellationToken` the MCP framework already provides.
+
+**Architecture:** Two new types in `RoslynCodeLens` (`ToolErrorCode` enum + `McpToolException`). One exception-conversion point at the MCP host boundary in `Program.cs` (mechanism TBD — see Task 2). All existing throws and five nullable-return tools are migrated to throw `McpToolException` with the right code. Async Logic methods get `CancellationToken` threaded end-to-end with `ThrowIfCancellationRequested` at hot-loop tops.
+
+**Tech Stack:** C# / .NET 10, Roslyn `Microsoft.CodeAnalysis`, `ModelContextProtocol` 1.3.0 (stdio MCP server), xUnit.
+
+**Design doc:** `docs/plans/2026-05-26-structured-tool-errors-design.md`
+
+---
+
+## Conventions
+
+- TDD: failing test → red → implement → green → commit.
+- Scoped runs: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~<Class>"`.
+- Full suite before merge: `dotnet test`.
+- Per-task commit, message prefix `feat(errors):` for code, `test(errors):` for tests-only.
+- The documented `IsAdapterRestoreFlake` (NUnit/MSTest/XUnit fixture restore CS0103/CS0234/CS0246) is environmental — keep its filter logic intact when editing `GetDiagnosticsToolTests`.
+- `InternalsVisibleTo("RoslynCodeLens.Tests")` is set, so `internal` types are reachable from the test project.
+
+---
+
+## Task 1: Add `ToolErrorCode` + `McpToolException` + unit tests
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/ToolErrorCode.cs`
+- Create: `src/RoslynCodeLens/McpToolException.cs`
+- Create: `tests/RoslynCodeLens.Tests/McpToolExceptionTests.cs`
+
+### Step 1: Write the failing tests
+
+```csharp
+// tests/RoslynCodeLens.Tests/McpToolExceptionTests.cs
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests;
+
+public class McpToolExceptionTests
+{
+    [Fact]
+    public void Ctor_SetsCodeAndMessage()
+    {
+        var ex = new McpToolException(ToolErrorCode.SymbolNotFound, "X");
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+        Assert.Equal("X", ex.Message);
+        Assert.Null(ex.Details);
+    }
+
+    [Fact]
+    public void Ctor_PreservesDetails()
+    {
+        var details = new { path = "/foo/bar" };
+        var ex = new McpToolException(ToolErrorCode.FileNotFound, "missing", details);
+        Assert.Same(details, ex.Details);
+    }
+
+    [Fact]
+    public void Enum_HasAllExpectedCodes()
+    {
+        // Lock the catalog. Adding a code is intentional; removing one is breaking.
+        var expected = new[]
+        {
+            "SymbolNotFound", "SolutionNotTrusted", "AmbiguousMatch",
+            "FileNotFound", "ProjectNotFound", "InvalidArgument", "Internal",
+        };
+        var actual = Enum.GetNames<ToolErrorCode>();
+        Assert.Equal(expected.Length, actual.Length);
+        foreach (var name in expected)
+            Assert.Contains(name, actual, StringComparer.Ordinal);
+    }
+}
+```
+
+### Step 2: Run to verify failure
+
+`dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~McpToolExceptionTests"`
+Expected: compile error.
+
+### Step 3: Implement
+
+```csharp
+// src/RoslynCodeLens/Models/ToolErrorCode.cs
+namespace RoslynCodeLens.Models;
+
+public enum ToolErrorCode
+{
+    SymbolNotFound,
+    SolutionNotTrusted,
+    AmbiguousMatch,
+    FileNotFound,
+    ProjectNotFound,
+    InvalidArgument,
+    Internal,
+}
+```
+
+```csharp
+// src/RoslynCodeLens/McpToolException.cs
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+public sealed class McpToolException : Exception
+{
+    public ToolErrorCode Code { get; }
+    public object? Details { get; }
+
+    public McpToolException(ToolErrorCode code, string message, object? details = null)
+        : base(message)
+    {
+        Code = code;
+        Details = details;
+    }
+}
+```
+
+### Step 4: Tests green
+
+`dotnet test ... --filter "...McpToolExceptionTests"` → 3 pass.
+
+### Step 5: Commit
+
+```
+git add src/RoslynCodeLens/Models/ToolErrorCode.cs src/RoslynCodeLens/McpToolException.cs tests/RoslynCodeLens.Tests/McpToolExceptionTests.cs
+git commit -m "feat(errors): add McpToolException + ToolErrorCode enum"
+```
+
+---
+
+## Task 2: Wire exception filter at the MCP host boundary
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Program.cs`
+- Possibly create: `src/RoslynCodeLens/McpToolExceptionFormatter.cs` (helper for JSON projection)
+- Create: `tests/RoslynCodeLens.Tests/McpToolExceptionFormatterTests.cs`
+
+### Background research (mandatory before writing code)
+
+The `ModelContextProtocol` 1.3.0 NuGet package exposes the server-side via `IMcpServerBuilder` extension methods (`AddMcpServer`, `WithStdioServerTransport`, `WithToolsFromAssembly`). The exception-conversion mechanism for thrown tools is package-specific. **Before implementing, the engineer must:**
+
+1. Inspect the installed `ModelContextProtocol.dll` (path: `~/.nuget/packages/modelcontextprotocol/1.3.0/lib/net10.0/`) using `inspect_external_assembly` MCP tool (yes, dogfooding) for any of:
+   - A `IMcpServerToolFilter` / `IExceptionHandler` interface
+   - An `McpServerOptions.OnException` callback
+   - Middleware via `Use(...)`
+   - Per-tool `OnError` attribute
+2. If none of the above exists, the fallback is to **catch in the Tool wrappers** — but that's per-tool churn. Avoid this if at all possible.
+
+Report back what was found before writing any code. The plan can then be refined to specify the exact wiring API.
+
+### Step 1: Write the failing test on the projection logic
+
+Regardless of wiring mechanism, the JSON projection is pure: input is an `Exception`, output is a string. Test that contract first:
+
+```csharp
+// tests/RoslynCodeLens.Tests/McpToolExceptionFormatterTests.cs
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests;
+
+public class McpToolExceptionFormatterTests
+{
+    [Fact]
+    public void Format_McpToolException_ProducesStructuredJson()
+    {
+        var ex = new McpToolException(
+            ToolErrorCode.SolutionNotTrusted,
+            "Solution 'Foo.sln' is not trusted.",
+            new { solutionPath = "C:\\Foo.sln" });
+
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.Contains("\"code\":\"SolutionNotTrusted\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"message\":\"Solution 'Foo.sln' is not trusted.\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"solutionPath\":\"C:\\\\Foo.sln\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_McpToolException_OmitsDetailsKeyWhenNull()
+    {
+        var ex = new McpToolException(ToolErrorCode.SymbolNotFound, "X");
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.DoesNotContain("\"details\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_OtherException_DefaultsToInternalCode()
+    {
+        var ex = new InvalidOperationException("boom");
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.Contains("\"code\":\"Internal\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"message\":\"boom\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_OperationCanceledException_Throws()
+    {
+        // Cancellation must not be formatted — it should bubble unchanged for the MCP framework to handle.
+        var ex = new OperationCanceledException();
+        Assert.Throws<InvalidOperationException>(() => McpToolExceptionFormatter.FormatAsContentText(ex));
+    }
+}
+```
+
+### Step 2: Implement the formatter
+
+```csharp
+// src/RoslynCodeLens/McpToolExceptionFormatter.cs
+using System.Text.Json;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+internal static class McpToolExceptionFormatter
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static string FormatAsContentText(Exception ex)
+    {
+        if (ex is OperationCanceledException)
+            throw new InvalidOperationException(
+                "OperationCanceledException must propagate to the MCP framework, not be formatted.");
+
+        var payload = ex switch
+        {
+            McpToolException mcp => new ErrorPayload(mcp.Code.ToString(), mcp.Message, mcp.Details),
+            _ => new ErrorPayload(nameof(ToolErrorCode.Internal), ex.Message, null),
+        };
+        return JsonSerializer.Serialize(payload, s_options);
+    }
+
+    private sealed record ErrorPayload(string Code, string Message, object? Details);
+}
+```
+
+> **Note:** `JsonNamingPolicy.CamelCase` lowercases the first letter of property names, so `Code` → `"code"`. The `ToolErrorCode` enum value is serialized as a string via `mcp.Code.ToString()` — gives `"SolutionNotTrusted"`, not `1`.
+
+### Step 3: Tests green; commit foundations
+
+```
+git add src/RoslynCodeLens/McpToolExceptionFormatter.cs tests/RoslynCodeLens.Tests/McpToolExceptionFormatterTests.cs
+git commit -m "feat(errors): add McpToolExceptionFormatter for structured error projection"
+```
+
+### Step 4: Wire the formatter into `Program.cs`
+
+After the research in the "Background research" block above, write the exact wiring. Best case: a single line registering a filter:
+
+```csharp
+// Pseudo-code — replace with the actual API once research is done
+builder.Services.AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly()
+    .WithExceptionFilter(McpToolExceptionFormatter.FormatAsContentText);
+```
+
+Worst case (no built-in hook): wrap `WithToolsFromAssembly()` with a custom decorator. **Do not** add try-catch to every `*Tool.cs` Execute method — that's the anti-pattern the design explicitly rejects.
+
+### Step 5: Smoke-build + commit wiring
+
+```
+dotnet build src/RoslynCodeLens/RoslynCodeLens.csproj
+git add src/RoslynCodeLens/Program.cs
+git commit -m "feat(errors): wire McpToolException filter on server host"
+```
+
+---
+
+## Task 3: Convert Group A throws — solution lifecycle tools
+
+**Files:**
+- Modify: `src/RoslynCodeLens/MultiSolutionManager.cs`
+- Modify: `src/RoslynCodeLens/Tools/LoadSolutionTool.cs` (if it has any inline throws)
+
+### Background
+
+Audit lists 15 throw sites in `MultiSolutionManager.cs` and `SolutionManager.cs`. Not all are user-facing — some are internal invariants. Only convert throws that surface to MCP tool callers:
+
+- `MultiSolutionManager.SetActive(...)` — ambiguous and not-found cases
+- `MultiSolutionManager.Unload(...)` — not-found case
+- `MultiSolutionManager.Load(...)` — error during load
+- `MultiSolutionManager.Active` getter — "no solution loaded" case (read by every tool's `EnsureLoaded()`)
+
+`SolutionManager`'s warmup-failed throws are infrastructure — leave them; they get re-thrown by `MultiSolutionManager` calls anyway and the message is already informative.
+
+### Step 1: Find all surface-facing throw sites
+
+```
+grep -n "throw new InvalidOperationException" src/RoslynCodeLens/MultiSolutionManager.cs
+```
+
+Walk each. For each user-facing throw, plan the `McpToolException` replacement:
+
+| Line | Today | New |
+|---|---|---|
+| ~64 | `"No solution loaded. Pass a .sln/.slnx path as argument."` or `"Active solution key 'X' not found"` | `McpToolException(InvalidArgument, ...)` |
+| ~143 | (read context) likely no-match in SetActive | `McpToolException(ProjectNotFound, ...)` |
+| ~147 | ambiguous match | `McpToolException(AmbiguousMatch, ..., details: { matches: [...] })` |
+| ~177 | Load failure | `McpToolException(InvalidArgument, ...)` (the message describes the load failure) |
+| ~216 / ~220 | Unload not-found | `McpToolException(ProjectNotFound, ...)` |
+
+### Step 2: Write tests first
+
+In `tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs`, add tests like:
+
+```csharp
+[Fact]
+public void SetActive_AmbiguousMatch_ThrowsAmbiguousMatchCode()
+{
+    var mgr = ... ; // existing fixture setup
+    var ex = Assert.Throws<McpToolException>(() => mgr.SetActive("A")); // ambiguous prefix
+    Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
+    Assert.Contains("A", ex.Message, StringComparison.Ordinal);
+}
+
+[Fact]
+public void SetActive_NoMatch_ThrowsProjectNotFoundCode()
+{
+    var mgr = ... ;
+    var ex = Assert.Throws<McpToolException>(() => mgr.SetActive("nonexistent"));
+    Assert.Equal(ToolErrorCode.ProjectNotFound, ex.Code);
+}
+
+[Fact]
+public void EnsureLoaded_NoSolution_ThrowsInvalidArgumentCode()
+{
+    var mgr = MultiSolutionManager.CreateEmpty();
+    var ex = Assert.Throws<McpToolException>(() => mgr.EnsureLoaded());
+    Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+}
+```
+
+Run → fail (still throws `InvalidOperationException`).
+
+### Step 3: Replace throws in `MultiSolutionManager.cs`
+
+Pattern: `throw new InvalidOperationException("X")` → `throw new McpToolException(ToolErrorCode.Y, "X")`. Add `using RoslynCodeLens.Models;` if not present.
+
+For ambiguous-match: include the matching keys in `details`:
+
+```csharp
+throw new McpToolException(
+    ToolErrorCode.AmbiguousMatch,
+    $"Multiple solutions match '{name}': {string.Join(", ", matches.Select(Path.GetFileName))}.",
+    new { matches = matches.Select(m => new { path = m, name = Path.GetFileName(m) }).ToArray() });
+```
+
+### Step 4: Tests green
+
+`dotnet test ... --filter "FullyQualifiedName~MultiSolutionManagerTests"`
+
+### Step 5: Commit
+
+```
+git commit -am "feat(errors): convert MultiSolutionManager throws to McpToolException"
+```
+
+---
+
+## Task 4: Convert Group A throws — analyzer trust path
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs:31-36`
+- Modify: `src/RoslynCodeLens/Tools/GetCodeFixesLogic.cs` (similar block)
+- Modify: `tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs` — `GetDiagnostics_UntrustedSolution_ThrowsWhenAnalyzersRequested` test
+
+### Step 1: Update the existing test to assert on the code
+
+```csharp
+[Fact]
+public async Task GetDiagnostics_UntrustedSolution_ThrowsSolutionNotTrustedCode()
+{
+    using var tempFile = new TempTrustFile();
+    var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
+    var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist(
+        "nuget-and-solution-bin",
+        RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot: null);
+
+    var ex = await Assert.ThrowsAsync<McpToolException>(async () =>
+    {
+        await GetDiagnosticsLogic.ExecuteAsync(
+            _loaded, _resolver, null, null, includeAnalyzers: true,
+            trustStore, allowlist, CancellationToken.None);
+    });
+
+    Assert.Equal(ToolErrorCode.SolutionNotTrusted, ex.Code);
+    Assert.Contains("not trusted", ex.Message, StringComparison.OrdinalIgnoreCase);
+}
+```
+
+The existing `Assert.ThrowsAsync<InvalidOperationException>` test must be replaced (not duplicated).
+
+### Step 2: Run, see failure
+
+### Step 3: Update Logic
+
+In `GetDiagnosticsLogic.cs:31-36`:
+
+```csharp
+if (solutionPath is null || !trustStore.IsTrusted(solutionPath))
+{
+    throw new McpToolException(
+        ToolErrorCode.SolutionNotTrusted,
+        $"Solution '{solutionPath ?? "<unknown>"}' is not trusted for analyzer execution. " +
+        $"Analyzer DLLs run as in-process code, so the user must explicitly authorize them. " +
+        $"Ask the user, then call the 'trust_solution' tool with this path. " +
+        $"To get compiler-only diagnostics, retry with includeAnalyzers=false.",
+        new { solutionPath });
+}
+```
+
+Same change in `GetCodeFixesLogic.cs` for the matching trust-check block.
+
+### Step 4: Tests green
+
+`dotnet test ... --filter "FullyQualifiedName~GetDiagnosticsToolTests|FullyQualifiedName~GetCodeFixesToolTests"`
+
+### Step 5: Commit
+
+```
+git commit -am "feat(errors): convert analyzer-trust throws to SolutionNotTrusted"
+```
+
+---
+
+## Task 5: Convert Group A throws — find_breaking_changes baseline
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/FindBreakingChangesLogic.cs:140,148,162,183`
+- Modify: `tests/RoslynCodeLens.Tests/Tools/FindBreakingChangesToolTests.cs`
+
+### Audit
+
+Four throws in `FindBreakingChangesLogic`:
+- Line 140: baseline file not found → `FileNotFound`
+- Line 148 / 162 / 183: read context first (JSON parse failure / invalid format / missing assembly) — most likely `InvalidArgument`. Verify by reading the surrounding code.
+
+### Step 1: Add test for the FileNotFound path
+
+```csharp
+[Fact]
+public void FindBreakingChanges_MissingBaseline_ThrowsFileNotFoundCode()
+{
+    var ex = Assert.Throws<McpToolException>(() =>
+        FindBreakingChangesLogic.Execute(_loaded, _resolver, _metadata,
+            baselinePath: "/nonexistent/baseline.json", project: null));
+    Assert.Equal(ToolErrorCode.FileNotFound, ex.Code);
+}
+```
+
+### Step 2-4: Replace, run, commit per the standard pattern
+
+```
+git commit -am "feat(errors): convert FindBreakingChanges baseline-load throws"
+```
+
+---
+
+## Task 6: Convert Group A throws — generate_test_skeleton symbol-not-found
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/GenerateTestSkeletonLogic.cs:20+`
+- Modify: `tests/RoslynCodeLens.Tests/Tools/GenerateTestSkeletonToolTests.cs`
+
+### Audit
+
+`GenerateTestSkeletonLogic.cs:20`: `throw new InvalidOperationException($"Symbol not found: {symbol}")` → `McpToolException(SymbolNotFound, ..., new { symbol })`.
+
+`Line 36`: read context — likely "framework not detected" or "type kind not supported". Probably `InvalidArgument`.
+
+### Steps 1-5: Standard pattern.
+
+```
+git commit -am "feat(errors): convert GenerateTestSkeleton symbol-not-found throw"
+```
+
+---
+
+## Task 7: Group B — convert nullable-as-error to throws (five tools)
+
+**Files (one commit covers all five since the pattern is identical):**
+- Modify: `src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs`
+- Modify: `src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetFileOverviewTool.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetSymbolContextTool.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs`
+- Modify: `src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs`
+- Modify: corresponding `*ToolTests.cs` files (5 of them)
+
+### Step 1: For each tool, find the test asserting on null and rewrite it
+
+Example (`GetTypeOverviewToolTests`):
+
+```csharp
+[Fact]
+public void GetTypeOverview_UnknownSymbol_ThrowsSymbolNotFoundCode()
+{
+    var ex = Assert.Throws<McpToolException>(() =>
+        GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "Nonexistent.Type"));
+    Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+}
+```
+
+If an existing test asserts `Assert.Null(result)` for the unknown-symbol case, replace it with the throw-pattern.
+
+### Step 2: Change signatures
+
+For each tool, change the Logic and Tool signatures from `T?` to `T` (non-nullable). Where the old code did `return null;`, change to:
+
+```csharp
+throw new McpToolException(
+    ToolErrorCode.SymbolNotFound,
+    $"Symbol '{symbol}' not found in solution.",
+    new { symbol });
+```
+
+For `GetFileOverview` use `ToolErrorCode.FileNotFound` and pass `new { filePath = path }`.
+
+### Step 3: Build will fail at any caller dereferencing the old nullable
+
+```
+dotnet build src/RoslynCodeLens/
+```
+
+Walk every compile error. Most are inside `tests/` and update naturally. If a Logic function calls another nullable-returning Logic, update the caller too.
+
+### Step 4: Run scoped + full tests
+
+```
+dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~AnalyzeMethodToolTests|FullyQualifiedName~GetFileOverviewToolTests|FullyQualifiedName~GetSymbolContextToolTests|FullyQualifiedName~GetTypeHierarchyToolTests|FullyQualifiedName~GetTypeOverviewToolTests"
+```
+
+### Step 5: Commit
+
+```
+git commit -am "feat(errors): nullable-as-error returns now throw SymbolNotFound/FileNotFound
+
+BREAKING: callers of analyze_method / get_file_overview / get_symbol_context /
+get_type_hierarchy / get_type_overview that previously received null for
+unknown symbols now receive a structured McpToolException."
+```
+
+---
+
+## Task 8: Group C — cancellation pass-through audit (find_references family)
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/FindReferencesLogic.cs` (and Tool if needed)
+- Modify: `src/RoslynCodeLens/Tools/FindCallersLogic.cs`
+- Modify: `src/RoslynCodeLens/Tools/AnalyzeChangeImpactLogic.cs` (delegates to the above)
+
+### Step 1: For each Logic file
+
+1. Confirm `ExecuteAsync` (or convert sync `Execute` to async) accepts `CancellationToken ct = default` as its last parameter.
+2. Pass `ct` to every awaited Roslyn API in the body (especially `SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken: ct)`).
+3. At the top of any outer `foreach (var project in ...)` or `foreach (var syntaxTree in ...)` loop, insert `ct.ThrowIfCancellationRequested();`.
+4. Update Tool wrapper to take `CancellationToken ct = default` and pass it through.
+
+> **Important:** today, `FindReferencesLogic.Execute` is sync. Converting it to async is a breaking signature change. **Defer this:** if it's currently sync, leave it sync; cancellation only matters for the async tools. Update the plan to skip this Task if the Logic is sync. Only audit async logic.
+
+### Step 2: Test cancellation
+
+```csharp
+[Fact]
+public async Task FindReferences_PreCancelledToken_ThrowsOperationCancelled()
+{
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await FindReferencesLogic.ExecuteAsync(_loaded, _resolver, _metadata, "IGreeter", cts.Token));
+}
+```
+
+Only add this test for tools whose Logic is genuinely async (use `Task<T>` return).
+
+### Step 3-5: Standard pattern.
+
+```
+git commit -am "feat(errors): honor CancellationToken in find_references family"
+```
+
+---
+
+## Task 9: Group C — cancellation pass-through audit (diagnostics + analyzers)
+
+**Files:**
+- Modify: `src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs` (already async)
+- Modify: `src/RoslynCodeLens/AnalyzerRunner.cs` (or wherever `RunAnalyzersAsync` lives)
+
+### Audit
+
+`GetDiagnosticsLogic.ExecuteAsync` already takes `ct` and passes it to `AnalyzerRunner.RunAnalyzersAsync`. Verify:
+
+1. The per-project loop in `ExecuteAsync` has `ct.ThrowIfCancellationRequested()` at the top.
+2. `AnalyzerRunner.RunAnalyzersAsync` passes `ct` to the actual Roslyn `WithAnalyzers(...).GetAnalyzerDiagnosticsAsync(ct)` call.
+
+### Test
+
+```csharp
+[Fact]
+public async Task GetDiagnostics_PreCancelledToken_ThrowsOperationCancelled()
+{
+    using var cts = new CancellationTokenSource();
+    cts.Cancel();
+    using var tempFile = new TempTrustFile();
+    var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
+    trustStore.AddSessionTrust(_loaded.Solution.FilePath!);
+    var allowlist = ...;
+
+    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        await GetDiagnosticsLogic.ExecuteAsync(
+            _loaded, _resolver, null, null, includeAnalyzers: true,
+            trustStore, allowlist, cts.Token));
+}
+```
+
+### Commit
+
+```
+git commit -am "feat(errors): honor CancellationToken in get_diagnostics + analyzer runner"
+```
+
+---
+
+## Task 10: Group C — cancellation audit (remaining high-latency async tools)
+
+**Files (one per tool, atomic commits):**
+- `find_tests_for_symbol` (`FindTestsForSymbolLogic` if async; if sync, skip)
+- `peek_il` (decompilation can be slow)
+- `rebuild_solution` (`MultiSolutionManager.ForceReloadAsync`)
+- `get_code_actions` / `get_code_fixes` / `apply_code_action` — all currently async with `ct`; verify `ct` flows to `CodeFixProvider.RegisterCodeFixesAsync` etc.
+- `find_naming_violations`, `find_async_violations`, `find_disposable_misuse`, `find_unused_symbols` — these are currently sync per the grep. **Leave them sync for this PR.** Document in the design doc's "out of scope" section that sync-tool cancellation is a separate concern.
+
+### Per tool: standard pattern
+
+Add a `PreCancelled_ThrowsOperationCancelled` test; thread `ct` through. Commit per tool.
+
+```
+git commit -am "feat(errors): honor CancellationToken in <tool_name>"
+```
+
+---
+
+## Task 11: Docs catch-up
+
+**Files:**
+- Modify: `README.md` — add a short "Error responses" section after "Response shape"
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` — add "Error codes" section near the top with the catalog
+- Modify: `docs/site/docs/index.md` — note in the "Working with results" callout
+
+### README addition
+
+```markdown
+## Error responses
+
+When a tool can't proceed (symbol not resolved, solution not trusted, file not found, …),
+the response is an `isError: true` content block carrying a structured JSON body:
+
+```json
+{
+  "code": "SolutionNotTrusted",
+  "message": "Solution 'Foo.sln' is not trusted for analyzer execution. …",
+  "details": { "solutionPath": "C:\\Foo.sln" }
+}
+```
+
+Codes: `SymbolNotFound`, `SolutionNotTrusted`, `AmbiguousMatch`, `FileNotFound`,
+`ProjectNotFound`, `InvalidArgument`, `Internal`. Switch on `code` to handle each.
+```
+
+### SKILL.md addition
+
+Mirror the README block in a "Error codes" section.
+
+### Commit
+
+```
+git commit -am "docs: document structured error responses and ToolErrorCode catalog"
+```
+
+---
+
+## Task 12: Final verification + PR
+
+### Step 1: Build clean
+
+```
+dotnet build
+```
+
+Must succeed with 0 errors. Pre-existing warnings stay (211 analyzer warnings on dependency-vulnerable transitive packages — not ours).
+
+### Step 2: Full test suite
+
+```
+dotnet test
+```
+
+Expected: all tests green except the known `IsAdapterRestoreFlake` family (CS0103/CS0234/CS0246 in NUnit/MSTest/XUnit fixtures — environmental). Document any new failures and triage before opening the PR.
+
+### Step 3: Manual smoke test
+
+Restart Claude / your MCP client. Call:
+
+1. `set_active_solution("nonexistent")` → expect `isError: true` with `code: "ProjectNotFound"` in the response body.
+2. `get_diagnostics({ includeAnalyzers: true })` on an untrusted solution → expect `code: "SolutionNotTrusted"`.
+3. `analyze_method("Foo.Nonexistent")` → expect `code: "SymbolNotFound"`.
+
+If any of those return the old free-form error message instead of a structured JSON body, Task 2's wiring is wrong — revisit.
+
+### Step 4: Open PR
+
+Push the branch, open a PR titled `feat: structured tool errors + cancellation pass-through`. PR body should include:
+
+- The new `ToolErrorCode` catalog
+- An example before/after error response showing the JSON shape
+- A **BREAKING CHANGES** callout listing the five Group B tools whose nullable returns now throw
+- A note about cancellation: "The MCP framework was already supplying CancellationToken; this PR makes ~11 long-running tools actually honor it."
+
+---
+
+## Gotchas
+
+- **Don't add try/catch in `*Tool.cs` Execute methods.** The whole point is the single conversion point at the MCP host. If you find yourself adding per-tool try/catch, you've taken a wrong turn — revisit Task 2's wiring.
+- **`OperationCanceledException` must NOT be caught/formatted** by the new filter. MCP has native cancellation semantics; converting OCE to a structured error muddies that. The formatter explicitly throws if asked to format an OCE — that's the guardrail.
+- **Don't convert bespoke `Success: bool` result types** (`CodeActionResult`, `FindAsyncViolationsResult`, etc.). They encode tool-specific "ran but reports failure" — different from "cannot proceed".
+- **Sync tools stay sync.** Adding CT param to sync tools is performative — there's nothing inside to check it. The list of high-latency sync tools is documented in the design's "out of scope" section.
+- **Verify by `inspect_external_assembly` first** before guessing the MCP SDK's filter API. The plan's Task 2 is intentionally vague there — research, then implement.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -50,3 +50,5 @@ List-returning tools (everything that produces "all X" or "every Y") cap their i
 ```
 
 If `truncated` is `true`, `items` is the top N by the tool's natural sort order (errors first, worst-first, most-relevant-first). Raise `limit` only if the tail matters for what you're doing — usually it won't.
+
+**When a tool can't proceed,** the response is an `isError: true` content block whose JSON body has `{ code, message, details? }`. Codes are stable: `SymbolNotFound`, `SolutionNotTrusted`, `AmbiguousMatch`, `FileNotFound`, `ProjectNotFound`, `InvalidArgument`, `Internal`. See the [main README](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp#error-responses) for examples.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -32,6 +32,22 @@ Tools that include a `summary` aggregate:
 
 Single-object tools (`get_type_overview`, `get_symbol_context`, `apply_code_action`, etc.) are unchanged — they return their bespoke shape directly.
 
+## Error responses
+
+When a tool can't proceed, the response is `isError: true` with content carrying a JSON body of `{ code, message, details? }`. Switch on `code`:
+
+| Code | Meaning | Common source |
+|---|---|---|
+| `SymbolNotFound` | type/method/property not resolved | `analyze_method`, `get_symbol_context`, `get_type_overview`, `get_type_hierarchy`, `generate_test_skeleton` |
+| `SolutionNotTrusted` | analyzers blocked until `trust_solution` is called | `get_diagnostics` (`includeAnalyzers: true`), `get_code_fixes` |
+| `AmbiguousMatch` | name matched multiple solutions; `details.matches` lists candidates | `set_active_solution`, `unload_solution` |
+| `FileNotFound` | file path / baseline doesn't exist or isn't in solution | `get_file_overview`, `find_breaking_changes` |
+| `ProjectNotFound` | solution name didn't match | `set_active_solution`, `unload_solution` |
+| `InvalidArgument` | malformed / unsupported caller input | various |
+| `Internal` | unexpected; `message` carries exception text | fallback |
+
+If `code: SolutionNotTrusted`, the right next step is calling `trust_solution` after asking the user. Don't catch and retry blindly — the user has to authorize analyzer execution.
+
 ## Detection
 
 If `find_implementations` is not available as an MCP tool, this skill is inert — do nothing, no errors.

--- a/src/RoslynCodeLens/CodeActionRunner.cs
+++ b/src/RoslynCodeLens/CodeActionRunner.cs
@@ -66,7 +66,7 @@ public static class CodeActionRunner
 
             return new CodeActionResult(true, matchedAction.Title, edits);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             return new CodeActionResult(false, actionTitle, [],
                 $"Failed to apply action: {ex.Message}");
@@ -91,7 +91,7 @@ public static class CodeActionRunner
                 var context = new CodeRefactoringContext(document, span, action => actions.Add(action), ct);
                 await provider.ComputeRefactoringsAsync(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 await Console.Error.WriteLineAsync(
                     $"[roslyn-codelens] Refactoring provider failed ({provider.GetType().Name}): {ex.Message}")
@@ -139,7 +139,7 @@ public static class CodeActionRunner
                         for (var i = countBefore; i < actions.Count; i++)
                             codeFixTitles.Add(actions[i].Title);
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (ex is not OperationCanceledException)
                     {
                         await Console.Error.WriteLineAsync(
                             $"[roslyn-codelens] CodeFix provider failed ({provider.GetType().Name}): {ex.Message}")

--- a/src/RoslynCodeLens/CodeFixRunner.cs
+++ b/src/RoslynCodeLens/CodeFixRunner.cs
@@ -26,6 +26,7 @@ public static class CodeFixRunner
 
         for (var i = 0; i < providers.Count; i++)
         {
+            ct.ThrowIfCancellationRequested();
             var provider = providers[i];
             var actions = new List<CodeAction>();
             var context = new CodeFixContext(document, diagnostic,
@@ -35,7 +36,7 @@ public static class CodeFixRunner
             {
                 await provider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 await Console.Error.WriteLineAsync($"[roslyn-codelens] CodeFix registration failed ({provider.GetType().Name}): {ex}").ConfigureAwait(false);
                 continue;

--- a/src/RoslynCodeLens/McpToolException.cs
+++ b/src/RoslynCodeLens/McpToolException.cs
@@ -1,0 +1,16 @@
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+public sealed class McpToolException : Exception
+{
+    public ToolErrorCode Code { get; }
+    public object? Details { get; }
+
+    public McpToolException(ToolErrorCode code, string message, object? details = null)
+        : base(message)
+    {
+        Code = code;
+        Details = details;
+    }
+}

--- a/src/RoslynCodeLens/McpToolExceptionFormatter.cs
+++ b/src/RoslynCodeLens/McpToolExceptionFormatter.cs
@@ -1,0 +1,32 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+internal static class McpToolExceptionFormatter
+{
+    private static readonly JsonSerializerOptions s_options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    public static string FormatAsContentText(Exception ex)
+    {
+        if (ex is OperationCanceledException)
+            throw new InvalidOperationException(
+                "OperationCanceledException must propagate to the MCP framework, not be formatted.");
+
+        ErrorPayload payload = ex switch
+        {
+            McpToolException mcp => new(mcp.Code.ToString(), mcp.Message, mcp.Details),
+            _ => new(nameof(ToolErrorCode.Internal), ex.Message, null),
+        };
+        return JsonSerializer.Serialize(payload, s_options);
+    }
+
+    private sealed record ErrorPayload(string Code, string Message, object? Details);
+}

--- a/src/RoslynCodeLens/Models/ToolErrorCode.cs
+++ b/src/RoslynCodeLens/Models/ToolErrorCode.cs
@@ -1,0 +1,12 @@
+namespace RoslynCodeLens.Models;
+
+public enum ToolErrorCode
+{
+    SymbolNotFound,
+    SolutionNotTrusted,
+    AmbiguousMatch,
+    FileNotFound,
+    ProjectNotFound,
+    InvalidArgument,
+    Internal,
+}

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -61,10 +61,12 @@ public sealed class MultiSolutionManager : IDisposable
             string? key;
             lock (_lock) { key = _activeKey; }
             if (key == null || !_managers.TryGetValue(key, out var m))
-                throw new InvalidOperationException(
+                throw new McpToolException(
+                    ToolErrorCode.InvalidArgument,
                     key == null
                         ? "No solution loaded. Pass a .sln/.slnx path as argument."
-                        : $"Active solution key '{key}' not found in loaded solutions.");
+                        : $"Active solution key '{key}' not found in loaded solutions.",
+                    new { activeKey = key });
             return m;
         }
     }
@@ -140,12 +142,16 @@ public sealed class MultiSolutionManager : IDisposable
             .ToList();
 
         if (matches.Count == 0)
-            throw new InvalidOperationException(
-                $"No solution matching '{name}'. Available: {string.Join(", ", _managers.Keys.Select(Path.GetFileName))}");
+            throw new McpToolException(
+                ToolErrorCode.ProjectNotFound,
+                $"No solution matching '{name}'. Available: {string.Join(", ", _managers.Keys.Select(Path.GetFileName))}",
+                new { name, available = _managers.Keys.Select(Path.GetFileName).ToArray() });
 
         if (matches.Count > 1)
-            throw new InvalidOperationException(
-                $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}");
+            throw new McpToolException(
+                ToolErrorCode.AmbiguousMatch,
+                $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}",
+                new { name, matches });
 
         lock (_lock) { _activeKey = matches[0]; }
         return matches[0];
@@ -174,7 +180,10 @@ public sealed class MultiSolutionManager : IDisposable
         {
             var message = manager.LoadFailureMessage!;
             manager.Dispose();
-            throw new InvalidOperationException(message);
+            throw new McpToolException(
+                ToolErrorCode.InvalidArgument,
+                message,
+                new { solutionPath = normalised, reason = message });
         }
 
         lock (_lock)
@@ -213,12 +222,16 @@ public sealed class MultiSolutionManager : IDisposable
                 .ToList();
 
             if (matches.Count == 0)
-                throw new InvalidOperationException(
-                    $"No solution matching '{name}'. Available: {string.Join(", ", keysSnapshot.Select(Path.GetFileName))}");
+                throw new McpToolException(
+                    ToolErrorCode.ProjectNotFound,
+                    $"No solution matching '{name}'. Available: {string.Join(", ", keysSnapshot.Select(Path.GetFileName))}",
+                    new { name, available = keysSnapshot.Select(Path.GetFileName).ToArray() });
 
             if (matches.Count > 1)
-                throw new InvalidOperationException(
-                    $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}");
+                throw new McpToolException(
+                    ToolErrorCode.AmbiguousMatch,
+                    $"Ambiguous match for '{name}'. Matches: {string.Join(", ", matches)}",
+                    new { name, matches });
 
             key = matches[0];
 

--- a/src/RoslynCodeLens/Program.cs
+++ b/src/RoslynCodeLens/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
+using ModelContextProtocol.Server;
 using RoslynCodeLens;
 using RoslynCodeLens.Security;
 
@@ -45,5 +46,17 @@ builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()
     .WithToolsFromAssembly();
+
+// Wrap every registered tool with StructuredErrorToolWrapper so thrown exceptions
+// surface as CallToolResult { IsError = true } carrying structured JSON.
+// OperationCanceledException intentionally bubbles unchanged.
+builder.Services.PostConfigure<McpServerOptions>(options =>
+{
+    var coll = options.ToolCollection;
+    if (coll is null) return;
+    var wrapped = coll.Select(t => (McpServerTool)new StructuredErrorToolWrapper(t)).ToList();
+    coll.Clear();
+    foreach (var t in wrapped) coll.Add(t);
+});
 
 await builder.Build().RunAsync().ConfigureAwait(false);

--- a/src/RoslynCodeLens/StructuredErrorToolWrapper.cs
+++ b/src/RoslynCodeLens/StructuredErrorToolWrapper.cs
@@ -1,0 +1,30 @@
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RoslynCodeLens;
+
+internal sealed class StructuredErrorToolWrapper(McpServerTool inner) : DelegatingMcpServerTool(inner)
+{
+    public override async ValueTask<CallToolResult> InvokeAsync(
+        RequestContext<CallToolRequestParams> request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await base.InvokeAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Let MCP framework handle cancellation natively.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new CallToolResult
+            {
+                IsError = true,
+                Content = [new TextContentBlock { Text = McpToolExceptionFormatter.FormatAsContentText(ex) }],
+            };
+        }
+    }
+}

--- a/src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs
@@ -7,11 +7,11 @@ namespace RoslynCodeLens.Tools;
 
 public static class AnalyzeMethodLogic
 {
-    public static MethodAnalysis? Execute(LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
+    public static MethodAnalysis Execute(LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
         var methods = resolver.FindMethods(symbol);
         if (methods.Count == 0)
-            return null;
+            throw new McpToolException(ToolErrorCode.SymbolNotFound, $"Method '{symbol}' not found.", new { symbol });
 
         var target = methods[0];
         var (file, line) = resolver.GetFileAndLine(target);

--- a/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
@@ -11,7 +11,7 @@ public static class AnalyzeMethodTool
      Description("Get a comprehensive analysis of a method in one call: signature, location, all callers, " +
                  "and all outgoing calls (methods this method invokes). " +
                  "More efficient than calling find_callers separately.")]
-    public static MethodAnalysis? Execute(
+    public static MethodAnalysis Execute(
         MultiSolutionManager manager,
         [Description("Method symbol (e.g. 'Greeter.Greet' or 'MyNamespace.MyClass.MyMethod')")] string symbol)
     {

--- a/src/RoslynCodeLens/Tools/ApplyCodeActionLogic.cs
+++ b/src/RoslynCodeLens/Tools/ApplyCodeActionLogic.cs
@@ -16,6 +16,7 @@ public static class ApplyCodeActionLogic
 
         foreach (var project in loaded.Solution.Projects)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var doc in project.Documents)
             {
                 if (doc.FilePath != null &&

--- a/src/RoslynCodeLens/Tools/FindBreakingChangesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindBreakingChangesLogic.cs
@@ -137,7 +137,10 @@ public static class FindBreakingChangesLogic
     private static IReadOnlyList<PublicApiEntry> LoadBaseline(string baselinePath)
     {
         if (!File.Exists(baselinePath))
-            throw new FileNotFoundException($"Baseline not found: {baselinePath}", baselinePath);
+            throw new McpToolException(
+                ToolErrorCode.FileNotFound,
+                $"Baseline not found: {baselinePath}",
+                new { baselinePath });
 
         var ext = Path.GetExtension(baselinePath);
         if (string.Equals(ext, ".json", StringComparison.OrdinalIgnoreCase))
@@ -145,8 +148,10 @@ public static class FindBreakingChangesLogic
         if (string.Equals(ext, ".dll", StringComparison.OrdinalIgnoreCase))
             return LoadBaselineFromAssembly(baselinePath);
 
-        throw new InvalidOperationException(
-            $"Unsupported baseline file extension: '{ext}'. Expected .json or .dll.");
+        throw new McpToolException(
+            ToolErrorCode.InvalidArgument,
+            $"Unsupported baseline file extension: '{ext}'. Expected .json or .dll.",
+            new { baselinePath, extension = ext });
     }
 
     private static IReadOnlyList<PublicApiEntry> LoadBaselineFromJson(string path)
@@ -159,8 +164,10 @@ public static class FindBreakingChangesLogic
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException(
-                $"Baseline JSON is not a valid get_public_api_surface result: {ex.Message}", ex);
+            throw new McpToolException(
+                ToolErrorCode.InvalidArgument,
+                $"Baseline JSON is not a valid get_public_api_surface result: {ex.Message}",
+                new { baselinePath = path, reason = ex.Message });
         }
     }
 
@@ -180,8 +187,10 @@ public static class FindBreakingChangesLogic
             references: bclRefs.Append(reference));
 
         if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol assembly)
-            throw new InvalidOperationException(
-                $"Failed to load assembly: {path}");
+            throw new McpToolException(
+                ToolErrorCode.InvalidArgument,
+                $"Failed to load assembly: {path}",
+                new { baselinePath = path, reason = "GetAssemblyOrModuleSymbol returned null" });
 
         var projectName = Path.GetFileNameWithoutExtension(path);
         return PublicApiSurfaceExtractor.Extract(assembly, projectName, requireSourceLocation: false);

--- a/src/RoslynCodeLens/Tools/GenerateTestSkeletonLogic.cs
+++ b/src/RoslynCodeLens/Tools/GenerateTestSkeletonLogic.cs
@@ -17,7 +17,10 @@ public static class GenerateTestSkeletonLogic
     {
         var symbols = resolver.FindSymbols(symbol);
         if (symbols.Count == 0)
-            throw new InvalidOperationException($"Symbol not found: {symbol}");
+            throw new McpToolException(
+                ToolErrorCode.SymbolNotFound,
+                $"Symbol not found: {symbol}",
+                new { symbol });
 
         var first = symbols[0];
         INamedTypeSymbol targetType;
@@ -33,14 +36,18 @@ public static class GenerateTestSkeletonLogic
                 targetMethods = new List<IMethodSymbol> { method };
                 break;
             default:
-                throw new InvalidOperationException(
-                    $"Symbol must be a type or method, got {first.Kind}: {symbol}");
+                throw new McpToolException(
+                    ToolErrorCode.InvalidArgument,
+                    $"Symbol must be a type or method, got {first.Kind}: {symbol}",
+                    new { symbol, kind = first.Kind.ToString() });
         }
 
         var sourceTree = targetType.Locations.FirstOrDefault(l => l.IsInSource)?.SourceTree;
         if (sourceTree is not null && GeneratedCodeDetector.IsGenerated(sourceTree))
-            throw new InvalidOperationException(
-                $"Symbol '{symbol}' is in generated code; refusing to generate a test skeleton.");
+            throw new McpToolException(
+                ToolErrorCode.InvalidArgument,
+                $"Symbol '{symbol}' is in generated code; refusing to generate a test skeleton.",
+                new { symbol });
 
         var fw = ResolveFramework(loaded, framework);
         var todoNotes = new List<string>();
@@ -82,8 +89,10 @@ public static class GenerateTestSkeletonLogic
                 "xunit" => TestFramework.XUnit,
                 "nunit" => TestFramework.NUnit,
                 "mstest" => TestFramework.MSTest,
-                _ => throw new InvalidOperationException(
-                    $"Unknown framework override '{overrideName}'. Use xunit, nunit, or mstest."),
+                _ => throw new McpToolException(
+                    ToolErrorCode.InvalidArgument,
+                    $"Unknown framework override '{overrideName}'. Use xunit, nunit, or mstest.",
+                    new { framework = overrideName }),
             };
         }
 

--- a/src/RoslynCodeLens/Tools/GetCodeActionsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeActionsLogic.cs
@@ -15,6 +15,7 @@ public static class GetCodeActionsLogic
 
         foreach (var project in loaded.Solution.Projects)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var doc in project.Documents)
             {
                 if (doc.FilePath != null &&

--- a/src/RoslynCodeLens/Tools/GetCodeFixesLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeFixesLogic.cs
@@ -39,10 +39,12 @@ public static class GetCodeFixesLogic
         var solutionPath = loaded.Solution.FilePath;
         if (solutionPath is null || !trustStore.IsTrusted(solutionPath))
         {
-            throw new InvalidOperationException(
+            throw new McpToolException(
+                ToolErrorCode.SolutionNotTrusted,
                 $"Solution '{solutionPath ?? "<unknown>"}' is not trusted for analyzer execution. " +
                 $"'get_code_fixes' loads analyzer DLLs to discover available fixes — these run as in-process code. " +
-                $"Ask the user, then call the 'trust_solution' tool with this path.");
+                $"Ask the user, then call the 'trust_solution' tool with this path.",
+                new { solutionPath });
         }
 
         var allDiagnostics = compilation.GetDiagnostics()

--- a/src/RoslynCodeLens/Tools/GetCodeFixesLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeFixesLogic.cs
@@ -17,6 +17,7 @@ public static class GetCodeFixesLogic
 
         foreach (var project in loaded.Solution.Projects)
         {
+            ct.ThrowIfCancellationRequested();
             foreach (var doc in project.Documents)
             {
                 if (doc.FilePath != null &&
@@ -66,6 +67,7 @@ public static class GetCodeFixesLogic
 
         for (var i = 0; i < matchingDiagnostics.Count; i++)
         {
+            ct.ThrowIfCancellationRequested();
             var diagnostic = matchingDiagnostics[i];
             var fixes = await CodeFixRunner.GetFixesAsync(targetProject, diagnostic, ct).ConfigureAwait(false);
             results.AddRange(fixes);

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs
@@ -41,6 +41,8 @@ public static class GetDiagnosticsLogic
 
         foreach (var (projectId, compilation) in loaded.Compilations)
         {
+            ct.ThrowIfCancellationRequested();
+
             var projectName = resolver.GetProjectName(projectId);
 
             if (project != null &&

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsLogic.cs
@@ -28,11 +28,13 @@ public static class GetDiagnosticsLogic
         var solutionPath = loaded.Solution.FilePath;
         if (solutionPath is null || !trustStore.IsTrusted(solutionPath))
         {
-            throw new InvalidOperationException(
+            throw new McpToolException(
+                ToolErrorCode.SolutionNotTrusted,
                 $"Solution '{solutionPath ?? "<unknown>"}' is not trusted for analyzer execution. " +
                 $"Analyzer DLLs run as in-process code, so the user must explicitly authorize them. " +
                 $"Ask the user, then call the 'trust_solution' tool with this path. " +
-                $"To get compiler-only diagnostics, retry with includeAnalyzers=false.");
+                $"To get compiler-only diagnostics, retry with includeAnalyzers=false.",
+                new { solutionPath });
         }
 
         var minSeverity = ParseMinSeverity(severity);

--- a/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
@@ -6,7 +6,7 @@ namespace RoslynCodeLens.Tools;
 
 public static class GetFileOverviewLogic
 {
-    public static async Task<FileOverview?> ExecuteAsync(
+    public static async Task<FileOverview> ExecuteAsync(
         LoadedSolution loaded, SymbolResolver resolver, string filePath, CancellationToken ct)
     {
         var normalizedPath = Path.GetFullPath(filePath);
@@ -29,7 +29,7 @@ public static class GetFileOverviewLogic
         }
 
         if (targetDocument == null || targetProject == null)
-            return null;
+            throw new McpToolException(ToolErrorCode.FileNotFound, $"File '{filePath}' not found in any loaded project.", new { filePath });
 
         // Types defined in this file
         var syntaxTree = await targetDocument.GetSyntaxTreeAsync(ct).ConfigureAwait(false);

--- a/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
@@ -10,7 +10,7 @@ public static class GetFileOverviewTool
     [McpServerTool(Name = "get_file_overview"),
      Description("Get a summary of a C# file: which types are defined in it and any compiler diagnostics. " +
                  "Useful for quickly understanding a file's contents without reading it.")]
-    public static async Task<FileOverview?> Execute(
+    public static async Task<FileOverview> Execute(
         MultiSolutionManager manager,
         [Description("Full path to the C# source file")] string filePath,
         CancellationToken ct = default)

--- a/src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextLogic.cs
@@ -6,7 +6,7 @@ namespace RoslynCodeLens.Tools;
 
 public static class GetSymbolContextLogic
 {
-    public static SymbolContext? Execute(
+    public static SymbolContext Execute(
         LoadedSolution loaded,
         SymbolResolver resolver,
         MetadataSymbolResolver metadata,
@@ -22,7 +22,7 @@ public static class GetSymbolContextLogic
         if (resolved?.Symbol is INamedTypeSymbol metadataType)
             return BuildMetadataContext(metadataType, resolved.Origin);
 
-        return null;
+        throw new McpToolException(ToolErrorCode.SymbolNotFound, $"Symbol '{symbol}' not found.", new { symbol });
     }
 
     private static SymbolContext BuildContext(SymbolResolver resolver, INamedTypeSymbol target, SymbolOrigin origin)

--- a/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
@@ -9,7 +9,7 @@ public static class GetSymbolContextTool
 {
     [McpServerTool(Name = "get_symbol_context"),
      Description("One-shot context dump for a type: namespace, base class, interfaces, injected dependencies, public members")]
-    public static SymbolContext? Execute(
+    public static SymbolContext Execute(
         MultiSolutionManager manager,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyLogic.cs
@@ -13,7 +13,7 @@ public static class GetTypeHierarchyLogic
     /// of a metadata interface will only be listed when they live in the loaded
     /// solution's source.
     /// </summary>
-    public static TypeHierarchy? Execute(
+    public static TypeHierarchy Execute(
         SymbolResolver resolver, MetadataSymbolResolver metadata, string symbol)
     {
         INamedTypeSymbol? target = null;
@@ -32,7 +32,7 @@ public static class GetTypeHierarchyLogic
         }
 
         if (target == null)
-            return null;
+            throw new McpToolException(ToolErrorCode.SymbolNotFound, $"Symbol '{symbol}' not found.", new { symbol });
 
         var bases = CollectBaseTypes(target, resolver);
         var interfaces = CollectInterfaces(target, resolver);

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
@@ -9,7 +9,7 @@ public static class GetTypeHierarchyTool
 {
     [McpServerTool(Name = "get_type_hierarchy"),
      Description("Walk up (base classes, interfaces) and down (derived types) from a type")]
-    public static TypeHierarchy? Execute(
+    public static TypeHierarchy Execute(
         MultiSolutionManager manager,
         [Description("Type name (simple or fully qualified)")] string symbol)
     {

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewLogic.cs
@@ -11,15 +11,13 @@ public static class GetTypeOverviewLogic
     /// list is empty by construction (the compiler does not attach diagnostics to
     /// closed-source assemblies) and derived types are source-only.
     /// </summary>
-    public static TypeOverview? Execute(
+    public static TypeOverview Execute(
         LoadedSolution loaded,
         SymbolResolver resolver,
         MetadataSymbolResolver metadata,
         string typeName)
     {
         var context = GetSymbolContextLogic.Execute(loaded, resolver, metadata, typeName);
-        if (context == null)
-            return null;
 
         var hierarchy = GetTypeHierarchyLogic.Execute(resolver, metadata, typeName);
 

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
@@ -11,7 +11,7 @@ public static class GetTypeOverviewTool
      Description("Get a comprehensive overview of a type in one call: full context (namespace, base class, interfaces, " +
                  "members, DI dependencies), type hierarchy (bases, interfaces, derived types), and diagnostics in the file. " +
                  "More efficient than calling get_symbol_context + get_type_hierarchy + get_diagnostics separately.")]
-    public static TypeOverview? Execute(
+    public static TypeOverview Execute(
         MultiSolutionManager manager,
         [Description("Type name (simple name or fully qualified)")] string typeName)
     {

--- a/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ApplyCodeActionLogicTests.cs
@@ -72,4 +72,20 @@ public class ApplyCodeActionLogicTests
         Assert.False(result.Success);
         Assert.Contains("not found", result.ErrorMessage!, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_PreCancelledToken_ThrowsOperationCancelled()
+    {
+        var project = _loaded.Solution.Projects.First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal));
+        var greeterPath = project.Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal)).FilePath!;
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ApplyCodeActionLogic.ExecuteAsync(
+                _loaded, greeterPath, line: 8, column: 5,
+                endLine: null, endColumn: null,
+                actionTitle: "anything", preview: true, cts.Token));
+    }
 }

--- a/tests/RoslynCodeLens.Tests/GetCodeActionsLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/GetCodeActionsLogicTests.cs
@@ -38,4 +38,19 @@ public class GetCodeActionsLogicTests
 
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_PreCancelledToken_ThrowsOperationCancelled()
+    {
+        var project = _loaded.Solution.Projects.First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal));
+        var greeterPath = project.Documents.First(d => string.Equals(d.Name, "Greeter.cs", StringComparison.Ordinal)).FilePath!;
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await GetCodeActionsLogic.ExecuteAsync(
+                _loaded, greeterPath, line: 8, column: 5,
+                endLine: null, endColumn: null, cts.Token));
+    }
 }

--- a/tests/RoslynCodeLens.Tests/McpToolExceptionFormatterTests.cs
+++ b/tests/RoslynCodeLens.Tests/McpToolExceptionFormatterTests.cs
@@ -1,0 +1,46 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests;
+
+public class McpToolExceptionFormatterTests
+{
+    [Fact]
+    public void Format_McpToolException_ProducesStructuredJson()
+    {
+        var ex = new McpToolException(
+            ToolErrorCode.SolutionNotTrusted,
+            "Solution 'Foo.sln' is not trusted.",
+            new { solutionPath = "C:\\Foo.sln" });
+
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.Contains("\"code\":\"SolutionNotTrusted\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"message\":\"Solution 'Foo.sln' is not trusted.\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"solutionPath\":\"C:\\\\Foo.sln\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_McpToolException_OmitsDetailsKeyWhenNull()
+    {
+        var ex = new McpToolException(ToolErrorCode.SymbolNotFound, "X");
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.DoesNotContain("\"details\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_OtherException_DefaultsToInternalCode()
+    {
+        var ex = new InvalidOperationException("boom");
+        var text = McpToolExceptionFormatter.FormatAsContentText(ex);
+        Assert.Contains("\"code\":\"Internal\"", text, StringComparison.Ordinal);
+        Assert.Contains("\"message\":\"boom\"", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Format_OperationCanceledException_Throws()
+    {
+        // Cancellation must not be formatted - it should bubble unchanged for the MCP framework to handle.
+        var ex = new OperationCanceledException();
+        Assert.Throws<InvalidOperationException>(() => McpToolExceptionFormatter.FormatAsContentText(ex));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/McpToolExceptionTests.cs
+++ b/tests/RoslynCodeLens.Tests/McpToolExceptionTests.cs
@@ -1,0 +1,39 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tests;
+
+public class McpToolExceptionTests
+{
+    [Fact]
+    public void Ctor_SetsCodeAndMessage()
+    {
+        var ex = new McpToolException(ToolErrorCode.SymbolNotFound, "X");
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+        Assert.Equal("X", ex.Message);
+        Assert.Null(ex.Details);
+    }
+
+    [Fact]
+    public void Ctor_PreservesDetails()
+    {
+        var details = new { path = "/foo/bar" };
+        var ex = new McpToolException(ToolErrorCode.FileNotFound, "missing", details);
+        Assert.Same(details, ex.Details);
+    }
+
+    [Fact]
+    public void Enum_HasAllExpectedCodes()
+    {
+        // Lock the catalog. Adding a code is intentional; removing one is breaking.
+        var expected = new[]
+        {
+            "SymbolNotFound", "SolutionNotTrusted", "AmbiguousMatch",
+            "FileNotFound", "ProjectNotFound", "InvalidArgument", "Internal",
+        };
+        var actual = Enum.GetNames<ToolErrorCode>();
+        Assert.Equal(expected.Length, actual.Length);
+        foreach (var name in expected)
+            Assert.Contains(name, actual, StringComparer.Ordinal);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 
 namespace RoslynCodeLens.Tests;
 
@@ -48,7 +49,8 @@ public class MultiSolutionManagerTests : IAsyncLifetime
     public void CreateEmpty_EnsureLoaded_Throws()
     {
         var multi = MultiSolutionManager.CreateEmpty();
-        Assert.Throws<InvalidOperationException>((Action)(() => multi.EnsureLoaded()));
+        var ex = Assert.Throws<McpToolException>((Action)(() => multi.EnsureLoaded()));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
         multi.Dispose();
     }
 
@@ -98,7 +100,8 @@ public class MultiSolutionManagerTests : IAsyncLifetime
     public async Task SetActiveSolution_UnknownName_Throws()
     {
         var multi = await MultiSolutionManager.CreateAsync([_solutionPath]);
-        Assert.Throws<InvalidOperationException>(() => multi.SetActiveSolution("DoesNotExist"));
+        var ex = Assert.Throws<McpToolException>(() => multi.SetActiveSolution("DoesNotExist"));
+        Assert.Equal(ToolErrorCode.ProjectNotFound, ex.Code);
         multi.Dispose();
     }
 
@@ -107,7 +110,8 @@ public class MultiSolutionManagerTests : IAsyncLifetime
     {
         var multi = await MultiSolutionManager.CreateAsync([_solutionPath, _altSolutionPath]);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => multi.SetActiveSolution("TestSolution"));
+        var ex = Assert.Throws<McpToolException>(() => multi.SetActiveSolution("TestSolution"));
+        Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
         Assert.Contains("Ambiguous", ex.Message, StringComparison.OrdinalIgnoreCase);
         multi.Dispose();
     }
@@ -231,7 +235,8 @@ public class MultiSolutionManagerTests : IAsyncLifetime
     public void UnloadSolution_UnknownName_Throws()
     {
         var multi = MultiSolutionManager.CreateEmpty();
-        Assert.Throws<InvalidOperationException>(() => multi.UnloadSolution("DoesNotExist"));
+        var ex = Assert.Throws<McpToolException>(() => multi.UnloadSolution("DoesNotExist"));
+        Assert.Equal(ToolErrorCode.ProjectNotFound, ex.Code);
         multi.Dispose();
     }
 
@@ -243,7 +248,8 @@ public class MultiSolutionManagerTests : IAsyncLifetime
         await multi.LoadSolutionAsync(_solutionPath);
         await multi.LoadSolutionAsync(_altSolutionPath);
 
-        var ex = Assert.Throws<InvalidOperationException>(() => multi.UnloadSolution("TestSolution"));
+        var ex = Assert.Throws<McpToolException>(() => multi.UnloadSolution("TestSolution"));
+        Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
         Assert.Contains("Ambiguous", ex.Message, StringComparison.OrdinalIgnoreCase);
         multi.Dispose();
     }

--- a/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/AnalyzeMethodToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -41,10 +42,11 @@ public class AnalyzeMethodToolTests
     }
 
     [Fact]
-    public void Execute_ForUnknownMethod_ReturnsNull()
+    public void Execute_ForUnknownMethod_ThrowsSymbolNotFound()
     {
-        var result = AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "NoSuchClass.NoSuchMethod");
+        var ex = Assert.Throws<McpToolException>(() =>
+            AnalyzeMethodLogic.Execute(_loaded, _resolver, _metadata, "NoSuchClass.NoSuchMethod"));
 
-        Assert.Null(result);
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/FindBreakingChangesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindBreakingChangesToolTests.cs
@@ -296,8 +296,9 @@ public class FindBreakingChangesToolTests
     public void MissingBaselineFile_ThrowsFileNotFound()
     {
         var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".json");
-        Assert.Throws<FileNotFoundException>(() =>
+        var ex = Assert.Throws<McpToolException>(() =>
             FindBreakingChangesLogic.Execute(_loaded, _resolver, path));
+        Assert.Equal(ToolErrorCode.FileNotFound, ex.Code);
     }
 
     [Fact]
@@ -307,8 +308,9 @@ public class FindBreakingChangesToolTests
         File.WriteAllText(path, "{ this is not valid json");
         try
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            var ex = Assert.Throws<McpToolException>(() =>
                 FindBreakingChangesLogic.Execute(_loaded, _resolver, path));
+            Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
         }
         finally
         {
@@ -323,8 +325,9 @@ public class FindBreakingChangesToolTests
         File.WriteAllText(path, "<root/>");
         try
         {
-            Assert.Throws<InvalidOperationException>(() =>
+            var ex = Assert.Throws<McpToolException>(() =>
                 FindBreakingChangesLogic.Execute(_loaded, _resolver, path));
+            Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
         }
         finally
         {

--- a/tests/RoslynCodeLens.Tests/Tools/GenerateTestSkeletonToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GenerateTestSkeletonToolTests.cs
@@ -168,12 +168,13 @@ public class GenerateTestSkeletonToolTests
     [Fact]
     public void UnknownSymbol_Throws()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<McpToolException>(() =>
             GenerateTestSkeletonLogic.Execute(
                 _loaded, _resolver,
                 symbol: "TestLib.DoesNotExist",
                 framework: "xunit"));
 
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
         Assert.Contains("not found", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -194,12 +195,13 @@ public class GenerateTestSkeletonToolTests
     [Fact]
     public void GeneratedCodeSymbol_IsRejected()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.Throws<McpToolException>(() =>
             GenerateTestSkeletonLogic.Execute(
                 _loaded, _resolver,
                 symbol: "TestLib.GeneratedTarget",
                 framework: "xunit"));
 
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
         Assert.Contains("generated", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -43,5 +44,26 @@ public class GetCodeFixesToolTests
         var results = await GetCodeFixesLogic.ExecuteAsync(
             _loaded, _resolver, diag.Id, diag.File, diag.Line, trustStore, allowlist, CancellationToken.None);
         Assert.NotNull(results);
+    }
+
+    [Fact]
+    public async Task GetCodeFixes_UntrustedSolution_ThrowsSolutionNotTrusted()
+    {
+        // No trust added — but a diagnostic must actually exist at the call site,
+        // otherwise the early "no matching diagnostics" return short-circuits the trust check.
+        var trustStore = new RoslynCodeLens.Security.TrustStore(Path.Combine(Path.GetTempPath(), $"trust-{Guid.NewGuid():N}.json"));
+        var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist("all", RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot: null);
+
+        // Find an existing compiler diagnostic to ensure we reach the trust check.
+        var diagnostics = GetDiagnosticsLogic.Execute(_loaded, _resolver, null, null);
+        var diag = diagnostics.FirstOrDefault(d => !string.IsNullOrEmpty(d.File));
+        if (diag is null) return; // no diagnostics in fixture — skip
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(async () =>
+        {
+            await GetCodeFixesLogic.ExecuteAsync(
+                _loaded, _resolver, diag.Id, diag.File, diag.Line, trustStore, allowlist, CancellationToken.None);
+        });
+        Assert.Equal(ToolErrorCode.SolutionNotTrusted, ex.Code);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetCodeFixesToolTests.cs
@@ -47,6 +47,25 @@ public class GetCodeFixesToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_PreCancelledToken_ThrowsOperationCancelled()
+    {
+        var trustStore = new RoslynCodeLens.Security.TrustStore(Path.Combine(Path.GetTempPath(), $"trust-{Guid.NewGuid():N}.json"));
+        trustStore.AddSessionTrust(_loaded.Solution.FilePath!);
+        var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist(
+            "all",
+            RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(),
+            dotnetSdkRoot: null);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await GetCodeFixesLogic.ExecuteAsync(
+                _loaded, _resolver, "FAKE999", "NonExistent.cs", 1,
+                trustStore, allowlist, cts.Token));
+    }
+
+    [Fact]
     public async Task GetCodeFixes_UntrustedSolution_ThrowsSolutionNotTrusted()
     {
         // No trust added — but a diagnostic must actually exist at the call site,

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
@@ -97,12 +97,13 @@ public class GetDiagnosticsToolTests
         var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
         var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist("nuget-and-solution-bin", RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot: null);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        var ex = await Assert.ThrowsAsync<McpToolException>(async () =>
         {
             await GetDiagnosticsLogic.ExecuteAsync(
                 _loaded, _resolver, null, null, includeAnalyzers: true,
                 trustStore, allowlist, CancellationToken.None);
         });
+        Assert.Equal(ToolErrorCode.SolutionNotTrusted, ex.Code);
         Assert.Contains("not trusted", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("trust_solution", ex.Message, StringComparison.Ordinal);
     }

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
@@ -123,6 +123,26 @@ public class GetDiagnosticsToolTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_PreCancelledToken_ThrowsOperationCancelled()
+    {
+        using var tempFile = new TempTrustFile();
+        var trustStore = new RoslynCodeLens.Security.TrustStore(tempFile.Path);
+        trustStore.AddSessionTrust(_loaded.Solution.FilePath!);
+        var allowlist = new RoslynCodeLens.Security.AnalyzerAllowlist(
+            "nuget-and-solution-bin",
+            RoslynCodeLens.Security.AnalyzerAllowlist.DefaultNugetGlobal(),
+            dotnetSdkRoot: null);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await GetDiagnosticsLogic.ExecuteAsync(
+                _loaded, _resolver, null, null, includeAnalyzers: true,
+                trustStore, allowlist, cts.Token));
+    }
+
+    [Fact]
     public async Task GetDiagnostics_TrustedSolution_RunsAnalyzers()
     {
         using var tempFile = new TempTrustFile();

--- a/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
 
@@ -34,11 +35,12 @@ public class GetFileOverviewToolTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidFile_ReturnsNull()
+    public async Task ExecuteAsync_InvalidFile_ThrowsFileNotFound()
     {
-        var result = await GetFileOverviewLogic.ExecuteAsync(
-            _loaded, _resolver, "nonexistent.cs", CancellationToken.None);
+        var ex = await Assert.ThrowsAsync<McpToolException>(() =>
+            GetFileOverviewLogic.ExecuteAsync(
+                _loaded, _resolver, "nonexistent.cs", CancellationToken.None));
 
-        Assert.Null(result);
+        Assert.Equal(ToolErrorCode.FileNotFound, ex.Code);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSymbolContextToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -29,6 +30,15 @@ public class GetSymbolContextToolTests
         Assert.Contains(result.InjectedDependencies, d => d.Contains("IGreeter", StringComparison.Ordinal));
         Assert.Contains(result.PublicMembers, m => m.Contains("SayHello", StringComparison.Ordinal));
         Assert.Equal("source", result.Origin?.Kind);
+    }
+
+    [Fact]
+    public void GetContext_ForUnknownType_ThrowsSymbolNotFound()
+    {
+        var ex = Assert.Throws<McpToolException>(() =>
+            GetSymbolContextLogic.Execute(_loaded, _resolver, _metadata, "NonExistentType99"));
+
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeHierarchyToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -50,11 +51,12 @@ public class GetTypeHierarchyToolTests
     }
 
     [Fact]
-    public void GetHierarchy_ForUnknownType_ReturnsNull()
+    public void GetHierarchy_ForUnknownType_ThrowsSymbolNotFound()
     {
-        var result = GetTypeHierarchyLogic.Execute(_resolver, _metadata, "NonExistentType");
+        var ex = Assert.Throws<McpToolException>(() =>
+            GetTypeHierarchyLogic.Execute(_resolver, _metadata, "NonExistentType"));
 
-        Assert.Null(result);
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetTypeOverviewToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 using RoslynCodeLens.Tools;
 using RoslynCodeLens.Tests.Fixtures;
@@ -33,11 +34,12 @@ public class GetTypeOverviewToolTests
     }
 
     [Fact]
-    public void Execute_ForUnknownType_ReturnsNull()
+    public void Execute_ForUnknownType_ThrowsSymbolNotFound()
     {
-        var result = GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "NonExistentType99");
+        var ex = Assert.Throws<McpToolException>(() =>
+            GetTypeOverviewLogic.Execute(_loaded, _resolver, _metadata, "NonExistentType99"));
 
-        Assert.Null(result);
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/Tools/UnloadSolutionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/UnloadSolutionToolTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Models;
 using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Tools;
@@ -22,11 +23,12 @@ public class UnloadSolutionToolTests
     }
 
     [Fact]
-    public void Execute_UnknownName_PropagatesException()
+    public void Execute_UnknownName_ThrowsProjectNotFound()
     {
         var manager = MultiSolutionManager.CreateEmpty();
 
-        Assert.Throws<InvalidOperationException>(() => UnloadSolutionTool.Execute(manager, "DoesNotExist"));
+        var ex = Assert.Throws<McpToolException>(() => UnloadSolutionTool.Execute(manager, "DoesNotExist"));
+        Assert.Equal(ToolErrorCode.ProjectNotFound, ex.Code);
 
         manager.Dispose();
     }


### PR DESCRIPTION
## Summary

Two correlated correctness improvements for the MCP server's contract with LLM consumers:

1. **Structured error responses.** Every tool that can't proceed now throws `McpToolException` with a prescribed `ToolErrorCode` enum. The host-side `StructuredErrorToolWrapper` (a `DelegatingMcpServerTool` subclass) projects it to MCP's `CallToolResult { IsError = true, Content = [TextContentBlock(json)] }`. LLM consumers can switch on `code` instead of parsing free-form messages.

2. **Cancellation honored.** The MCP framework was already supplying `CancellationToken` to async tools, but only 8 of 24 actually threaded it through. Audited 11 high-latency async tools and inserted `ct.ThrowIfCancellationRequested()` at outermost hot loops. Also filtered four `catch (Exception ex)` blocks in `CodeActionRunner` / `CodeFixRunner` with `when (ex is not OperationCanceledException)` so OCE can propagate to the framework's native cancellation handler.

## Error code catalog

| Code | Common source |
|---|---|
| `SymbolNotFound` | `analyze_method`, `get_symbol_context`, `get_type_overview`, `get_type_hierarchy`, `generate_test_skeleton` |
| `SolutionNotTrusted` | `get_diagnostics` (`includeAnalyzers: true`), `get_code_fixes` |
| `AmbiguousMatch` | `set_active_solution`, `unload_solution` |
| `FileNotFound` | `get_file_overview`, `find_breaking_changes` |
| `ProjectNotFound` | `set_active_solution`, `unload_solution` |
| `InvalidArgument` | various |
| `Internal` | fallback for unmodeled exceptions |

## BREAKING CHANGES

Five tools that previously returned `T?` (with `null` signalling "lookup failed") now throw `McpToolException` with `SymbolNotFound` or `FileNotFound`:

- `analyze_method`
- `get_type_overview`
- `get_type_hierarchy`
- `get_symbol_context`
- `get_file_overview`

Callers expecting `null` now receive a structured error instead.

## Documents

- Design: `docs/plans/2026-05-26-structured-tool-errors-design.md`
- Plan: `docs/plans/2026-05-26-structured-tool-errors.md`

## Test plan

- [ ] CI green
- [ ] **Manual smoke (post-merge):** restart MCP server, call:
  - `set_active_solution("nonexistent")` → expect `isError: true` with `code: "ProjectNotFound"`
  - `get_diagnostics({ includeAnalyzers: true })` on untrusted solution → `code: "SolutionNotTrusted"`
  - `analyze_method("Foo.Nonexistent")` → `code: "SymbolNotFound"`

If any returns the old free-form message instead of structured JSON, the wrapper wiring is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)