### PR TITLE
feat(symbols): SymbolSignatureComparer for cross-compilation identity (from @kazrac's #210)

### DIFF
--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens;
 
@@ -91,9 +92,8 @@ public class SymbolResolver
                      Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>)
         BuildInheritanceMaps(List<INamedTypeSymbol> allTypes)
     {
-        var comparer = SymbolEqualityComparer.Default;
-        var implementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
-        var derived = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(comparer);
+        var implementors = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(NamedTypeSignatureComparer.Instance);
+        var derived = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(NamedTypeSignatureComparer.Instance);
 
         foreach (ref readonly var type in CollectionsMarshal.AsSpan(allTypes))
         {

--- a/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
@@ -1,0 +1,33 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Symbols;
+
+// Compares INamedTypeSymbol by signature (namespace, name, arity, assembly name) rather than
+// object identity. Roslyn creates a separate symbol object for each Compilation, so the same
+// type appears as a different object in the declaring project versus any referencing project.
+// SymbolEqualityComparer.Default treats those as different, breaking cross-project index lookups.
+// Intentional omissions: type-parameter names (may differ between source and metadata) and
+// assembly version (to tolerate multi-targeting and binding redirects).
+internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeSymbol>
+{
+	public static readonly NamedTypeSignatureComparer Instance = new();
+
+	public bool Equals(INamedTypeSymbol? x, INamedTypeSymbol? y)
+	{
+		if (ReferenceEquals(x, y)) return true;
+		if (x is null || y is null) return false;
+		return x.Arity == y.Arity
+			&& string.Equals(x.Name, y.Name, StringComparison.Ordinal)
+			&& string.Equals(x.ContainingNamespace.ToDisplayString(), y.ContainingNamespace.ToDisplayString(), StringComparison.Ordinal)
+			&& string.Equals(x.ContainingAssembly?.Identity.Name, y.ContainingAssembly?.Identity.Name, StringComparison.Ordinal);
+	}
+
+	public int GetHashCode(INamedTypeSymbol obj)
+	{
+		return HashCode.Combine(
+			obj.Name,
+			obj.Arity,
+			obj.ContainingNamespace.ToDisplayString(),
+			obj.ContainingAssembly?.Identity.Name);
+	}
+}

--- a/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/SymbolSignatureComparer.cs
@@ -1,0 +1,88 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Symbols;
+
+// Compares ISymbol instances by declared signature rather than object identity.
+// Roslyn compiles each project separately, so the same type/method/member appears as a different
+// object in the declaring compilation versus any referencing compilation.
+// SymbolEqualityComparer.Default treats those as different, causing cross-project lookups
+// (references, callers, unused-symbol detection) to miss matches.
+// For methods, parameter type display strings are included to distinguish overloads.
+// Assembly version and type-parameter names are ignored — see NamedTypeSignatureComparer.
+internal sealed class SymbolSignatureComparer : IEqualityComparer<ISymbol>
+{
+	public static readonly SymbolSignatureComparer Instance = new();
+
+	public bool Equals(ISymbol? x, ISymbol? y)
+	{
+		if (ReferenceEquals(x, y)) return true;
+		if (x is null || y is null) return false;
+		if (x.Kind != y.Kind) return false;
+
+		return x switch
+		{
+			INamedTypeSymbol nt => NamedTypeSignatureComparer.Instance.Equals(nt, y as INamedTypeSymbol),
+			IMethodSymbol m => MethodEquals(m, y as IMethodSymbol),
+			_ => MemberEquals(x, y)
+		};
+	}
+
+	public int GetHashCode(ISymbol obj)
+	{
+		return obj switch
+		{
+			INamedTypeSymbol nt => NamedTypeSignatureComparer.Instance.GetHashCode(nt),
+			IMethodSymbol m => MethodHashCode(m),
+			_ => MemberHashCode(obj)
+		};
+	}
+
+	private static string ContainingTypeKey(ISymbol symbol)
+	{
+		if (symbol.ContainingType is { } ct)
+			return NamedTypeSignatureComparer.Instance.GetHashCode(ct).ToString();
+		if (symbol.ContainingNamespace is { IsGlobalNamespace: false } ns)
+			return ns.ToDisplayString();
+		return string.Empty;
+	}
+
+	private static bool MethodEquals(IMethodSymbol? x, IMethodSymbol? y)
+	{
+		if (x is null || y is null) return false;
+		if (!string.Equals(x.MetadataName, y.MetadataName, StringComparison.Ordinal)) return false;
+		if (!NamedTypeSignatureComparer.Instance.Equals(x.ContainingType, y.ContainingType)) return false;
+		if (x.Parameters.Length != y.Parameters.Length) return false;
+
+		for (int i = 0; i < x.Parameters.Length; i++)
+		{
+			var xParam = x.Parameters[i].Type.ToDisplayString();
+			var yParam = y.Parameters[i].Type.ToDisplayString();
+			if (!string.Equals(xParam, yParam, StringComparison.Ordinal))
+				return false;
+		}
+
+		return true;
+	}
+
+	private static int MethodHashCode(IMethodSymbol m)
+	{
+		var hc = new HashCode();
+		hc.Add(m.MetadataName, StringComparer.Ordinal);
+		hc.Add(NamedTypeSignatureComparer.Instance.GetHashCode(m.ContainingType));
+		hc.Add(m.Parameters.Length);
+		foreach (var p in m.Parameters)
+			hc.Add(p.Type.ToDisplayString(), StringComparer.Ordinal);
+		return hc.ToHashCode();
+	}
+
+	private static bool MemberEquals(ISymbol x, ISymbol y)
+	{
+		if (!string.Equals(x.MetadataName, y.MetadataName, StringComparison.Ordinal)) return false;
+		return string.Equals(ContainingTypeKey(x), ContainingTypeKey(y), StringComparison.Ordinal);
+	}
+
+	private static int MemberHashCode(ISymbol s)
+	{
+		return HashCode.Combine(s.MetadataName, ContainingTypeKey(s));
+	}
+}

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
@@ -110,7 +111,7 @@ public static class FindUnusedSymbolsLogic
 
     private static HashSet<ISymbol> CollectReferencedSymbols(LoadedSolution loaded)
     {
-        var referencedSymbols = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        var referencedSymbols = new HashSet<ISymbol>(SymbolSignatureComparer.Instance);
 
         foreach (var (_, compilation) in loaded.Compilations)
         {
@@ -210,7 +211,7 @@ public static class FindUnusedSymbolsLogic
             foreach (var iface in containingType.AllInterfaces)
             {
                 var impl = containingType.FindImplementationForInterfaceMember(method);
-                if (impl != null && SymbolEqualityComparer.Default.Equals(impl, method))
+                if (impl != null && SymbolSignatureComparer.Instance.Equals(impl, method))
                     return true;
             }
         }
@@ -225,7 +226,7 @@ public static class FindUnusedSymbolsLogic
             foreach (var iface in containingType.AllInterfaces)
             {
                 var impl = containingType.FindImplementationForInterfaceMember(prop);
-                if (impl != null && SymbolEqualityComparer.Default.Equals(impl, prop))
+                if (impl != null && SymbolSignatureComparer.Instance.Equals(impl, prop))
                     return true;
             }
         }

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/ICrossProjectOnly.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/ICrossProjectOnly.cs
@@ -1,0 +1,6 @@
+namespace TestLib;
+
+public interface ICrossProjectOnly
+{
+	string Execute();
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/CrossProjectGreeter.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib2/CrossProjectGreeter.cs
@@ -1,0 +1,9 @@
+using TestLib;
+
+namespace TestLib2;
+
+public class CrossProjectGreeter : IGreeter, ICrossProjectOnly
+{
+	public string Greet(string name) => $"Cross-project hello, {name}!";
+	public string Execute() => Greet("World");
+}

--- a/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
+++ b/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tests.Symbols;
+
+public class SymbolSignatureComparerTests
+{
+	// Builds two separate compilations that model the cross-project scenario:
+	// - libCompilation: defines IFoo in assembly "Lib"
+	// - consumerCompilation: references Lib as metadata, so its view of IFoo
+	//   is a metadata symbol — a different object than the source symbol in libCompilation.
+	private static (INamedTypeSymbol sourceSymbol, INamedTypeSymbol metadataSymbol) BuildCrossCompilationSymbols(
+		string interfaceSource = "namespace Lib; public interface IFoo { void Do(); }",
+		string typeName = "IFoo")
+	{
+		var libTree = CSharpSyntaxTree.ParseText(interfaceSource);
+		var libCompilation = CSharpCompilation.Create(
+			"Lib",
+			[libTree],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		// Compile Lib to an in-memory stream so Consumer can reference it as metadata
+		using var ms = new System.IO.MemoryStream();
+		var emitResult = libCompilation.Emit(ms);
+		Assert.True(emitResult.Success, string.Join("\n", emitResult.Diagnostics));
+		ms.Position = 0;
+		var libMetadataRef = MetadataReference.CreateFromStream(ms);
+
+		var memberImpl = typeName == "IFoo" ? "public void Do() {}" : "";
+		var consumerTree = CSharpSyntaxTree.ParseText(
+			$"using Lib; public class Bar : {typeName} {{ {memberImpl} }}");
+		var consumerCompilation = CSharpCompilation.Create(
+			"Consumer",
+			[consumerTree],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location), libMetadataRef],
+			new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+		var sourceSymbol = libCompilation.GlobalNamespace
+			.GetNamespaceMembers().First(n => n.Name == "Lib")
+			.GetTypeMembers(typeName).Single();
+
+		var metadataSymbol = consumerCompilation.GetTypeByMetadataName($"Lib.{typeName}")!;
+
+		return (sourceSymbol, metadataSymbol);
+	}
+
+	[Fact]
+	public void RoslynDefault_SameTypeFromDifferentCompilations_AreNotEqual()
+	{
+		// Documents the root cause: SymbolEqualityComparer.Default treats the same logical type
+		// as different objects when retrieved from separate compilations.
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.False(SymbolEqualityComparer.Default.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_SameTypeFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.True(NamedTypeSignatureComparer.Instance.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_SameTypeFromDifferentCompilations_HaveSameHashCode()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.Equal(
+			NamedTypeSignatureComparer.Instance.GetHashCode(source),
+			NamedTypeSignatureComparer.Instance.GetHashCode(metadata));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_DifferentTypes_AreNotEqual()
+	{
+		var (iFoo, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo { }", "IFoo");
+		var (iBar, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IBar { }", "IBar");
+
+		Assert.False(NamedTypeSignatureComparer.Instance.Equals(iFoo, iBar));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_GenericTypeDistinguishedByArity()
+	{
+		var (nonGeneric, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo { }", "IFoo");
+		var (generic, _) = BuildCrossCompilationSymbols("namespace Lib; public interface IFoo<T> { }", "IFoo");
+
+		Assert.False(NamedTypeSignatureComparer.Instance.Equals(nonGeneric, generic));
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_UsableAsDictionaryKey_FindsCrossCompilationSymbol()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		// Simulate the inheritance map: keyed on the source symbol, looked up with metadata symbol
+		var dict = new Dictionary<INamedTypeSymbol, string>(NamedTypeSignatureComparer.Instance)
+		{
+			[source] = "found"
+		};
+
+		Assert.True(dict.TryGetValue(metadata, out var value));
+		Assert.Equal("found", value);
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_SameTypeFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		Assert.True(SymbolSignatureComparer.Instance.Equals(source, metadata));
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_SameMethodFromDifferentCompilations_AreEqual()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		var sourceMethod = source.GetMembers("Do").OfType<IMethodSymbol>().Single();
+		var metadataMethod = metadata.GetMembers("Do").OfType<IMethodSymbol>().Single();
+
+		Assert.True(SymbolSignatureComparer.Instance.Equals(sourceMethod, metadataMethod));
+	}
+
+	[Fact]
+	public void SymbolSignatureComparer_UsableAsHashSetKey_FindsCrossCompilationSymbol()
+	{
+		var (source, metadata) = BuildCrossCompilationSymbols();
+
+		// Simulate the referenced-symbol set: added from one compilation, checked from another
+		var set = new HashSet<ISymbol>(SymbolSignatureComparer.Instance) { source };
+
+		Assert.Contains(metadata, set);
+	}
+}

--- a/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindCallersToolTests.cs
@@ -39,6 +39,17 @@ public class FindCallersToolTests
     }
 
     [Fact]
+    public void FindCallers_InterfaceMethod_FindsCallersInReferencingProject()
+    {
+        // IGreeter.Greet is defined in TestLib; GreeterConsumer in TestLib2 calls it via the interface.
+        // Without cross-compilation symbol normalisation, the interface dispatch check uses
+        // reference-equality symbols, missing callers from other projects.
+        var results = FindCallersLogic.Execute(_loaded, _resolver, _metadata, "IGreeter.Greet");
+
+        Assert.Contains(results, r => r.File.Contains("TestLib2", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<CallerInfo>

--- a/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindImplementationsToolTests.cs
@@ -47,6 +47,17 @@ public class FindImplementationsToolTests
     }
 
     [Fact]
+    public void FindImplementations_ForInterface_FindsImplementorInReferencingProject()
+    {
+        // IGreeter is defined in TestLib; CrossProjectGreeter implements it in TestLib2.
+        // Without cross-compilation symbol normalisation, only same-project implementors
+        // are found because Roslyn produces different ISymbol instances per compilation.
+        var results = FindImplementationsLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
+
+        Assert.Contains(results, r => r.FullName.Contains("CrossProjectGreeter", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<SymbolLocation>

--- a/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindReferencesToolTests.cs
@@ -58,6 +58,17 @@ public class FindReferencesToolTests
     }
 
     [Fact]
+    public void FindReferences_ForInterface_FindsUsagesInReferencingProject()
+    {
+        // IGreeter is defined in TestLib; GreeterConsumer and CrossProjectGreeter in TestLib2 reference it.
+        // Without cross-compilation symbol normalisation, cross-project usages are missed
+        // because the target set is built with reference-equality symbols from one compilation.
+        var results = FindReferencesLogic.Execute(_loaded, _resolver, _metadata, "IGreeter");
+
+        Assert.Contains(results, r => r.File.Contains("TestLib2", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Sort_OrdersByFileThenLine()
     {
         var input = new List<SymbolReference>

--- a/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUnusedSymbolsToolTests.cs
@@ -50,6 +50,19 @@ public class FindUnusedSymbolsToolTests
     }
 
     [Fact]
+    public void FindUnusedSymbols_TypeUsedFromAnotherProject_IsNotReportedAsUnused()
+    {
+        // ICrossProjectOnly is defined in TestLib but has no implementations or usages
+        // within TestLib itself — it is only implemented by CrossProjectGreeter in TestLib2.
+        // Without cross-compilation symbol normalisation, that cross-project usage is not
+        // matched in the referenced-symbol set, causing ICrossProjectOnly to be incorrectly
+        // reported as unused.
+        var (items, _) = FindUnusedSymbolsLogic.Execute(_loaded, _resolver, "TestLib", false);
+
+        Assert.DoesNotContain(items, i => i.SymbolName.Contains("ICrossProjectOnly", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void BuildSummary_GroupsByKind()
     {
         var input = new List<UnusedSymbolInfo>


### PR DESCRIPTION
## All credit to @kazrac

This PR re-applies the surviving pieces of **#210** by @kazrac onto current `main`. The original PR is closed not on the merits — the analysis there is one of the cleanest writeups of the cross-compilation `ISymbol` identity issue I've read — but because [#211](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/pull/211) landed first with a different (and complementary) approach.

### What changed vs #210

**Dropped (now redundant after #211):**
- `src/RoslynCodeLens/Tools/FindCallersLogic.cs` edits — #211 replaced this file entirely with `SymbolFinder.FindCallersAsync`
- `src/RoslynCodeLens/Tools/FindReferencesLogic.cs` edits — same, via `SymbolFinder.FindReferencesAsync`

**Kept (the surviving value-add):**

1. **`SymbolSignatureComparer` + `NamedTypeSignatureComparer`** — signature-based equality for `ISymbol` / `INamedTypeSymbol`. Required for the HashSet/Dictionary use cases that `SymbolFinder` doesn't cover (enumeration-based, not query-based).

2. **`SymbolResolver.BuildInheritanceMaps`** — uses `NamedTypeSignatureComparer` so inheritance maps unify the same type across compilations.

3. **`FindUnusedSymbolsLogic` fix** — `CollectReferencedSymbols` + `ShouldSkipMember` now use `SymbolSignatureComparer`. This is the **same bug class as #211**, in a code path #211 didn't touch. `find_unused_symbols` was silently missing cross-project usages for the same reason as the other tools.

4. **Test fixtures + regression tests** — `ICrossProjectOnly` (TestLib) + `CrossProjectGreeter` (TestLib2), plus cross-project test methods added to `FindReferencesToolTests`, `FindCallersToolTests`, `FindImplementationsToolTests`, `FindUnusedSymbolsToolTests`. These complement #211's coverage too.

### Attribution

Single commit, `Co-authored-by: kazrac <kazrac@users.noreply.github.com>`. The design and >95% of the code in this PR is @kazrac's work — I'm just the rebase + drop-redundancies operator.

Original PR: https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/pull/210
