### PR TITLE
fix(bg-tasks): set Result/ErrorCode/ErrorMessage before flipping Status to terminal

### DIFF
--- a/src/RoslynCodeLens/BackgroundTasks/BackgroundTaskStore.cs
+++ b/src/RoslynCodeLens/BackgroundTasks/BackgroundTaskStore.cs
@@ -34,8 +34,8 @@ public sealed class BackgroundTaskStore : IDisposable
             try
             {
                 var result = await work(task.Cts.Token).ConfigureAwait(false);
-                task.Status = BackgroundTaskStatus.Succeeded;
                 task.Result = result;
+                task.Status = BackgroundTaskStatus.Succeeded;
             }
             catch (OperationCanceledException)
             {
@@ -43,15 +43,18 @@ public sealed class BackgroundTaskStore : IDisposable
             }
             catch (McpToolException mcpEx)
             {
-                task.Status = BackgroundTaskStatus.Failed;
+                // Populate payload fields *before* the terminal Status flip so a
+                // polling consumer that observes Status != Running cannot also
+                // observe null ErrorCode/ErrorMessage.
                 task.ErrorCode = mcpEx.Code.ToString();
                 task.ErrorMessage = mcpEx.Message;
+                task.Status = BackgroundTaskStatus.Failed;
             }
             catch (Exception ex)
             {
-                task.Status = BackgroundTaskStatus.Failed;
                 task.ErrorCode = nameof(ToolErrorCode.Internal);
                 task.ErrorMessage = ex.Message;
+                task.Status = BackgroundTaskStatus.Failed;
             }
             finally
             {


### PR DESCRIPTION
## Problem

`BackgroundTaskStoreTests.Start_FailedTask_GenericException_DefaultsToInternalCode` flaked on PR #211's CI run:
```
Expected: "boom"
Actual:   null
```

The test polls `BackgroundTaskStore.Get(taskId)` every 20ms and returns the first snapshot where `Status != Running`. The polled snapshot showed `Status=Failed` but `ErrorMessage=null`.

## Root cause

`BackgroundTaskStore.Start`'s background `Task.Run` block writes `Status = Failed` **before** writing `ErrorCode` and `ErrorMessage`:

```csharp
catch (Exception ex)
{
    task.Status = BackgroundTaskStatus.Failed;   // <-- terminal status written first
    task.ErrorCode = nameof(ToolErrorCode.Internal);
    task.ErrorMessage = ex.Message;              // <-- payload written second
}
```

A polling reader on another thread that observes `Status != Running` can race the second/third write and read null for the payload. Same race exists in the success path (`Status` set before `Result`) and the `McpToolException` path.

## Fix

Reorder so payload fields are written **before** the terminal Status flip. After the change, any reader that observes a non-Running Status is guaranteed (program-order on the writer thread) to see the payload that belongs with it.

```csharp
catch (Exception ex)
{
    task.ErrorCode = nameof(ToolErrorCode.Internal);
    task.ErrorMessage = ex.Message;
    task.Status = BackgroundTaskStatus.Failed;   // <-- now last
}
```

No allocation, no locking — just write ordering.

## Notes

- A fully race-free fix would add a memory barrier (`Volatile.Write` on `Status`) or wrap the assignments in a `lock`. The reorder alone is sufficient for the test's behavior; if you want belt-and-suspenders, happy to add the barrier in a follow-up.
- This was surfaced by #211's CI run and is unrelated to that PR's changes.
