### PR TITLE
fix(find_references, find_callers): use SymbolFinder for cross-compilation symbol identity

### DIFF
--- a/src/RoslynCodeLens/Tools/FindCallersLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersLogic.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 
@@ -27,43 +28,43 @@ public static class FindCallersLogic
                 return [];
         }
 
-        var targetSet = new HashSet<IMethodSymbol>(targetMethods, SymbolEqualityComparer.Default);
-        // For metadata targets resolved from one compilation, build a name-based fallback
-        // so cross-compilation symbol comparisons work (metadata from different compilations
-        // have different ISymbol instances but the same containing type + name).
-        var targetMetadataKeys = BuildMetadataKeys(targetMethods);
         var results = new List<CallerInfo>();
         var seen = new HashSet<(string, int)>();
 
-        foreach (var (projectId, compilation) in loaded.Compilations)
+        foreach (var target in targetMethods)
         {
-            var projectName = source.GetProjectName(projectId);
+            // Roslyn's SymbolFinder.FindCallersAsync handles cross-compilation symbol
+            // identity, virtual-dispatch cascading, and interface→implementation matching.
+            var callerInfos = SymbolFinder.FindCallersAsync(target, loaded.Solution)
+                .GetAwaiter().GetResult();
 
-            foreach (var syntaxTree in compilation.SyntaxTrees)
+            foreach (var callerInfo in callerInfos)
             {
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
-                var root = syntaxTree.GetRoot();
-
-                foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+                foreach (var location in callerInfo.Locations)
                 {
-                    var symbolInfo = semanticModel.GetSymbolInfo(invocation);
-                    if (symbolInfo.Symbol is not IMethodSymbol calledMethod)
+                    var sourceTree = location.SourceTree;
+                    if (sourceTree == null)
                         continue;
 
-                    if (!IsMethodMatch(calledMethod, targetSet, targetMethods, targetMetadataKeys))
-                        continue;
-
-                    var lineSpan = invocation.GetLocation().GetLineSpan();
+                    var lineSpan = location.GetLineSpan();
                     var file = lineSpan.Path;
                     var line = lineSpan.StartLinePosition.Line + 1;
 
                     if (!seen.Add((file, line)))
                         continue;
 
-                    var callerName = GetCallerName(invocation);
-                    var snippet = invocation.ToString();
+                    var node = sourceTree.GetRoot().FindNode(location.SourceSpan);
+                    var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+                    var snippet = (invocation ?? node).ToString();
+                    var callerName = GetCallerName(callerInfo.CallingSymbol, invocation ?? node);
 
-                    results.Add(new CallerInfo(callerName, file, line, snippet, projectName, source.IsGenerated(file)));
+                    var document = loaded.Solution.GetDocument(sourceTree);
+                    var projectName = document != null
+                        ? source.GetProjectName(document.Project.Id)
+                        : string.Empty;
+
+                    results.Add(new CallerInfo(
+                        callerName, file, line, snippet, projectName, source.IsGenerated(file)));
                 }
             }
         }
@@ -71,81 +72,11 @@ public static class FindCallersLogic
         return results;
     }
 
-    private static HashSet<string> BuildMetadataKeys(IReadOnlyList<IMethodSymbol> methods)
+    private static string GetCallerName(ISymbol? callingSymbol, SyntaxNode node)
     {
-        var keys = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var m in methods)
-        {
-            if (m.Locations.All(l => !l.IsInSource))
-            {
-                var typeName = m.ContainingType?.ToDisplayString() ?? string.Empty;
-                keys.Add($"{typeName}.{m.Name}");
-            }
-        }
-        return keys;
-    }
+        if (callingSymbol is IMethodSymbol caller && caller.ContainingType != null)
+            return $"{caller.ContainingType.Name}.{caller.Name}";
 
-    private static bool IsMethodMatch(
-        IMethodSymbol calledMethod,
-        HashSet<IMethodSymbol> targetSet,
-        IReadOnlyList<IMethodSymbol> targetMethods,
-        HashSet<string> targetMetadataKeys)
-    {
-        if (targetSet.Contains(calledMethod) || targetSet.Contains(calledMethod.OriginalDefinition))
-            return true;
-
-        // Cross-compilation fallback for metadata symbols: compare by containing type name + method name
-        if (targetMetadataKeys.Count > 0 && calledMethod.Locations.All(l => !l.IsInSource))
-        {
-            var typeName = (calledMethod.OriginalDefinition.ContainingType ?? calledMethod.ContainingType)
-                ?.ToDisplayString() ?? string.Empty;
-            if (targetMetadataKeys.Contains($"{typeName}.{calledMethod.Name}"))
-                return true;
-        }
-
-        for (int i = 0; i < targetMethods.Count; i++)
-        {
-            if (!string.Equals(calledMethod.Name, targetMethods[i].Name, StringComparison.Ordinal))
-                continue;
-            if (IsInterfaceImplementation(calledMethod, targetMethods[i]))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static bool IsInterfaceImplementation(IMethodSymbol calledMethod, IMethodSymbol targetMethod)
-    {
-        // If the target is an interface method, check if the called method's containing type
-        // implements that interface and the call resolves through the interface
-        if (targetMethod.ContainingType.TypeKind == TypeKind.Interface)
-        {
-            // Direct interface call: calledMethod is the interface method itself
-            if (SymbolEqualityComparer.Default.Equals(calledMethod, targetMethod))
-                return true;
-
-            // Check if calledMethod implements the target interface method
-            var containingType = calledMethod.ContainingType;
-            var implementation = containingType.FindImplementationForInterfaceMember(targetMethod);
-            if (implementation != null &&
-                SymbolEqualityComparer.Default.Equals(implementation, calledMethod))
-                return true;
-        }
-
-        // If the called method is an interface method, check if it matches the target
-        if (calledMethod.ContainingType.TypeKind == TypeKind.Interface &&
-            targetMethod.ContainingType.TypeKind == TypeKind.Interface)
-        {
-            return SymbolEqualityComparer.Default.Equals(
-                calledMethod.ContainingType, targetMethod.ContainingType) &&
-                string.Equals(calledMethod.Name, targetMethod.Name, StringComparison.Ordinal);
-        }
-
-        return false;
-    }
-
-    private static string GetCallerName(SyntaxNode node)
-    {
         var method = node.Ancestors().OfType<MethodDeclarationSyntax>().FirstOrDefault();
         var type = node.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
 

--- a/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Symbols;
 
@@ -19,55 +20,47 @@ public static class FindReferencesLogic
             targets = [resolved.Symbol];
         }
 
-        var targetSet = BuildTargetSet(targets);
-        return ScanForReferences(loaded, source, targetSet);
-    }
-
-    private static HashSet<ISymbol> BuildTargetSet(IReadOnlyList<ISymbol> targets)
-    {
-        var targetSet = new HashSet<ISymbol>(targets, SymbolEqualityComparer.Default);
-        foreach (var t in targets)
-        {
-            if (t.OriginalDefinition != null)
-                targetSet.Add(t.OriginalDefinition);
-        }
-        return targetSet;
+        return ScanForReferences(loaded, source, targets);
     }
 
     private static List<SymbolReference> ScanForReferences(
-        LoadedSolution loaded, SymbolResolver resolver, HashSet<ISymbol> targetSet)
+        LoadedSolution loaded, SymbolResolver resolver, IReadOnlyList<ISymbol> targets)
     {
         var results = new List<SymbolReference>();
         var seen = new HashSet<(string, int)>();
 
-        foreach (var (projectId, compilation) in loaded.Compilations)
+        foreach (var target in targets)
         {
-            var projectName = resolver.GetProjectName(projectId);
+            // Roslyn's SymbolFinder handles cross-compilation symbol identity, generic
+            // constructions, partial-class merges, and metadata-vs-source symbol unification.
+            // A hand-rolled walk that compares with SymbolEqualityComparer.Default misses
+            // references in downstream projects when the consuming compilation observes the
+            // same logical symbol as a distinct ISymbol instance.
+            var references = SymbolFinder.FindReferencesAsync(target, loaded.Solution)
+                .GetAwaiter().GetResult();
 
-            foreach (var syntaxTree in compilation.SyntaxTrees)
+            foreach (var referencedSymbol in references)
             {
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
-                var root = syntaxTree.GetRoot();
-
-                foreach (var node in root.DescendantNodes())
+                foreach (var location in referencedSymbol.Locations)
                 {
-                    var (referencedSymbol, kind) = ResolveNodeSymbol(node, semanticModel);
-
-                    if (referencedSymbol == null)
+                    var sourceTree = location.Location.SourceTree;
+                    if (sourceTree == null)
                         continue;
 
-                    if (!IsMatch(referencedSymbol, targetSet))
-                        continue;
-
-                    var lineSpan = node.GetLocation().GetLineSpan();
+                    var lineSpan = location.Location.GetLineSpan();
                     var file = lineSpan.Path;
                     var line = lineSpan.StartLinePosition.Line + 1;
 
                     if (!seen.Add((file, line)))
                         continue;
 
+                    var node = sourceTree.GetRoot().FindNode(location.Location.SourceSpan);
+                    var kind = ClassifyReferenceNode(node);
                     var snippet = GetContainingStatement(node);
-                    results.Add(new SymbolReference(kind, file, line, snippet, projectName, resolver.IsGenerated(file)));
+                    var projectName = resolver.GetProjectName(location.Document.Project.Id);
+
+                    results.Add(new SymbolReference(
+                        kind, file, line, snippet, projectName, resolver.IsGenerated(file)));
                 }
             }
         }
@@ -75,37 +68,17 @@ public static class FindReferencesLogic
         return results;
     }
 
-    private static (ISymbol? Symbol, string Kind) ResolveNodeSymbol(SyntaxNode node, SemanticModel semanticModel)
+    private static string ClassifyReferenceNode(SyntaxNode node)
     {
-        return node switch
-        {
-            IdentifierNameSyntax identifier => (semanticModel.GetSymbolInfo(identifier).Symbol, ClassifyReference(identifier)),
-            GenericNameSyntax genericName => (semanticModel.GetSymbolInfo(genericName).Symbol, "type_argument"),
-            _ => (null, "usage")
-        };
-    }
+        var identifier = node as IdentifierNameSyntax
+            ?? node.FirstAncestorOrSelf<IdentifierNameSyntax>();
+        if (identifier != null)
+            return ClassifyReference(identifier);
 
-    private static bool IsMatch(ISymbol candidate, HashSet<ISymbol> targets)
-    {
-        if (targets.Contains(candidate))
-            return true;
-        if (candidate.OriginalDefinition != null && targets.Contains(candidate.OriginalDefinition))
-            return true;
-        // For interface implementations
-        if (candidate is IMethodSymbol method)
-        {
-            foreach (var target in targets)
-            {
-                if (target is IMethodSymbol targetMethod &&
-                    targetMethod.ContainingType?.TypeKind == TypeKind.Interface)
-                {
-                    var impl = method.ContainingType?.FindImplementationForInterfaceMember(targetMethod);
-                    if (impl != null && SymbolEqualityComparer.Default.Equals(impl, method))
-                        return true;
-                }
-            }
-        }
-        return false;
+        if (node is GenericNameSyntax || node.FirstAncestorOrSelf<GenericNameSyntax>() != null)
+            return "type_argument";
+
+        return "usage";
     }
 
     private static string ClassifyReference(IdentifierNameSyntax identifier)
@@ -118,6 +91,7 @@ public static class FindReferencesLogic
             TypeConstraintSyntax => "type_constraint",
             BaseTypeSyntax => "base_type",
             ObjectCreationExpressionSyntax => "instantiation",
+            TypeArgumentListSyntax => "type_argument",
             _ => "usage"
         };
     }


### PR DESCRIPTION
## Summary

`find_references` and `find_callers` miss references in downstream projects on larger solutions. Both tools previously walked every compilation by hand and matched symbols with `SymbolEqualityComparer.Default`. That comparison does not reliably treat the same logical symbol as equal across compilation boundaries when the consuming compilation observes it as a distinct `ISymbol` instance — common in larger solutions where `ProjectReference` chains, `partial class` definitions, or generic constructions cause Roslyn to surface multiple symbol instances for one logical type.

Replaces the hand-rolled walks with Roslyn's canonical `SymbolFinder.FindReferencesAsync` / `SymbolFinder.FindCallersAsync`. Preserves the existing classification + snippet + per-line-dedup envelope by re-walking the syntax node at each returned location.

## Root cause

[`FindReferencesLogic.Execute`](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/blob/main/src/RoslynCodeLens/Tools/FindReferencesLogic.cs) iterates every project compilation and asks the semantic model for each node's symbol, then compares against the target set with `SymbolEqualityComparer.Default`. When a downstream project consumes a type via `ProjectReference`, `GetSymbolInfo` returns the type as resolved in *its own* compilation; that `ISymbol` instance is not equal to the target obtained from the defining project's compilation under default semantics in larger workspaces. Result: hits inside the defining project succeed, hits downstream silently fail.

[`FindCallersLogic.Execute`](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/blob/main/src/RoslynCodeLens/Tools/FindCallersLogic.cs) has the same hand-roll. The existing `targetMetadataKeys` name-based fallback only fires when the target itself is from metadata, so source-defined methods used cross-project miss.

The repo's own design docs for `get_call_graph` and closed-source assembly support already recommend `SymbolFinder.FindReferencesAsync` — `GetCallGraphLogic` uses it. This PR aligns `find_references` and `find_callers` with that pattern.

## Reproduction

Real-world repro: a 99-project .NET 10 solution with `<DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>`. Target type \`FilterSearchProductUpdated\` (Avro-generated \`public partial class\`) used as a generic type argument (\`IKafkaProducer<int, FilterSearchProductUpdated>\`, \`IKafkaMessageBatchConsumer<int, FilterSearchProductUpdated>\`) across project boundaries.

| Query | Before | After (this PR) | Ground truth |
|---|---|---|---|
| \`find_references(\"FilterSearchProductUpdated\")\` | 6 refs / 1 project | 18 refs / 3 projects | 18 refs / 3 projects |
| \`find_callers(\"FilterSearchProductUpdatedProducer.ProduceUpdatesAsync\")\` | 0 | (expected) ≥1 | ≥1 |
| \`analyze_change_impact(\"FilterSearchProductUpdated\")\` | 6 refs / 0 callers | (inherited) fixed | full graph |

Ground truth verified independently against another Roslyn-backed implementation.

## Test status

Local run of \`FindReferencesToolTests\` + \`FindCallersToolTests\` on this branch:

- **8/10 pass** (same as baseline)
- **2/10 fail** — \`FindReferences_MetadataInterface_FindsSourceUsages\` and \`FindCallers_MetadataExtensionMethod_FindsSourceInvocations\`. Both fail identically on \`main\` and on this branch. These appear to be pre-existing failures in the metadata-resolver path (different code path from the source-symbol case fixed here) and are out of scope for this PR.

The full test suite has 48 pre-existing failures on a clean \`main\` clone in this environment (macOS, .NET 10.0.102) — none in the FindReferences/FindCallers area beyond the 2 above. Those are likely environment-specific and orthogonal to this change; I left them untouched.

## Limitation: no new regression test

The existing test fixture (\`TestLib\` + \`TestLib2\`, two projects connected by direct \`ProjectReference\`) is small enough that Roslyn cleanly unifies symbols across compilations, so neither the bug nor the fix changes behavior on it — the source-level cross-project tests pass on baseline as well as on this branch. Constructing a fixture that reliably triggers the cross-compilation symbol-identity issue in a unit test isn't straightforward (it depends on project graph size, build output state, and metadata-vs-source resolution path).

Open to suggestions: either an integration-style test that loads a synthetic many-project solution, or accepting the real-world repro above as justification. Happy to add whichever shape you prefer.

## Diff size

\`src/RoslynCodeLens/Tools/FindReferencesLogic.cs\`: -94 / +44
\`src/RoslynCodeLens/Tools/FindCallersLogic.cs\`: -58 / +13
Net: -95 lines. Behavior preserved on the existing test fixture; correctness improved on larger solutions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)