### PR TITLE
fix(symbols): tolerate ErrorTypeSymbol in inheritance index (#222)

### DIFF
--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -99,6 +99,9 @@ public class SymbolResolver
         {
             foreach (var iface in type.AllInterfaces)
             {
+                // Skip error symbols (e.g. NoPiaMissingCanonicalTypeSymbol from unresolved
+                // embedded-interop types) — they have no real identity and would pollute the index.
+                if (iface.TypeKind == TypeKind.Error) continue;
                 if (!implementors.TryGetValue(iface, out var implList))
                 {
                     implList = new List<INamedTypeSymbol>();
@@ -110,6 +113,7 @@ public class SymbolResolver
             var baseType = type.BaseType;
             while (baseType != null && baseType.SpecialType != SpecialType.System_Object)
             {
+                if (baseType.TypeKind == TypeKind.Error) break;
                 if (!derived.TryGetValue(baseType, out var derivedList))
                 {
                     derivedList = new List<INamedTypeSymbol>();

--- a/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
+++ b/src/RoslynCodeLens/Symbols/NamedTypeSignatureComparer.cs
@@ -8,6 +8,9 @@ namespace RoslynCodeLens.Symbols;
 // SymbolEqualityComparer.Default treats those as different, breaking cross-project index lookups.
 // Intentional omissions: type-parameter names (may differ between source and metadata) and
 // assembly version (to tolerate multi-targeting and binding redirects).
+// Null-safe on ContainingNamespace and ContainingAssembly to tolerate ErrorTypeSymbol
+// instances (e.g. NoPiaMissingCanonicalTypeSymbol) that surface from AllInterfaces / BaseType
+// when references are unresolved.
 internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeSymbol>
 {
 	public static readonly NamedTypeSignatureComparer Instance = new();
@@ -18,7 +21,7 @@ internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeS
 		if (x is null || y is null) return false;
 		return x.Arity == y.Arity
 			&& string.Equals(x.Name, y.Name, StringComparison.Ordinal)
-			&& string.Equals(x.ContainingNamespace.ToDisplayString(), y.ContainingNamespace.ToDisplayString(), StringComparison.Ordinal)
+			&& string.Equals(x.ContainingNamespace?.ToDisplayString(), y.ContainingNamespace?.ToDisplayString(), StringComparison.Ordinal)
 			&& string.Equals(x.ContainingAssembly?.Identity.Name, y.ContainingAssembly?.Identity.Name, StringComparison.Ordinal);
 	}
 
@@ -27,7 +30,7 @@ internal sealed class NamedTypeSignatureComparer : IEqualityComparer<INamedTypeS
 		return HashCode.Combine(
 			obj.Name,
 			obj.Arity,
-			obj.ContainingNamespace.ToDisplayString(),
+			obj.ContainingNamespace?.ToDisplayString(),
 			obj.ContainingAssembly?.Identity.Name);
 	}
 }

--- a/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
+++ b/tests/RoslynCodeLens.Tests/Symbols/SymbolSignatureComparerTests.cs
@@ -136,4 +136,51 @@ public class SymbolSignatureComparerTests
 
 		Assert.Contains(metadata, set);
 	}
+
+	// Repro for issue #222: NoPiaMissingCanonicalTypeSymbol (an ErrorTypeSymbol) has a null
+	// ContainingNamespace and surfaces from AllInterfaces when embedded-interop canonical
+	// type lookup fails (e.g. WebView2 referenced from a WPF app). The comparer must not NRE
+	// when such a symbol is hashed or compared.
+	private static INamedTypeSymbol BuildErrorTypeWithoutNamespace()
+	{
+		var compilation = CSharpCompilation.Create(
+			"Empty",
+			[],
+			[MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+		return compilation.CreateErrorTypeSymbol(container: null, name: "", arity: 0);
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_GetHashCode_ErrorTypeWithNullNamespace_DoesNotThrow()
+	{
+		var errorType = BuildErrorTypeWithoutNamespace();
+		// Sanity check: this is the precondition the regression depends on.
+		Assert.Null(errorType.ContainingNamespace);
+
+		var ex = Record.Exception(() => NamedTypeSignatureComparer.Instance.GetHashCode(errorType));
+
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_Equals_ErrorTypeWithNullNamespace_DoesNotThrow()
+	{
+		var errorType = BuildErrorTypeWithoutNamespace();
+
+		var ex = Record.Exception(() => NamedTypeSignatureComparer.Instance.Equals(errorType, errorType));
+
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public void NamedTypeSignatureComparer_UsableAsDictionaryKey_ErrorTypeWithNullNamespace_DoesNotThrow()
+	{
+		// Mirrors BuildInheritanceMaps: the dictionary insert triggers GetHashCode on the key.
+		var errorType = BuildErrorTypeWithoutNamespace();
+		var dict = new Dictionary<INamedTypeSymbol, string>(NamedTypeSignatureComparer.Instance);
+
+		var ex = Record.Exception(() => dict[errorType] = "x");
+
+		Assert.Null(ex);
+	}
 }


### PR DESCRIPTION
Closes #222.

Thanks @khoffdbh for the detailed report — your hypothesis about filtering at `SymbolResolver` was right; I went with that as the primary fix and kept the comparer guards as defense in depth.

## Summary
- **Root cause:** `NoPiaMissingCanonicalTypeSymbol` (an `ErrorTypeSymbol` Roslyn fabricates when an embedded-interop canonical type can't be resolved — e.g. WebView2 referenced from a WPF app) has a `null` `ContainingNamespace`. `BuildInheritanceMaps` walks `type.AllInterfaces` / `BaseType` and inserts every result as a `Dictionary<INamedTypeSymbol, …>` key, which calls `NamedTypeSignatureComparer.GetHashCode` and dereferences null.
- **Fix at the source** (`SymbolResolver.BuildInheritanceMaps`): skip interfaces and base types where `TypeKind == Error`. They have no real identity and would only pollute the inheritance index.
- **Defense in depth** (`NamedTypeSignatureComparer`): null-guard `ContainingNamespace` in `Equals` and `GetHashCode`. `SymbolSignatureComparer` delegates here, so this covers it too.

## Test plan
- [x] New regression test reproduces the bug by constructing an `ErrorTypeSymbol` via `Compilation.CreateErrorTypeSymbol(container: null, …)` and verifying it survives hash / equality / dictionary insertion. Verified the test fails with the exact NRE+stack from the issue when the comparer fix is reverted, and passes once restored.
- [x] Sanity assertion `Assert.Null(errorType.ContainingNamespace)` in the test guards against Roslyn changing that behavior silently.
- [x] Full suite: 562 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)