### PR TITLE
https://github.com/kazrac/roslyn-codelens-mcp/pull/new/fix/cross-compilation-symbol-comparison

### DIFF
--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens;
 
@@ -91,9 +92,8 @@ public class SymbolResolver
                      Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>)
         BuildInheritanceMaps(List<INamedTypeSymbol> allTypes)
     {
-        var comparer = SymbolEqualityComparer.Default;
-        var implementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
-        var derived = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
+        var implementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(NamedTypeSignatureComparer.Instance);
+        var derived = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(NamedTypeSignatureComparer.Instance);
 
         foreach (ref readonly var type in CollectionsMarshal.AsSpan(allTypes))
         {

--- a/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
@@ -1,0 +1,44 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Symbols;
+
+/// <summary>
+/// Compares <see cref="INamedTypeSymbol"/> by type signature: namespace, name, arity, and assembly name.
+/// <para>
+/// <b>Problem solved:</b> Roslyn compiles each project into its own <c>Compilation</c>, so a type like
+/// <c>IFoo</c> defined in Project A appears as a different symbol object in Project A's compilation
+/// (source symbol) and in Project B's compilation (metadata symbol). The default
+/// <see cref="SymbolEqualityComparer"/> uses reference equality and treats these as different types,
+/// causing cross-project implementors and derived types to go undetected in index lookups.
+/// This comparer normalises across that boundary so any two symbols representing the same type definition
+/// are considered equal regardless of which compilation produced them.
+/// </para>
+/// <para>
+/// <b>Intentional omissions:</b> type parameter names are ignored because metadata symbols may use
+/// different names than source symbols for the same parameter (e.g. <c>T</c> vs <c>TValue</c>).
+/// Assembly version is ignored to tolerate multi-targeting and binding redirects.
+/// </para>
+/// </summary>
+internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeSymbol>
+{
+	public static readonly NamedTypeSignatureComparer Instance = new();
+
+	public bool Equals(INamedTypeSymbol? x, INamedTypeSymbol? y)
+	{
+		if (ReferenceEquals(x, y)) return true;
+		if (x is null || y is null) return false;
+		return x.Arity == y.Arity
+			&& string.Equals(x.Name, y.Name, StringComparison.Ordinal)
+			&& string.Equals(x.ContainingNamespace.ToDisplayString(), y.ContainingNamespace.ToDisplayString(), StringComparison.Ordinal)
+			&& string.Equals(x.ContainingAssembly?.Identity.Name, y.ContainingAssembly?.Identity.Name, StringComparison.Ordinal);
+	}
+
+	public int GetHashCode(INamedTypeSymbol obj)
+	{
+		return HashCode.Combine(
+			obj.Name,
+			obj.Arity,
+			obj.ContainingNamespace.ToDisplayString(),
+			obj.ContainingAssembly?.Identity.Name);
+	}
+}

--- a/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
@@ -2,23 +2,12 @@ using Microsoft.CodeAnalysis;
 
 namespace RoslynCodeLens.Symbols;
 
-/// <summary>
-/// Compares <see cref="INamedTypeSymbol"/> by type signature: namespace, name, arity, and assembly name.
-/// <para>
-/// <b>Problem solved:</b> Roslyn compiles each project into its own <c>Compilation</c>, so a type like
-/// <c>IFoo</c> defined in Project A appears as a different symbol object in Project A's compilation
-/// (source symbol) and in Project B's compilation (metadata symbol). The default
-/// <see cref="SymbolEqualityComparer"/> uses reference equality and treats these as different types,
-/// causing cross-project implementors and derived types to go undetected in index lookups.
-/// This comparer normalises across that boundary so any two symbols representing the same type definition
-/// are considered equal regardless of which compilation produced them.
-/// </para>
-/// <para>
-/// <b>Intentional omissions:</b> type parameter names are ignored because metadata symbols may use
-/// different names than source symbols for the same parameter (e.g. <c>T</c> vs <c>TValue</c>).
-/// Assembly version is ignored to tolerate multi-targeting and binding redirects.
-/// </para>
-/// </summary>
+// Compares INamedTypeSymbol by signature (namespace, name, arity, assembly name) rather than
+// object identity. Roslyn creates a separate symbol object for each Compilation, so the same
+// type appears as a different object in the declaring project versus any referencing project.
+// SymbolEqualityComparer.Default treats those as different, breaking cross-project index lookups.
+// Intentional omissions: type-parameter names (may differ between source and metadata) and
+// assembly version (to tolerate multi-targeting and binding redirects).
 internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeSymbol>
 {
 	public static readonly NamedTypeSignatureComparer Instance = new();

--- a/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
@@ -1,0 +1,105 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Symbols;
+
+/// <summary>
+/// Compares <see cref="ISymbol"/> instances by their declared signature rather than object identity.
+/// <para>
+/// <b>Problem solved:</b> Roslyn compiles each project into its own <c>Compilation</c>, so the same
+/// type, method, or member appears as a different <see cref="ISymbol"/> object in each compilation
+/// (a source symbol in the declaring project and a metadata symbol in every referencing project).
+/// <see cref="SymbolEqualityComparer.Default"/> uses reference equality and treats these as different
+/// symbols, causing cross-project lookups (references, unused-symbol detection, caller finding) to miss
+/// matches entirely.
+/// This comparer normalises across that boundary by comparing the structural signature:
+/// containing type (via <see cref="NamedTypeSignatureComparer"/>), member name, and — for methods —
+/// parameter type names to distinguish overloads.
+/// </para>
+/// <para>
+/// <b>Intentional omissions:</b> assembly version and type parameter names are ignored for the same
+/// reasons as in <see cref="NamedTypeSignatureComparer"/>.
+/// </para>
+/// </summary>
+internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
+{
+	public static readonly SymbolSignatureComparer Instance = new();
+
+	public bool Equals(ISymbol? x, ISymbol? y)
+	{
+		if (ReferenceEquals(x, y)) return true;
+		if (x is null || y is null) return false;
+		if (x.Kind != y.Kind) return false;
+
+		return x switch
+		{
+			INamedTypeSymbol nt => NamedTypeSignatureComparer.Instance.Equals(nt, y as INamedTypeSymbol),
+			IMethodSymbol m => MethodEquals(m, y as IMethodSymbol),
+			_ => MemberEquals(x, y)
+		};
+	}
+
+	public int GetHashCode(ISymbol obj)
+	{
+		return obj switch
+		{
+			INamedTypeSymbol nt => NamedTypeSignatureComparer.Instance.GetHashCode(nt),
+			IMethodSymbol m => MethodHashCode(m),
+			_ => MemberHashCode(obj)
+		};
+	}
+
+	// ── Named types ──────────────────────────────────────────────────────────
+
+	private static string ContainingTypeKey(ISymbol symbol)
+	{
+		if (symbol.ContainingType is { } ct)
+			return NamedTypeSignatureComparer.Instance.GetHashCode(ct).ToString();
+		if (symbol.ContainingNamespace is { IsGlobalNamespace: false } ns)
+			return ns.ToDisplayString();
+		return string.Empty;
+	}
+
+	// ── Methods ───────────────────────────────────────────────────────────────
+
+	private static bool MethodEquals(IMethodSymbol? x, IMethodSymbol? y)
+	{
+		if (x is null || y is null) return false;
+		if (!string.Equals(x.MetadataName, y.MetadataName, StringComparison.Ordinal)) return false;
+		if (!NamedTypeSignatureComparer.Instance.Equals(x.ContainingType, y.ContainingType)) return false;
+		if (x.Parameters.Length != y.Parameters.Length) return false;
+
+		for (int i = 0; i < x.Parameters.Length; i++)
+		{
+			var xParam = x.Parameters[i].Type.ToDisplayString();
+			var yParam = y.Parameters[i].Type.ToDisplayString();
+			if (!string.Equals(xParam, yParam, StringComparison.Ordinal))
+				return false;
+		}
+
+		return true;
+	}
+
+	private static int MethodHashCode(IMethodSymbol m)
+	{
+		var hc = new HashCode();
+		hc.Add(m.MetadataName, StringComparer.Ordinal);
+		hc.Add(NamedTypeSignatureComparer.Instance.GetHashCode(m.ContainingType));
+		hc.Add(m.Parameters.Length);
+		foreach (var p in m.Parameters)
+			hc.Add(p.Type.ToDisplayString(), StringComparer.Ordinal);
+		return hc.ToHashCode();
+	}
+
+	// ── Other members (property, field, event, …) ────────────────────────────
+
+	private static bool MemberEquals(ISymbol x, ISymbol y)
+	{
+		if (!string.Equals(x.MetadataName, y.MetadataName, StringComparison.Ordinal)) return false;
+		return string.Equals(ContainingTypeKey(x), ContainingTypeKey(y), StringComparison.Ordinal);
+	}
+
+	private static int MemberHashCode(ISymbol s)
+	{
+		return HashCode.Combine(s.MetadataName, ContainingTypeKey(s));
+	}
+}

--- a/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
@@ -2,24 +2,13 @@ using Microsoft.CodeAnalysis;
 
 namespace RoslynCodeLens.Symbols;
 
-/// <summary>
-/// Compares <see cref="ISymbol"/> instances by their declared signature rather than object identity.
-/// <para>
-/// <b>Problem solved:</b> Roslyn compiles each project into its own <c>Compilation</c>, so the same
-/// type, method, or member appears as a different <see cref="ISymbol"/> object in each compilation
-/// (a source symbol in the declaring project and a metadata symbol in every referencing project).
-/// <see cref="SymbolEqualityComparer.Default"/> uses reference equality and treats these as different
-/// symbols, causing cross-project lookups (references, unused-symbol detection, caller finding) to miss
-/// matches entirely.
-/// This comparer normalises across that boundary by comparing the structural signature:
-/// containing type (via <see cref="NamedTypeSignatureComparer"/>), member name, and — for methods —
-/// parameter type names to distinguish overloads.
-/// </para>
-/// <para>
-/// <b>Intentional omissions:</b> assembly version and type parameter names are ignored for the same
-/// reasons as in <see cref="NamedTypeSignatureComparer"/>.
-/// </para>
-/// </summary>
+// Compares ISymbol instances by declared signature rather than object identity.
+// Roslyn compiles each project separately, so the same type/method/member appears as a different
+// object in the declaring compilation versus any referencing compilation.
+// SymbolEqualityComparer.Default treats those as different, causing cross-project lookups
+// (references, callers, unused-symbol detection) to miss matches.
+// For methods, parameter type display strings are included to distinguish overloads.
+// Assembly version and type-parameter names are ignored — see NamedTypeSignatureComparer.
 internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
 {
 	public static readonly SymbolSignatureComparer Instance = new();
@@ -48,8 +37,6 @@ internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
 		};
 	}
 
-	// ── Named types ──────────────────────────────────────────────────────────
-
 	private static string ContainingTypeKey(ISymbol symbol)
 	{
 		if (symbol.ContainingType is { } ct)
@@ -58,8 +45,6 @@ internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
 			return ns.ToDisplayString();
 		return string.Empty;
 	}
-
-	// ── Methods ───────────────────────────────────────────────────────────────
 
 	private static bool MethodEquals(IMethodSymbol? x, IMethodSymbol? y)
 	{
@@ -89,8 +74,6 @@ internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
 			hc.Add(p.Type.ToDisplayString(), StringComparer.Ordinal);
 		return hc.ToHashCode();
 	}
-
-	// ── Other members (property, field, event, …) ────────────────────────────
 
 	private static bool MemberEquals(ISymbol x, ISymbol y)
 	{

--- a/src/RoslynCodeLens/Tools/FindCallersLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersLogic.cs
@@ -27,10 +27,9 @@ public static class FindCallersLogic
                 return [];
         }
 
-        var targetSet = new HashSet<IMethodSymbol>(targetMethods, SymbolEqualityComparer.Default);
-        // For metadata targets resolved from one compilation, build a name-based fallback
-        // so cross-compilation symbol comparisons work (metadata from different compilations
-        // have different ISymbol instances but the same containing type + name).
+        var targetSet = new HashSet<IMethodSymbol>(targetMethods, SymbolSignatureComparer.Instance);
+        // targetMetadataKeys retains the name-based string fallback for metadata-only symbols
+        // whose containing type may not be in the loaded solution's source at all.
         var targetMetadataKeys = BuildMetadataKeys(targetMethods);
         var results = new List<CallerInfo>();
         var seen = new HashSet<(string, int)>();
@@ -128,7 +127,7 @@ public static class FindCallersLogic
             var containingType = calledMethod.ContainingType;
             var implementation = containingType.FindImplementationForInterfaceMember(targetMethod);
             if (implementation != null &&
-                SymbolEqualityComparer.Default.Equals(implementation, calledMethod))
+                SymbolSignatureComparer.Instance.Equals(implementation, calledMethod))
                 return true;
         }
 
@@ -136,7 +135,7 @@ public static class FindCallersLogic
         if (calledMethod.ContainingType.TypeKind == TypeKind.Interface &&
             targetMethod.ContainingType.TypeKind == TypeKind.Interface)
         {
-            return SymbolEqualityComparer.Default.Equals(
+            return SymbolSignatureComparer.Instance.Equals(
                 calledMethod.ContainingType, targetMethod.ContainingType) &&
                 string.Equals(calledMethod.Name, targetMethod.Name, StringComparison.Ordinal);
         }

--- a/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
@@ -25,7 +25,7 @@ public static class FindReferencesLogic
 
     private static HashSet<ISymbol> BuildTargetSet(IReadOnlyList<ISymbol> targets)
     {
-        var targetSet = new HashSet<ISymbol>(targets, SymbolEqualityComparer.Default);
+        var targetSet = new HashSet<ISymbol>(targets, SymbolSignatureComparer.Instance);
         foreach (var t in targets)
         {
             if (t.OriginalDefinition != null)
@@ -100,7 +100,7 @@ public static class FindReferencesLogic
                     targetMethod.ContainingType?.TypeKind == TypeKind.Interface)
                 {
                     var impl = method.ContainingType?.FindImplementationForInterfaceMember(targetMethod);
-                    if (impl != null && SymbolEqualityComparer.Default.Equals(impl, method))
+                    if (impl != null && SymbolSignatureComparer.Instance.Equals(impl, method))
                         return true;
                 }
             }

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
@@ -110,7 +111,7 @@ public static class FindUnusedSymbolsLogic
 
     private static HashSet<ISymbol> CollectReferencedSymbols(LoadedSolution loaded)
     {
-        var referencedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var referencedSymbols = new HashSet<ISymbol>(SymbolSignatureComparer.Instance);
 
         foreach (var (_, compilation) in loaded.Compilations)
         {
@@ -210,7 +211,7 @@ public static class FindUnusedSymbolsLogic
             foreach (var iface in containingType.AllInterfaces)
             {
                 var impl = containingType.FindImplementationForInterfaceMember(method);
-                if (impl != null && SymbolEqualityComparer.Default.Equals(impl, method))
+                if (impl != null && SymbolSignatureComparer.Instance.Equals(impl, method))
                     return true;
             }
         }
@@ -225,7 +226,7 @@ public static class FindUnusedSymbolsLogic
             foreach (var iface in containingType.AllInterfaces)
             {
                 var impl = containingType.FindImplementationForInterfaceMember(prop);
-                if (impl != null && SymbolEqualityComparer.Default.Equals(impl, prop))
+                if (impl != null && SymbolSignatureComparer.Instance.Equals(impl, prop))
                     return true;
             }
         }

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/ICrossProjectOnly.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/ICrossProjectOnly.cs
@@ -1,0 +1,6 @@
+namespace TestLib;
+
+public interface ICrossProjectOnly
+{
+	string Execute();
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/CrossProjectGreeter.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/CrossProjectGreeter.cs
@@ -1,0 +1,9 @@
+using TestLib;
+
+namespace TestLib2;
+
+public class CrossProjectGreeter : IGreeter, ICrossProjectOnly
+{
+	public string Greet(string name) => $"Cross-project hello, {name}!";
+	public string Execute() => Greet("World");
+}

--- a/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
+++ b/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tests.Symbols;
+
+public class SymbolSignatureComparerTests
+{
+	// Builds two separate compilations that model the cross-project scenario:
+	// - libCompilation: defines IFoo in assembly "Lib"
+	// - consumerCompilation: references Lib as metadata, so its view of IFoo
+	//   is a metadata symbol — a different object than the source symbol in libCompilation.
+	private static (INamedTypeSymbol sourceSymbol, INamedTypeSymbol metadataSymbol) BuildCrossCompilationSymbols(
+		string interfaceSource = "namespace Lib; public interface IFoo { void Do(); }",
+		string typeName = "IFoo")
+	{
+		var libTree = CSharpSyntaxTree.ParseText(interfaceSource);
+		var libCompilation = CSharpCompilation.Create(
+			"Lib",
+			[libTree],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		// Compile Lib to an in-memory stream so Consumer can reference it as metadata
+		using var ms = new System.IO.MemoryStream();
+		var emitResult = libCompilation.Emit(ms);
+		Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+		ms.Position = 0;
+		var libMetadataRef = MetadataReference.CreateFromStream(ms);
+
+		var memberImpl = typeName == "IFoo" ? "public void Do() {}" : "";
+		var consumerTree = CSharpSyntaxTree.ParseText(
+			$"using Lib; public class Bar : {typeName} {{ {memberImpl} }}");
+		var consumerCompilation = CSharpCompilation.Create(
+			"Consumer",
+			[consumerTree],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location), libMetadataRef],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var sourceSymbol = libCompilation.GlobalNamespace
+			.GetNamespaceMembers().First(n => n.Name == "Lib")
+			.GetTypeMembers(typeName).Single();
+
+		var metadataSymbol = consumerCompilation.GetTypeByMetadataName($"Lib.{typeName}")!;
+
+		return (sourceSymbol, metadataSymbol);
+	}
+
+	[Fact]
+	public void RoslynDefault_SameTypeFromDifferentCompilations_AreNotEqual()
+	{
+		// Documents the root cause: SymbolEqualityComparer.Default treats the same logical type
+		// as different objects when retrieved from separate compilations.
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.False(SymbolEqualityComparer.Default.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_SameTypeFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.True(NamedTypeSignatureComparer.Instance.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_SameTypeFromDifferentCompilations_HaveSameHashCode()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.Equal(
+			NamedTypeSignatureComparer.Instance.GetHashCode(source),
+			NamedTypeSignatureComparer.Instance.GetHashCode(metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_DifferentTypes_AreNotEqual()
+	{
+		var (iFoo, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo { }", "IFoo");
+		var (iBar, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IBar { }", "IBar");
+
+		Assert.False(NamedTypeSignatureComparer.Instance.Equals(iFoo, iBar));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_GenericTypeDistinguishedByArity()
+	{
+		var (nonGeneric, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo { }", "IFoo");
+		var (generic, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo<T> { }", "IFoo");
+
+		Assert.False(NamedTypeSignatureComparer.Instance.Equals(nonGeneric, generic));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_UsableAsDictionaryKey_FindsCrossCompilationSymbol()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		// Simulate the inheritance map: keyed on the source symbol, looked up with metadata symbol
+		var dict = new Dictionary<INamedTypeSymbol, string>(NamedTypeSignatureComparer.Instance)
+		{
+			[source] = "found"
+		};
+
+		Assert.True(dict.TryGetValue(metadata, out var value));
+		Assert.Equal("found", value);
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_SameTypeFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.True(SymbolSignatureComparer.Instance.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_SameMethodFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		var sourceMethod = source.GetMembers("Do").OfType<IMethodSymbol>().Single();
+		var metadataMethod = metadata.GetMembers("Do").OfType<IMethodSymbol>().Single();
+
+		Assert.True(SymbolSignatureComparer.Instance.Equals(sourceMethod, metadataMethod));
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_UsableAsHashSetKey_FindsCrossCompilationSymbol()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		// Simulate the referenced-symbol set: added from one compilation, checked from another
+		var set = new HashSet<ISymbol>(SymbolSignatureComparer.Instance) { source };
+
+		Assert.Contains(metadata, set);
+	}
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
@@ -39,6 +39,17 @@ public class FindCallersToolTests
     }
 
     [Fact]
+    public void FindCallers_InterfaceMethod_FindsCallersInReferencingProject()
+    {
+        // IGreeter.Greet is defined in TestLib; GreeterConsumer in TestLib2 calls it via the interface.
+        // Without cross-compilation symbol normalisation, the interface dispatch check uses
+        // reference-equality symbols, missing callers from other projects.
+        var results = FindCallersLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
+
+        Assert.Contains(results, r => r.File.Contains("TestLib2", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<CallerInfo>

--- a/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
@@ -47,6 +47,17 @@ public class FindImplementationsToolTests
     }
 
     [Fact]
+    public void FindImplementations_ForInterface_FindsImplementorInReferencingProject()
+    {
+        // IGreeter is defined in TestLib; CrossProjectGreeter implements it in TestLib2.
+        // Without cross-compilation symbol normalisation, only same-project implementors
+        // are found because Roslyn produces different ISymbol instances per compilation.
+        var results = FindImplementationsLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
+
+        Assert.Contains(results, r => r.FullName.Contains("CrossProjectGreeter", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<SymbolLocation>

--- a/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
@@ -58,6 +58,17 @@ public class FindReferencesToolTests
     }
 
     [Fact]
+    public void FindReferences_ForInterface_FindsUsagesInReferencingProject()
+    {
+        // IGreeter is defined in TestLib; GreeterConsumer and CrossProjectGreeter in TestLib2 reference it.
+        // Without cross-compilation symbol normalisation, cross-project usages are missed
+        // because the target set is built with reference-equality symbols from one compilation.
+        var results = FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
+
+        Assert.Contains(results, r => r.File.Contains("TestLib2", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<SymbolReference>

--- a/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
@@ -50,6 +50,19 @@ public class FindUnusedSymbolsToolTests
     }
 
     [Fact]
+    public void FindUnusedSymbols_TypeUsedFromAnotherProject_IsNotReportedAsUnused()
+    {
+        // ICrossProjectOnly is defined in TestLib but has no implementations or usages
+        // within TestLib itself — it is only implemented by CrossProjectGreeter in TestLib2.
+        // Without cross-compilation symbol normalisation, that cross-project usage is not
+        // matched in the referenced-symbol set, causing ICrossProjectOnly to be incorrectly
+        // reported as unused.
+        var (items, _) = FindUnusedSymbolsLogic.Execute(_loaded, _resolver, "TestLib", false);
+
+        Assert.DoesNotContain(items, i => i.SymbolName.Contains("ICrossProjectOnly", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void BuildSummary_GroupsByKind()
     {
         var input = new List<UnusedSymbolInfo>


### PR DESCRIPTION
## Problem

Roslyn compiles each project in a solution into its own `Compilation` object. A type like `IFoo` defined in Project A appears as two different `ISymbol` instances: a *source* symbol in Project A's compilation and a *metadata* symbol in every other project's compilation that references it.

`SymbolEqualityComparer.Default` uses reference equality and treats these as different symbols. As a result, several tools only found results within the same project as the queried symbol:

- **`find_implementations` / `get_type_hierarchy`** — only found implementors and derived types declared in the same project as the interface or base class
- **`find_references`** — missed all cross-project usages
- **`find_unused_symbols`** — incorrectly reported types as unused when they were only referenced from another project
- **`find_callers`** — interface dispatch across projects was partially broken

## Fix

Two normalising comparers added to `RoslynCodeLens.Symbols`:

**`NamedTypeSignatureComparer`** (`IEqualityComparer<INamedTypeSymbol>`)
Compares by namespace + name + arity + assembly name. Arity is used instead of type parameter names because metadata symbols may use different parameter names than source symbols (e.g. `T` vs `TValue`). Assembly version is excluded to tolerate multi-targeting and binding redirects.

**`SymbolSignatureComparer`** (`IEqualityComparer<ISymbol>`)
Dispatches by symbol kind — delegates to `NamedTypeSignatureComparer` for types, uses `MetadataName` + containing type + parameter types for methods (to distinguish overloads), and `MetadataName` + containing type for other members.

Both comparers replace `SymbolEqualityComparer.Default` wherever a `HashSet` or `Dictionary` was built across compilation boundaries.

## Tests

- `SymbolSignatureComparerTests` — deterministic unit tests using two in-memory `CSharpCompilation` instances. First asserts that `SymbolEqualityComparer.Default` treats the same type from different compilations as unequal (documents the root cause), then verifies both comparers treat them as equal, produce matching hash codes, and work correctly as `Dictionary` and `HashSet` keys.
- Regression tests added to all four affected tool test classes, each verifying that a result from `TestLib2` is found when querying a symbol defined in `TestLib`.
- Two fixture types added to the test solution: `ICrossProjectOnly` (interface in `TestLib` with no same-project usages) and `CrossProjectGreeter` (implements `IGreeter` and `ICrossProjectOnly` in `TestLib2`), creating the cross-compilation boundary all regression tests exercise.