### PR TITLE
fix(ci): retry MCP Registry publish to absorb NuGet indexing lag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,4 +76,16 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # The registry validates by hitting NuGet's search API, which lags ~1-2 min
+        # behind the upload that the preceding `publish` job just performed. Retry
+        # so we don't fail the workflow on indexing latency.
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if ./mcp-publisher publish; then
+              exit 0
+            fi
+            echo "::warning::MCP Registry publish attempt $attempt failed; retrying in 30s"
+            sleep 30
+          done
+          echo "::error::MCP Registry publish failed after 6 attempts"
+          exit 1


### PR DESCRIPTION
## Summary

The MCP Registry publish step failed during the 2.2.2 release ([run 27623619964](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/actions/runs/27623619964/job/81680073941)) because the registry validates entries by querying NuGet's search API, which lags ~1–2 minutes behind the upload that the preceding \`publish\` job just performed.

\`\`\`
registry validation failed for package 0 (RoslynCodeLens.Mcp):
NuGet package 'RoslynCodeLens.Mcp' exists but version 2.2.2 does not
exist in the registry. If you recently published the version, wait for
validation to complete
\`\`\`

A manual re-run 30 minutes later succeeded — confirming the failure was purely propagation latency, not a real registry rejection.

## Change

Wrap \`./mcp-publisher publish\` in a 6-attempt loop with 30s between retries (max ~3 min). Each retry logs a workflow warning; only final exhaustion is an error.

## Test plan

- [ ] Observable in the next release. If NuGet's search index has already caught up by the time the step runs, attempt 1 succeeds and no warnings appear (same as today's happy path). If it hasn't, retries silently absorb the lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)