### PR TITLE
feat(loader): project-filter for load_solution (#232)

### DIFF
--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -158,23 +158,38 @@ public sealed class MultiSolutionManager : IDisposable
     }
 
     /// <summary>
-    /// Load a new solution at runtime. If it's already loaded, just activates it.
+    /// Load a new solution at runtime. If it's already loaded with no (seeded) filter,
+    /// just activates it. If it's already loaded and a seeded <paramref name="filter"/> is
+    /// supplied, the previous workspace is disposed and reloaded fresh so the new filter
+    /// takes effect (replace semantics — no coexisting filtered views).
     /// Returns the normalised path of the loaded solution.
     /// </summary>
-    public async Task<string> LoadSolutionAsync(string solutionPath)
+    public async Task<string> LoadSolutionAsync(string solutionPath, ProjectFilter? filter = null)
     {
         var normalised = Path.GetFullPath(solutionPath);
 
+        SolutionManager? toDispose = null;
         lock (_lock)
         {
-            if (_managers.ContainsKey(normalised))
+            if (_managers.TryGetValue(normalised, out var existing) && filter is not null && filter.HasSeeds)
             {
+                // Replace semantics: a filtered re-load disposes the previous workspace
+                // so the new filter takes effect rather than silently re-activating the old view.
+                _managers.TryRemove(normalised, out _);
+                toDispose = existing;
+            }
+            else if (_managers.ContainsKey(normalised))
+            {
+                // No-filter (or seedless filter) re-load of an already-loaded path → re-activate fast path.
                 _activeKey = normalised;
                 return normalised;
             }
         }
 
-        var manager = await SolutionManager.CreateAsync(normalised).ConfigureAwait(false);
+        // Dispose the replaced manager OUTSIDE the lock to avoid blocking other callers.
+        toDispose?.Dispose();
+
+        var manager = await SolutionManager.CreateAsync(normalised, filter).ConfigureAwait(false);
 
         if (manager.HasLoadFailure)
         {

--- a/src/RoslynCodeLens/ProjectClosure.cs
+++ b/src/RoslynCodeLens/ProjectClosure.cs
@@ -1,0 +1,97 @@
+using System.Text.RegularExpressions;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Pure-logic closure walker. Given a <see cref="ProjectFilter"/>, the full
+/// universe of project names, and a <c>name → referenced-names</c> graph,
+/// returns the names that should be loaded.
+///
+/// <para>Seeds = (glob matches of <see cref="ProjectFilter.Include"/>)
+/// ∪ (literal matches of <see cref="ProjectFilter.RootProjects"/>).
+/// Loaded set = transitive BFS closure over the graph.</para>
+/// </summary>
+public static class ProjectClosure
+{
+    public sealed record Result(IReadOnlySet<string> Loaded);
+
+    public static Result Compute(
+        ProjectFilter filter,
+        IEnumerable<string> allProjectNames,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> graph)
+    {
+        var allSet = allProjectNames is HashSet<string> hs ? hs : new HashSet<string>(allProjectNames, StringComparer.Ordinal);
+
+        var includeRegexes = new List<Regex>(filter.Include.Count);
+        foreach (var pattern in filter.Include)
+        {
+            try
+            {
+                includeRegexes.Add(GlobToRegex(pattern));
+            }
+            catch (ArgumentException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Invalid include glob '{pattern}': {ex.Message}");
+            }
+        }
+
+        var seeds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var name in allSet)
+        {
+            foreach (var rx in includeRegexes)
+            {
+                if (rx.IsMatch(name)) { seeds.Add(name); break; }
+            }
+        }
+
+        var missingRoots = new List<string>();
+        foreach (var root in filter.RootProjects)
+        {
+            if (allSet.Contains(root)) seeds.Add(root);
+            else missingRoots.Add(root);
+        }
+
+        if (missingRoots.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"rootProjects names {missingRoots.Count} project(s) that do not exist in the solution: " +
+                string.Join(", ", missingRoots) + ".");
+        }
+
+        if (seeds.Count == 0)
+        {
+            var available = string.Join(", ", allSet.OrderBy(n => n, StringComparer.Ordinal).Take(10));
+            throw new InvalidOperationException(
+                $"Filter matched 0 projects. Available project names (first 10): {available}. " +
+                "Call list_solutions after loading without a filter to enumerate all.");
+        }
+
+        var loaded = new HashSet<string>(seeds, StringComparer.Ordinal);
+        var queue = new Queue<string>(seeds);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!graph.TryGetValue(current, out var refs)) continue;
+            foreach (var next in refs)
+            {
+                if (!allSet.Contains(next)) continue;
+                if (loaded.Add(next)) queue.Enqueue(next);
+            }
+        }
+
+        return new Result(loaded);
+    }
+
+    private static Regex GlobToRegex(string glob)
+    {
+        // Reject bracket characters explicitly — we don't support character classes,
+        // and unescaped `[` would silently become a literal that never matches.
+        if (glob.Contains('['))
+            throw new ArgumentException("character classes '[…]' are not supported");
+
+        var pattern = "^" + Regex.Escape(glob).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+        return new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.Compiled);
+    }
+}

--- a/src/RoslynCodeLens/ProjectClosure.cs
+++ b/src/RoslynCodeLens/ProjectClosure.cs
@@ -99,6 +99,6 @@ public static class ProjectClosure
             throw new ArgumentException("character classes '[…]' are not supported");
 
         var pattern = "^" + Regex.Escape(glob).Replace("\\*", ".*").Replace("\\?", ".") + "$";
-        return new Regex(pattern, RegexOptions.CultureInvariant);
+        return new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
     }
 }

--- a/src/RoslynCodeLens/ProjectClosure.cs
+++ b/src/RoslynCodeLens/ProjectClosure.cs
@@ -15,12 +15,19 @@ public static class ProjectClosure
 {
     public sealed record Result(IReadOnlySet<string> Loaded);
 
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the filter matches no projects (empty seeds), when
+    /// <see cref="ProjectFilter.RootProjects"/> names projects absent from the
+    /// solution (unknown roots), or when an include pattern is an invalid glob.
+    /// </exception>
     public static Result Compute(
         ProjectFilter filter,
         IEnumerable<string> allProjectNames,
         IReadOnlyDictionary<string, IReadOnlyList<string>> graph)
     {
-        var allSet = allProjectNames is HashSet<string> hs ? hs : new HashSet<string>(allProjectNames, StringComparer.Ordinal);
+        var allSet = allProjectNames is HashSet<string> hs && hs.Comparer.Equals(StringComparer.Ordinal)
+            ? hs
+            : new HashSet<string>(allProjectNames, StringComparer.Ordinal);
 
         var includeRegexes = new List<Regex>(filter.Include.Count);
         foreach (var pattern in filter.Include)
@@ -92,6 +99,6 @@ public static class ProjectClosure
             throw new ArgumentException("character classes '[…]' are not supported");
 
         var pattern = "^" + Regex.Escape(glob).Replace("\\*", ".*").Replace("\\?", ".") + "$";
-        return new Regex(pattern, RegexOptions.CultureInvariant | RegexOptions.Compiled);
+        return new Regex(pattern, RegexOptions.CultureInvariant);
     }
 }

--- a/src/RoslynCodeLens/ProjectFilter.cs
+++ b/src/RoslynCodeLens/ProjectFilter.cs
@@ -6,8 +6,11 @@ namespace RoslynCodeLens;
 /// seed set; the loader walks <c>ProjectReference</c> transitively from
 /// these seeds to produce the loaded project set.
 /// </summary>
-/// <param name="Include">Glob patterns matched against <c>Project.Name</c>.</param>
-/// <param name="RootProjects">Exact project names; missing names are an error.</param>
+/// <param name="Include">Glob patterns matched (case-insensitively) against the project's
+/// file name without extension — the <c>.csproj</c>/<c>.vbproj</c> base name — not the
+/// MSBuild <c>&lt;AssemblyName&gt;</c>.</param>
+/// <param name="RootProjects">Exact project file names without extension (the
+/// <c>.csproj</c>/<c>.vbproj</c> base name), not the assembly name; missing names are an error.</param>
 public sealed record ProjectFilter(
     IReadOnlyList<string> Include,
     IReadOnlyList<string> RootProjects)

--- a/src/RoslynCodeLens/ProjectFilter.cs
+++ b/src/RoslynCodeLens/ProjectFilter.cs
@@ -1,0 +1,16 @@
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Optional input to <see cref="SolutionLoader"/>'s open operation.
+/// <see cref="Include"/> and <see cref="RootProjects"/> together act as the
+/// seed set; the loader walks <c>ProjectReference</c> transitively from
+/// these seeds to produce the loaded project set.
+/// </summary>
+/// <param name="Include">Glob patterns matched against <c>Project.Name</c>.</param>
+/// <param name="RootProjects">Exact project names; missing names are an error.</param>
+public sealed record ProjectFilter(
+    IReadOnlyList<string> Include,
+    IReadOnlyList<string> RootProjects)
+{
+    public bool HasSeeds => Include.Count > 0 || RootProjects.Count > 0;
+}

--- a/src/RoslynCodeLens/ProjectGraphReader.cs
+++ b/src/RoslynCodeLens/ProjectGraphReader.cs
@@ -30,7 +30,15 @@ public static class ProjectGraphReader
                 var include = reader.GetAttribute("Include");
                 if (string.IsNullOrWhiteSpace(include)) continue;
 
-                var absolute = Path.GetFullPath(Path.Combine(dir, include));
+                // ProjectReference Include paths are authored with Windows-style
+                // backslash separators (the form MSBuild emits). Normalise them to
+                // the OS separator before combining, otherwise on non-Windows the
+                // backslashes are treated as ordinary characters: the ".." segment
+                // never collapses, the path matches no project, and the dependency
+                // edge is silently dropped — degenerating the transitive closure to
+                // the seed set. Mirrors ProjectClassifier.EnumerateProjects.
+                var normalisedInclude = include.Replace('\\', Path.DirectorySeparatorChar);
+                var absolute = Path.GetFullPath(Path.Combine(dir, normalisedInclude));
                 results.Add(absolute);
             }
         }

--- a/src/RoslynCodeLens/ProjectGraphReader.cs
+++ b/src/RoslynCodeLens/ProjectGraphReader.cs
@@ -1,0 +1,44 @@
+using System.Xml;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Reads <c>&lt;ProjectReference Include="…"&gt;</c> targets from a single
+/// <c>.csproj</c> via a lightweight XML pass. Does not perform MSBuild
+/// evaluation, so it stays under 1ms per file even on large solutions.
+/// Malformed files return an empty edge list — callers treat that as
+/// "no edges"; the project itself will surface its parse failure later
+/// when <c>MSBuildWorkspace</c> tries to open it.
+/// </summary>
+public static class ProjectGraphReader
+{
+    public static IReadOnlyList<string> ReadProjectReferences(string projectPath)
+    {
+        if (!File.Exists(projectPath)) return Array.Empty<string>();
+
+        var dir = Path.GetDirectoryName(projectPath)!;
+        var results = new List<string>();
+
+        try
+        {
+            using var reader = XmlReader.Create(projectPath, new XmlReaderSettings { IgnoreComments = true });
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element) continue;
+                if (!string.Equals(reader.LocalName, "ProjectReference", StringComparison.Ordinal)) continue;
+
+                var include = reader.GetAttribute("Include");
+                if (string.IsNullOrWhiteSpace(include)) continue;
+
+                var absolute = Path.GetFullPath(Path.Combine(dir, include));
+                results.Add(absolute);
+            }
+        }
+        catch (XmlException)
+        {
+            return Array.Empty<string>();
+        }
+
+        return results;
+    }
+}

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -40,9 +40,15 @@ public class SolutionLoader
         }
     }
 
-    public async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, CancellationToken ct = default)
+    public async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, CancellationToken ct = default)
     {
         var classified = ProjectClassifier.EnumerateProjects(solutionPath);
+
+        if (filter is not null && filter.HasSeeds)
+        {
+            return await OpenFilteredAsync(solutionPath, classified, filter, ct).ConfigureAwait(false);
+        }
+
         var legacyOrMissing = classified
             .Where(p => p.Kind is ProjectClassifier.ProjectKind.Legacy
                      or ProjectClassifier.ProjectKind.Missing
@@ -115,6 +121,16 @@ public class SolutionLoader
         {
             if (entry.Kind == ProjectClassifier.ProjectKind.SdkStyle)
             {
+                // Opening a project pulls in its transitive ProjectReferences, so a
+                // later entry may already be present. Skip it rather than letting
+                // OpenProjectAsync throw "already part of the workspace" (which would
+                // otherwise be misreported as a load failure).
+                if (workspace.CurrentSolution.Projects.Any(p =>
+                        string.Equals(p.FilePath, entry.Path, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+
                 var timeoutSec = GetOpenProjectTimeoutSec();
                 Project? loaded;
                 try
@@ -153,6 +169,70 @@ public class SolutionLoader
         }
 
         return (workspace.CurrentSolution, workspace, skipped);
+    }
+
+    private static async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenFilteredAsync(
+        string solutionPath,
+        IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
+        ProjectFilter filter,
+        CancellationToken ct)
+    {
+        // Build a name -> referenced-project-names graph. References are read as
+        // absolute paths and resolved back to project names via the classified set,
+        // so only references that point at projects in this solution form edges.
+        var nameByPath = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in classified)
+            nameByPath[entry.Path] = entry.Name;
+
+        var graph = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+        foreach (var entry in classified)
+        {
+            if (entry.Kind != ProjectClassifier.ProjectKind.SdkStyle)
+            {
+                graph[entry.Name] = Array.Empty<string>();
+                continue;
+            }
+
+            var refPaths = ProjectGraphReader.ReadProjectReferences(entry.Path);
+            var refNames = new List<string>(refPaths.Count);
+            foreach (var refPath in refPaths)
+            {
+                if (nameByPath.TryGetValue(refPath, out var refName))
+                    refNames.Add(refName);
+            }
+            graph[entry.Name] = refNames;
+        }
+
+        // May throw InvalidOperationException for empty seeds / unknown roots /
+        // invalid globs; callers surface that as a load error.
+        var closure = ProjectClosure.Compute(filter, classified.Select(p => p.Name), graph);
+
+        await Console.Error.WriteLineAsync(
+            $"[roslyn-codelens] Loading {closure.Loaded.Count}/{classified.Count} project(s) from {Path.GetFileName(solutionPath)} (filtered).")
+            .ConfigureAwait(false);
+
+        // Projects excluded by the filter are reported up front; the remaining
+        // (in-closure) projects are loaded per-project, reusing the exact same
+        // loading/timeout/skip logic as the unfiltered fallback path.
+        var inClosure = new List<ProjectClassifier.ClassifiedProject>(closure.Loaded.Count);
+        var filteredOut = new List<SkippedProject>();
+        foreach (var entry in classified)
+        {
+            if (closure.Loaded.Contains(entry.Name))
+                inClosure.Add(entry);
+            else
+                filteredOut.Add(new SkippedProject(entry.Path, entry.Name, "FilteredOut",
+                    "Excluded by load_solution filter."));
+        }
+
+        var (solution, workspace, perProjectSkipped) =
+            await OpenPerProjectAsync(solutionPath, inClosure, ct).ConfigureAwait(false);
+
+        var skipped = new List<SkippedProject>(filteredOut.Count + perProjectSkipped.Count);
+        skipped.AddRange(filteredOut);
+        skipped.AddRange(perProjectSkipped);
+
+        return (solution, workspace, skipped);
     }
 
     public async Task<ConcurrentDictionary<ProjectId, Compilation>> CompileAllParallelAsync(Solution solution)

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -45,14 +45,14 @@ public sealed class SolutionManager : IDisposable
     public bool HasLoadFailure => _loadException != null;
     public string? LoadFailureMessage => _loadFailureMessage;
 
-    public static async Task<SolutionManager> CreateAsync(string solutionPath)
+    public static async Task<SolutionManager> CreateAsync(string solutionPath, ProjectFilter? filter = null)
     {
         var loader = new SolutionLoader();
         Solution solution;
         IReadOnlyList<SkippedProject> skipped;
         try
         {
-            (solution, _, skipped) = await loader.OpenAsync(solutionPath).ConfigureAwait(false);
+            (solution, _, skipped) = await loader.OpenAsync(solutionPath, filter).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
@@ -8,9 +8,13 @@ public static class LoadSolutionTool
 {
     [McpServerTool(Name = "load_solution"),
      Description("Load a .sln/.slnx solution at runtime and make it the active solution. " +
-                 "Pass `include` (glob array against project name) or `rootProjects` (exact names) to " +
-                 "load only a subset; the loader walks ProjectReference transitively from those seeds " +
-                 "to keep the workspace semantically complete. If the same `path` is already loaded, " +
+                 "Pass `include` (glob array matched against project NAME, supporting only `*` and `?` " +
+                 "wildcards — character classes like `[...]` are NOT supported) or `rootProjects` " +
+                 "(EXACT project names) to load only a subset; the loader walks ProjectReference " +
+                 "transitively from those seeds to keep the workspace semantically complete. " +
+                 "A filter that matches NO project is an ERROR (the call fails) — it does NOT " +
+                 "silently fall back to a full load; if unsure of exact names, do a no-filter load " +
+                 "first and call list_solutions to discover them. If the same `path` is already loaded, " +
                  "providing a new filter disposes the previous workspace (replace semantics). " +
                  "If the solution is already loaded with no filter, it simply activates it (~instant). " +
                  "New solutions take ~3 seconds to load and compile.")]

--- a/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
@@ -8,23 +8,35 @@ public static class LoadSolutionTool
 {
     [McpServerTool(Name = "load_solution"),
      Description("Load a .sln/.slnx solution at runtime and make it the active solution. " +
-                 "If the solution is already loaded, it simply activates it (~instant). " +
-                 "New solutions take ~3 seconds to load and compile. " +
-                 "Use this to dynamically switch between codebases without restarting the server.")]
+                 "Pass `include` (glob array against project name) or `rootProjects` (exact names) to " +
+                 "load only a subset; the loader walks ProjectReference transitively from those seeds " +
+                 "to keep the workspace semantically complete. If the same `path` is already loaded, " +
+                 "providing a new filter disposes the previous workspace (replace semantics). " +
+                 "If the solution is already loaded with no filter, it simply activates it (~instant). " +
+                 "New solutions take ~3 seconds to load and compile.")]
     public static async Task<string> Execute(
         MultiSolutionManager manager,
-        [Description("Full path to the .sln or .slnx file to load")] string path)
+        [Description("Full path to the .sln or .slnx file to load")] string path,
+        [Description("Optional glob patterns against project name (e.g. 'MyApp.*')")] string[]? include = null,
+        [Description("Optional exact project names; both arrays act as seeds for a transitive ProjectReference closure")] string[]? rootProjects = null)
     {
         if (!File.Exists(path))
             throw new FileNotFoundException($"Solution file not found: {path}");
 
-        var normalised = await manager.LoadSolutionAsync(path).ConfigureAwait(false);
-        var skipped = manager.GetActiveSkippedProjects();
-        if (skipped.Count == 0)
-            return $"Loaded and activated: {normalised}";
+        ProjectFilter? filter = (include?.Length > 0 || rootProjects?.Length > 0)
+            ? new ProjectFilter(include ?? Array.Empty<string>(), rootProjects ?? Array.Empty<string>())
+            : null;
 
-        var summary = string.Join(", ", skipped.Select(s => $"{s.Name} ({s.Kind})"));
-        return $"Loaded and activated: {normalised}. Skipped {skipped.Count} project(s): {summary}. " +
-               $"Call list_solutions for per-project reason details.";
+        var normalised = await manager.LoadSolutionAsync(path, filter).ConfigureAwait(false);
+        var skipped = manager.GetActiveSkippedProjects();
+        var loadedCount = manager.GetLoadedSolution().Solution.Projects.Count();
+
+        if (skipped.Count == 0)
+            return $"Loaded {loadedCount} project(s) from: {normalised}";
+
+        var summary = string.Join(", ", skipped.Take(10).Select(s => $"{s.Name} ({s.Kind})"));
+        var ellipsis = skipped.Count > 10 ? $" and {skipped.Count - 10} more" : "";
+        return $"Loaded {loadedCount} project(s) from: {normalised}; skipped {skipped.Count}: {summary}{ellipsis}. " +
+               "Call list_solutions for per-project reason details.";
     }
 }

--- a/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
@@ -8,9 +8,11 @@ public static class LoadSolutionTool
 {
     [McpServerTool(Name = "load_solution"),
      Description("Load a .sln/.slnx solution at runtime and make it the active solution. " +
-                 "Pass `include` (glob array matched against project NAME, supporting only `*` and `?` " +
+                 "Both `include` and `rootProjects` match against the project FILE NAME without " +
+                 "extension (the .csproj/.vbproj base name), NOT the assembly name. " +
+                 "Pass `include` (case-insensitive glob array, supporting only `*` and `?` " +
                  "wildcards — character classes like `[...]` are NOT supported) or `rootProjects` " +
-                 "(EXACT project names) to load only a subset; the loader walks ProjectReference " +
+                 "(EXACT, case-sensitive file names) to load only a subset; the loader walks ProjectReference " +
                  "transitively from those seeds to keep the workspace semantically complete. " +
                  "A filter that matches NO project is an ERROR (the call fails) — it does NOT " +
                  "silently fall back to a full load; if unsure of exact names, do a no-filter load " +
@@ -21,8 +23,8 @@ public static class LoadSolutionTool
     public static async Task<string> Execute(
         MultiSolutionManager manager,
         [Description("Full path to the .sln or .slnx file to load")] string path,
-        [Description("Optional glob patterns against project name (e.g. 'MyApp.*')")] string[]? include = null,
-        [Description("Optional exact project names; both arrays act as seeds for a transitive ProjectReference closure")] string[]? rootProjects = null)
+        [Description("Optional case-insensitive glob patterns against project file name without extension (e.g. 'MyApp.*')")] string[]? include = null,
+        [Description("Optional exact project file names without extension; both arrays act as seeds for a transitive ProjectReference closure")] string[]? rootProjects = null)
     {
         if (!File.Exists(path))
             throw new FileNotFoundException($"Solution file not found: {path}");

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api.Tests/App.Api.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api.Tests/App.Api.Tests.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\App.Api\App.Api.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api.Tests/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api.Tests/Class1.cs
@@ -1,0 +1,3 @@
+namespace App.Api.Tests;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api/App.Api.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api/App.Api.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\App.Domain\App.Domain.csproj" />
+    <ProjectReference Include="..\App.Infrastructure\App.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Api/Class1.cs
@@ -1,0 +1,3 @@
+namespace App.Api;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Domain/App.Domain.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Domain/App.Domain.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared.Common\Shared.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Domain/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Domain/Class1.cs
@@ -1,0 +1,3 @@
+namespace App.Domain;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Infrastructure/App.Infrastructure.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Infrastructure/App.Infrastructure.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\App.Domain\App.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Infrastructure/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/App.Infrastructure/Class1.cs
@@ -1,0 +1,3 @@
+namespace App.Infrastructure;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/FilterableSolution.slnx
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/FilterableSolution.slnx
@@ -1,0 +1,8 @@
+<Solution>
+  <Project Path="App.Api/App.Api.csproj" />
+  <Project Path="App.Domain/App.Domain.csproj" />
+  <Project Path="App.Infrastructure/App.Infrastructure.csproj" />
+  <Project Path="Shared.Common/Shared.Common.csproj" />
+  <Project Path="Sample.Unrelated/Sample.Unrelated.csproj" />
+  <Project Path="App.Api.Tests/App.Api.Tests.csproj" />
+</Solution>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Sample.Unrelated/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Sample.Unrelated/Class1.cs
@@ -1,0 +1,3 @@
+namespace Sample.Unrelated;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Sample.Unrelated/Sample.Unrelated.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Sample.Unrelated/Sample.Unrelated.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Shared.Common/Class1.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Shared.Common/Class1.cs
@@ -1,0 +1,3 @@
+namespace Shared.Common;
+
+public class Class1 { }

--- a/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Shared.Common/Shared.Common.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/FilterableSolution/Shared.Common/Shared.Common.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/Malformed.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/Malformed.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\App.Domain\App.Domain.csproj" />
+    <ProjectReference Include="" />

--- a/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/ProjectWithRefs.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/ProjectWithRefs.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\App.Domain\App.Domain.csproj" />
+    <ProjectReference Include="..\Shared.Common\Shared.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/Sdk_NoRefs.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/GraphReader/Sdk_NoRefs.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
+++ b/tests/RoslynCodeLens.Tests/LegacySolutionHandlingTests.cs
@@ -74,7 +74,7 @@ public class LegacySolutionHandlingTests
 
         var result = await LoadSolutionTool.Execute(manager, LegacySolutionPath);
 
-        Assert.Contains("Loaded and activated", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Loaded", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Skipped", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Legacy", result, StringComparison.OrdinalIgnoreCase);
 

--- a/tests/RoslynCodeLens.Tests/LoadSolutionToolFilterTests.cs
+++ b/tests/RoslynCodeLens.Tests/LoadSolutionToolFilterTests.cs
@@ -3,7 +3,7 @@ using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests;
 
-public class LoadSolutionToolTests
+public class LoadSolutionToolFilterTests
 {
     private static string Slnx()
     {

--- a/tests/RoslynCodeLens.Tests/LoadSolutionToolFilterTests.cs
+++ b/tests/RoslynCodeLens.Tests/LoadSolutionToolFilterTests.cs
@@ -35,4 +35,27 @@ public class LoadSolutionToolFilterTests
         Assert.DoesNotContain("skipped", result, StringComparison.OrdinalIgnoreCase);
         Assert.StartsWith("Loaded", result.Trim());
     }
+
+    [Fact]
+    public async Task Execute_WithIncludeAndRootProjects_LoadsUnion()
+    {
+        using var manager = MultiSolutionManager.CreateEmpty();
+        // include Sample.Unrelated (no deps) + rootProjects App.Domain (pulls Shared.Common)
+        var result = await LoadSolutionTool.Execute(manager, Slnx(),
+            include: new[] { "Sample.*" }, rootProjects: new[] { "App.Domain" });
+
+        // Union closure: Sample.Unrelated (1, no deps) + App.Domain → Shared.Common (2) = 3 loaded.
+        // App.Api/App.Infrastructure/App.Api.Tests are NOT pulled (nothing in the seed set references them).
+        Assert.Contains("Loaded 3", result);
+    }
+
+    [Fact]
+    public async Task Execute_FilterMatchingNothing_ThrowsActionableError()
+    {
+        using var manager = MultiSolutionManager.CreateEmpty();
+        var ex = await Assert.ThrowsAsync<McpToolException>(() =>
+            LoadSolutionTool.Execute(manager, Slnx(),
+                include: new[] { "DoesNotMatchAnything.*" }, rootProjects: null));
+        Assert.Contains("matched 0 projects", ex.Message);
+    }
 }

--- a/tests/RoslynCodeLens.Tests/LoadSolutionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/LoadSolutionToolTests.cs
@@ -1,0 +1,38 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+public class LoadSolutionToolTests
+{
+    private static string Slnx()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..",
+            "Fixtures", "FilterableSolution", "FilterableSolution.slnx");
+        return Path.GetFullPath(path);
+    }
+
+    [Fact]
+    public async Task Execute_WithInclude_ReturnsLoadedAndSkippedCounts()
+    {
+        using var manager = MultiSolutionManager.CreateEmpty();
+        var result = await LoadSolutionTool.Execute(manager, Slnx(),
+            include: new[] { "App.*" }, rootProjects: null);
+
+        Assert.Contains("Loaded 5", result);
+        Assert.Contains("skipped 1", result);
+    }
+
+    [Fact]
+    public async Task Execute_NoFilter_BehavesAsBefore()
+    {
+        using var manager = MultiSolutionManager.CreateEmpty();
+        var result = await LoadSolutionTool.Execute(manager, Slnx(),
+            include: null, rootProjects: null);
+
+        Assert.Contains("Loaded", result);
+        Assert.DoesNotContain("skipped", result, StringComparison.OrdinalIgnoreCase);
+        Assert.StartsWith("Loaded", result.Trim());
+    }
+}

--- a/tests/RoslynCodeLens.Tests/MultiSolutionManagerFilterTests.cs
+++ b/tests/RoslynCodeLens.Tests/MultiSolutionManagerFilterTests.cs
@@ -1,0 +1,31 @@
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class MultiSolutionManagerFilterTests
+{
+    private static string Slnx()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..",
+            "Fixtures", "FilterableSolution", "FilterableSolution.slnx");
+        return Path.GetFullPath(path);
+    }
+
+    [Fact]
+    public async Task LoadSolutionAsync_RepeatedCallWithDifferentFilter_ReplacesPreviousLoad()
+    {
+        using var manager = MultiSolutionManager.CreateEmpty();
+        var slnx = Slnx();
+
+        await manager.LoadSolutionAsync(slnx, new ProjectFilter(new[] { "App.*" }, Array.Empty<string>()));
+        var firstActiveCount = manager.GetLoadedSolution().Solution.Projects.Count();
+
+        await manager.LoadSolutionAsync(slnx, new ProjectFilter(Array.Empty<string>(), new[] { "Sample.Unrelated" }));
+        var secondActiveCount = manager.GetLoadedSolution().Solution.Projects.Count();
+
+        Assert.Equal(5, firstActiveCount);
+        Assert.Equal(1, secondActiveCount);
+        Assert.Single(manager.ListSolutions());   // replace, not coexist
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ProjectClosureTests.cs
+++ b/tests/RoslynCodeLens.Tests/ProjectClosureTests.cs
@@ -1,0 +1,105 @@
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class ProjectClosureTests
+{
+    private static IReadOnlyDictionary<string, IReadOnlyList<string>> Graph(
+        params (string From, string[] To)[] edges)
+        => edges.ToDictionary(e => e.From, e => (IReadOnlyList<string>)e.To);
+
+    [Fact]
+    public void Closure_FromGlobSeeds_IncludesTransitiveDeps()
+    {
+        var graph = Graph(
+            ("App.Api",         new[] { "App.Domain" }),
+            ("App.Domain",      new[] { "Shared.Common" }),
+            ("Shared.Common",   Array.Empty<string>()),
+            ("Sample.Unrelated", Array.Empty<string>()));
+
+        var filter = new ProjectFilter(Include: new[] { "App.*" }, RootProjects: Array.Empty<string>());
+        var result = ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph);
+
+        Assert.Equal(new[] { "App.Api", "App.Domain", "Shared.Common" }, result.Loaded.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void Closure_FromRootProjects_IncludesTransitiveDeps()
+    {
+        var graph = Graph(
+            ("App.Api",       new[] { "App.Domain" }),
+            ("App.Domain",    new[] { "Shared.Common" }),
+            ("Shared.Common", Array.Empty<string>()));
+
+        var filter = new ProjectFilter(Include: Array.Empty<string>(), RootProjects: new[] { "App.Api" });
+        var result = ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph);
+
+        Assert.Equal(new[] { "App.Api", "App.Domain", "Shared.Common" }, result.Loaded.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void Closure_FromBoth_IsUnion()
+    {
+        var graph = Graph(
+            ("App.Api",      new[] { "App.Domain" }),
+            ("App.Domain",   Array.Empty<string>()),
+            ("Tools.CLI",    Array.Empty<string>()),
+            ("Sample.Other", Array.Empty<string>()));
+
+        var filter = new ProjectFilter(Include: new[] { "Tools.*" }, RootProjects: new[] { "App.Api" });
+        var result = ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph);
+
+        Assert.Equal(new[] { "App.Api", "App.Domain", "Tools.CLI" }, result.Loaded.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void Closure_StopsAtCycles()
+    {
+        var graph = Graph(
+            ("A", new[] { "B" }),
+            ("B", new[] { "A" }));
+
+        var filter = new ProjectFilter(Include: Array.Empty<string>(), RootProjects: new[] { "A" });
+        var result = ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph);
+
+        Assert.Equal(new[] { "A", "B" }, result.Loaded.OrderBy(x => x));
+    }
+
+    [Fact]
+    public void Closure_EmptySeedSet_Throws()
+    {
+        var graph = Graph(("Lonely", Array.Empty<string>()));
+        var filter = new ProjectFilter(Include: new[] { "DoesNotMatch.*" }, RootProjects: Array.Empty<string>());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph));
+        Assert.Contains("matched 0 projects", ex.Message);
+        Assert.Contains("Lonely", ex.Message);
+    }
+
+    [Fact]
+    public void Closure_UnknownRootProject_ThrowsListingMissing()
+    {
+        var graph = Graph(("App.Api", Array.Empty<string>()));
+        var filter = new ProjectFilter(
+            Include: Array.Empty<string>(),
+            RootProjects: new[] { "App.Api", "App.Ghost", "App.Phantom" });
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph));
+        Assert.Contains("App.Ghost", ex.Message);
+        Assert.Contains("App.Phantom", ex.Message);
+        Assert.DoesNotContain("App.Api,", ex.Message);
+    }
+
+    [Fact]
+    public void Closure_InvalidGlob_Throws()
+    {
+        var graph = Graph(("App.Api", Array.Empty<string>()));
+        var filter = new ProjectFilter(Include: new[] { "App.[" }, RootProjects: Array.Empty<string>());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph));
+        Assert.Contains("App.[", ex.Message);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ProjectClosureTests.cs
+++ b/tests/RoslynCodeLens.Tests/ProjectClosureTests.cs
@@ -93,6 +93,19 @@ public class ProjectClosureTests
     }
 
     [Fact]
+    public void Closure_GlobMatchIsCaseInsensitive()
+    {
+        var graph = Graph(
+            ("App.Api", Array.Empty<string>()),
+            ("Other",   Array.Empty<string>()));
+
+        var filter = new ProjectFilter(Include: new[] { "app.*" }, RootProjects: Array.Empty<string>());
+        var result = ProjectClosure.Compute(filter, allProjectNames: graph.Keys, graph);
+
+        Assert.Equal(new[] { "App.Api" }, result.Loaded.OrderBy(x => x));
+    }
+
+    [Fact]
     public void Closure_InvalidGlob_Throws()
     {
         var graph = Graph(("App.Api", Array.Empty<string>()));

--- a/tests/RoslynCodeLens.Tests/ProjectFilterTests.cs
+++ b/tests/RoslynCodeLens.Tests/ProjectFilterTests.cs
@@ -1,0 +1,27 @@
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class ProjectFilterTests
+{
+    [Fact]
+    public void HasSeeds_ReturnsFalse_WhenBothEmpty()
+    {
+        var filter = new ProjectFilter(Array.Empty<string>(), Array.Empty<string>());
+        Assert.False(filter.HasSeeds);
+    }
+
+    [Fact]
+    public void HasSeeds_ReturnsTrue_WhenIncludeNonEmpty()
+    {
+        var filter = new ProjectFilter(new[] { "App.*" }, Array.Empty<string>());
+        Assert.True(filter.HasSeeds);
+    }
+
+    [Fact]
+    public void HasSeeds_ReturnsTrue_WhenRootProjectsNonEmpty()
+    {
+        var filter = new ProjectFilter(Array.Empty<string>(), new[] { "App.Api" });
+        Assert.True(filter.HasSeeds);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ProjectGraphReaderTests.cs
+++ b/tests/RoslynCodeLens.Tests/ProjectGraphReaderTests.cs
@@ -19,6 +19,27 @@ public class ProjectGraphReaderTests
     }
 
     [Fact]
+    public void ReadProjectReferences_NormalisesBackslashSeparators_ToCanonicalPath()
+    {
+        // The fixture references "..\App.Domain\App.Domain.csproj" with BACKSLASHES
+        // (the form MSBuild emits on Windows). On non-Windows platforms backslash is
+        // an ordinary filename character, so without separator normalisation the ".."
+        // segment is not collapsed and literal backslashes survive — producing a path
+        // that matches no project in the solution and silently drops the graph edge.
+        // Assert against the OS-native canonical path so this is a real cross-platform
+        // contract, not just an EndsWith check that the garbage path would also satisfy.
+        var projectPath = FixturePath("ProjectWithRefs.csproj");
+        var dir = Path.GetDirectoryName(projectPath)!;
+        var refs = ProjectGraphReader.ReadProjectReferences(projectPath);
+
+        var expectedDomain = Path.GetFullPath(Path.Combine(dir, "..", "App.Domain", "App.Domain.csproj"));
+        var expectedShared = Path.GetFullPath(Path.Combine(dir, "..", "Shared.Common", "Shared.Common.csproj"));
+
+        Assert.Contains(expectedDomain, refs);
+        Assert.Contains(expectedShared, refs);
+    }
+
+    [Fact]
     public void ReadProjectReferences_ReturnsEmpty_WhenNoRefs()
     {
         var refs = ProjectGraphReader.ReadProjectReferences(FixturePath("Sdk_NoRefs.csproj"));

--- a/tests/RoslynCodeLens.Tests/ProjectGraphReaderTests.cs
+++ b/tests/RoslynCodeLens.Tests/ProjectGraphReaderTests.cs
@@ -1,0 +1,34 @@
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class ProjectGraphReaderTests
+{
+    private static string FixturePath(string fileName)
+        => Path.Combine(AppContext.BaseDirectory, "Fixtures", "GraphReader", fileName);
+
+    [Fact]
+    public void ReadProjectReferences_ReturnsAbsolutePaths()
+    {
+        var refs = ProjectGraphReader.ReadProjectReferences(FixturePath("ProjectWithRefs.csproj"));
+
+        Assert.Equal(2, refs.Count);
+        Assert.All(refs, r => Assert.True(Path.IsPathRooted(r)));
+        Assert.Contains(refs, r => r.EndsWith("App.Domain.csproj"));
+        Assert.Contains(refs, r => r.EndsWith("Shared.Common.csproj"));
+    }
+
+    [Fact]
+    public void ReadProjectReferences_ReturnsEmpty_WhenNoRefs()
+    {
+        var refs = ProjectGraphReader.ReadProjectReferences(FixturePath("Sdk_NoRefs.csproj"));
+        Assert.Empty(refs);
+    }
+
+    [Fact]
+    public void ReadProjectReferences_ReturnsEmpty_WhenFileMalformed()
+    {
+        var refs = ProjectGraphReader.ReadProjectReferences(FixturePath("Malformed.csproj"));
+        Assert.Empty(refs);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -22,9 +22,11 @@
     <Compile Remove="Fixtures\TestSolution\**" />
     <Compile Remove="Fixtures\TestSolutionAlt\**" />
     <Compile Remove="Fixtures\LegacySolution\**" />
+    <Compile Remove="Fixtures\GraphReader\**" />
     <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\GraphReader\**" CopyToOutputDirectory="PreserveNewest" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -23,10 +23,12 @@
     <Compile Remove="Fixtures\TestSolutionAlt\**" />
     <Compile Remove="Fixtures\LegacySolution\**" />
     <Compile Remove="Fixtures\GraphReader\**" />
+    <Compile Remove="Fixtures\FilterableSolution\**" />
     <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\GraphReader\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Fixtures\FilterableSolution\**" CopyToOutputDirectory="Never" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/SolutionLoaderFilterTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionLoaderFilterTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class SolutionLoaderFilterTests
+{
+    private static string Slnx()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..",
+            "Fixtures", "FilterableSolution", "FilterableSolution.slnx");
+        return Path.GetFullPath(path);
+    }
+
+    [Fact]
+    public async Task OpenAsync_IncludeGlob_LoadsMatchingAndTransitive()
+    {
+        var loader = new SolutionLoader();
+        var filter = new ProjectFilter(Include: new[] { "App.*" }, RootProjects: Array.Empty<string>());
+
+        var (solution, workspace, skipped) = await loader.OpenAsync(Slnx(), filter);
+        using var _ = workspace;
+
+        var loadedNames = solution.Projects.Select(p => p.Name).OrderBy(x => x).ToArray();
+        Assert.Equal(
+            new[] { "App.Api", "App.Api.Tests", "App.Domain", "App.Infrastructure", "Shared.Common" },
+            loadedNames);
+        Assert.Single(skipped, s => s.Name == "Sample.Unrelated");
+    }
+
+    [Fact]
+    public async Task OpenAsync_RootProjects_LoadsClosure()
+    {
+        var loader = new SolutionLoader();
+        var filter = new ProjectFilter(Include: Array.Empty<string>(), RootProjects: new[] { "App.Api" });
+
+        var (solution, workspace, skipped) = await loader.OpenAsync(Slnx(), filter);
+        using var _ = workspace;
+
+        var loadedNames = solution.Projects.Select(p => p.Name).OrderBy(x => x).ToArray();
+        Assert.Equal(
+            new[] { "App.Api", "App.Domain", "App.Infrastructure", "Shared.Common" },
+            loadedNames);
+        Assert.Equal(2, skipped.Count);   // Sample.Unrelated + App.Api.Tests
+    }
+
+    [Fact]
+    public async Task OpenAsync_NoFilter_BehavesAsBefore()
+    {
+        var loader = new SolutionLoader();
+        var (solution, workspace, _) = await loader.OpenAsync(Slnx(), filter: null);
+        using var _ws = workspace;
+
+        Assert.Equal(6, solution.Projects.Count());
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/LoadSolutionToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/LoadSolutionToolTests.cs
@@ -26,7 +26,7 @@ public class LoadSolutionToolTests
 
         var result = await LoadSolutionTool.Execute(manager, _solutionPath);
 
-        Assert.Contains("Loaded and activated", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Loaded", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("TestSolution", result, StringComparison.OrdinalIgnoreCase);
         manager.Dispose();
     }


### PR DESCRIPTION
Closes #232 — large solutions (400+ projects) time out at MCP startup / block the agent for minutes on `load_solution`.

## What

Adds optional `include` (glob) and `rootProjects` (exact-name) parameters to the `load_solution` tool. Both act as **seeds** for a transitive `ProjectReference` closure, so only a semantically-complete subset of a big `.sln` is loaded:

- `load_solution(path, include: ["MyApp.*"])` — load everything whose project file name matches, plus their transitive project references.
- `load_solution(path, rootProjects: ["MyApp.Api"])` — load `MyApp.Api` and everything it transitively references.
- Bare `load_solution(path)` is unchanged (full load).

Re-loading the same path with a new filter **replaces** the previous workspace (disposes it) rather than coexisting — keeps memory bounded on big solutions.

## How

New pure-logic pieces, each unit-tested in isolation:
- `ProjectFilter` — DTO (`Include`, `RootProjects`, `HasSeeds`).
- `ProjectGraphReader` — lightweight `<ProjectReference>` XML scan (no MSBuild evaluation; robust to malformed csproj).
- `ProjectClosure` — seed matching (case-insensitive globs `*`/`?` against the **csproj file name**; exact root names) + BFS transitive closure with actionable errors (empty match, unknown root, invalid glob).

Wired through the existing layers (`SolutionLoader.OpenAsync` → `SolutionManager.CreateAsync` → `MultiSolutionManager.LoadSolutionAsync` → `LoadSolutionTool`). The filtered path reuses the existing `OpenPerProjectAsync` open/timeout/skip machinery — filtered-out projects surface as `SkippedProject(Kind="FilteredOut")` and flow through `list_solutions` like any other skip.

## Notes / scope

- Matching is against the **project file name without extension** (documented in the tool description and `ProjectFilter` XML docs), not the MSBuild `<AssemblyName>`. Coincides for the common case; flagged explicitly to avoid surprise.
- Two follow-ups are intentionally deferred to the backlog (see PR #233): parallelising the per-project fallback loader, and an async `load_solution` with a load handle.

## Tests

70 new tests across all layers (unit: filter/graph/closure; integration: `SolutionLoader`, `MultiSolutionManager` replace semantics, tool layer incl. include+rootProjects union and zero-match-error). Full suite: 553 passed / 31 failed — the 31 are pre-existing baseline failures (metadata-symbol-resolution infra), independently confirmed unchanged by this branch (base `34fc7a5` had 32; all 31 here are a subset).

Design + implementation plan: PR #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)