### PR TITLE
fix(ci): prevent CI from publishing stable NuGet versions (#225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,18 @@ jobs:
       - name: Restore tools
         run: dotnet tool restore
 
-      - name: Run GitVersion
-        id: gitversion
+      - name: Compute CI package version
+        id: pkgver
         run: |
-          VERSION=$(dotnet gitversion /showvariable SemVer)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Package version: $VERSION"
+          SEMVER=$(dotnet gitversion /showvariable SemVer)
+          # Always append a CI prerelease suffix so a main-branch CI publish can never
+          # collide with the stable version that release-please publishes for a tag.
+          # See #225: a stable "2.2.1" got published from a regular push to main, then
+          # the release-please publish for the actual v2.2.1 silently no-op'd via
+          # --skip-duplicate, leaving the wrong build at the released version on NuGet.
+          CI_VERSION="${SEMVER}-ci.${{ github.run_number }}"
+          echo "version=$CI_VERSION" >> "$GITHUB_OUTPUT"
+          echo "CI package version: $CI_VERSION"
 
       - name: Restore
         run: dotnet restore
@@ -39,14 +45,14 @@ jobs:
         run: dotnet restore tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
 
       - name: Build
-        run: dotnet build --no-restore -c Release -p:Version=${{ steps.gitversion.outputs.version }}
+        run: dotnet build --no-restore -c Release -p:Version=${{ steps.pkgver.outputs.version }}
 
       - name: Test
         run: dotnet test --no-build -c Release --verbosity normal
 
       - name: Pack
         run: |
-          dotnet pack src/RoslynCodeLens/RoslynCodeLens.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
+          dotnet pack src/RoslynCodeLens/RoslynCodeLens.csproj --no-build -c Release -p:PackageVersion=${{ steps.pkgver.outputs.version }} -o ./artifacts
 
       - name: Push to NuGet (pre-release)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,9 @@ jobs:
           dotnet pack src/RoslynCodeLens/RoslynCodeLens.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
 
       - name: Push to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        # No --skip-duplicate: if the release version already exists on NuGet, fail loudly
+        # rather than silently masking a version collision (see #225).
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
       - name: Upload to GitHub Release
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ./nupkg/*.nupkg


### PR DESCRIPTION
Closes #225.

Thanks again @khoffdbh for spotting this — the NuGet \`2.2.1\` does not include the #222 fix; it's the shell-quote dependabot build from 2026-06-11.

## What happened

- \`ci.yml\` runs on every push to \`main\` and publishes to NuGet using \`dotnet gitversion /showvariable SemVer\`, which under \`mode: ContinuousDeployment\` produces **stable** versions (e.g. \`2.2.1\`) with no prerelease suffix.
- On 2026-06-11 the shell-quote dependabot PR (\`42dce1b\`) merged. CI computed \`2.2.1\` and pushed \`RoslynCodeLens.Mcp.2.2.1.nupkg\` to NuGet.
- Today (2026-06-16) \`release-please\` cut \`v2.2.1\` with the #222 fix. Its \`publish\` job called \`dotnet nuget push --skip-duplicate\` — but the version was already taken, so it silently no-op'd. The NuGet \`2.2.1\` is still the shell-quote build.
- Side note: \`release.yml\` (which triggers on \`release: published\` without \`--skip-duplicate\`) hasn't run since 2026-03-15. \`GITHUB_TOKEN\`-created releases don't fire \`release\` workflows, so it's been dormant since release-please took over. Not changed here, but worth deleting in a follow-up.

## Changes

- **\`ci.yml\`** — pack/push using \`<SemVer>-ci.{github.run_number}\` so a main-branch CI publish is unambiguously prerelease. The author's stated intent (commit \`ba9e92d\`: *"GitVersion for pre-release alpha versions on every push to main"*) was always preview packages; this enforces it without touching \`GitVersion.yml\`.
- **\`release-please.yml\`** — drop \`--skip-duplicate\` so a future collision fails the workflow loudly instead of silently masking the bug.

## Manual follow-up required (maintainer)

1. **Unlist** \`RoslynCodeLens.Mcp 2.2.1\` on NuGet.org so users stop installing the wrong build.
2. **Force a 2.2.2 patch release** so the #222 fix actually ships. Either land a trivial \`fix:\` commit on \`main\`, or push an empty commit with \`Release-As: 2.2.2\` in the footer to instruct release-please.
3. Optional: delete \`release.yml\` — it's orphaned.

## Test plan

- [ ] After merge, observe CI run on \`main\` push: NuGet publish step pushes a version like \`2.2.2-ci.123\` (or similar) instead of a stable \`X.Y.Z\`.
- [ ] After follow-up 2.2.2 release: release-please publish job pushes \`2.2.2.nupkg\` cleanly (no \`--skip-duplicate\` needed; new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
