### PR TITLE
perf(loader): parallelise per-project loading with re-stitch (#232)

### DIFF
--- a/benchmarks/RoslynCodeLens.Benchmarks/Program.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/Program.cs
@@ -1,4 +1,12 @@
 using BenchmarkDotNet.Running;
 using RoslynCodeLens.Benchmarks;
 
-BenchmarkRunner.Run<CodeGraphBenchmarks>();
+var switcher = BenchmarkSwitcher.FromTypes(new[]
+{
+    typeof(CodeGraphBenchmarks),
+    typeof(SolutionLoadBenchmarks),
+});
+
+// No args → run everything (preserves the prior `dotnet run` behaviour);
+// otherwise honour BenchmarkDotNet's CLI filters, e.g. --filter *SolutionLoad*.
+switcher.Run(args.Length == 0 ? new[] { "--filter", "*" } : args);

--- a/benchmarks/RoslynCodeLens.Benchmarks/SolutionLoadBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/SolutionLoadBenchmarks.cs
@@ -1,0 +1,73 @@
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Benchmarks;
+
+/// <summary>
+/// Compares sequential (single-worker) vs parallel project loading for the
+/// per-project loader path (issue #232, deferred item a). The bundled fixture is
+/// small, so the absolute numbers are modest — the value is the head-to-head ratio
+/// and a ready harness to point at a large real solution by overriding
+/// <c>ROSLYN_CODELENS_BENCH_SOLUTION</c>.
+/// </summary>
+[MemoryDiagnoser]
+public class SolutionLoadBenchmarks
+{
+    private const string ParallelismKey = "ROSLYN_CODELENS_LOAD_PARALLELISM";
+    private static readonly string SolutionPath;
+
+    static SolutionLoadBenchmarks()
+    {
+        if (!MSBuildLocator.IsRegistered)
+            MSBuildLocator.RegisterDefaults();
+        SolutionPath = ResolveSolutionPath();
+    }
+
+    private static string ResolveSolutionPath()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("ROSLYN_CODELENS_BENCH_SOLUTION");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+            return overridePath;
+
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "RoslynCodeLens.slnx")))
+            dir = dir.Parent;
+
+        return dir == null
+            ? throw new InvalidOperationException(
+                "Could not find repo root (RoslynCodeLens.slnx) starting from " + AppContext.BaseDirectory)
+            : Path.Combine(dir.FullName,
+                "tests", "RoslynCodeLens.Tests", "Fixtures", "FilterableSolution", "FilterableSolution.slnx");
+    }
+
+    // Force the per-project loader (rather than the monolithic OpenSolutionAsync)
+    // by seeding an all-projects filter; that is the path the parallelisation
+    // changed and the one a large solution would hit after filtering.
+    private static ProjectFilter AllProjectsFilter => new(Include: new[] { "*" }, RootProjects: Array.Empty<string>());
+
+    [Benchmark(Baseline = true, Description = "OpenAsync (sequential, parallelism=1)")]
+    public async Task<int> LoadSequential()
+    {
+        Environment.SetEnvironmentVariable(ParallelismKey, "1");
+        return await OpenAndCountAsync().ConfigureAwait(false);
+    }
+
+    [Benchmark(Description = "OpenAsync (parallel, default parallelism)")]
+    public async Task<int> LoadParallel()
+    {
+        Environment.SetEnvironmentVariable(ParallelismKey, null);
+        return await OpenAndCountAsync().ConfigureAwait(false);
+    }
+
+    private static async Task<int> OpenAndCountAsync()
+    {
+        var (solution, workspace, _) = await new SolutionLoader()
+            .OpenAsync(SolutionPath, AllProjectsFilter).ConfigureAwait(false);
+        using (workspace as IDisposable)
+        {
+            return solution.Projects.Count();
+        }
+    }
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -27,9 +27,9 @@ Companions to `apply_code_action`, but for shapes that Roslyn doesn't ship out o
 
 ## 4. Startup & loading performance
 
-Big-solution scenarios (400+ projects) where the structural open dominates wall-clock and blocks the client agent. The project-filter feature (issue [#232](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/232)) is the in-flight first step; the items below are deferred companions.
+Big-solution scenarios (400+ projects) where the structural open dominates wall-clock and blocks the client agent. The project-filter feature (issue [#232](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/232)) was the first step; the items below were its deferred companions.
 
-- **Parallelise the per-project fallback loader** — `SolutionLoader.OpenPerProjectAsync` currently iterates `foreach … await workspace.OpenProjectAsync(entry.Path)` sequentially. With 400 projects even an unfiltered load would benefit. *Note: `MSBuildWorkspace` is documented as not fully thread-safe for opens; needs validation (probably one workspace per worker, then re-stitch). Promote once the filter feature ships and we have measurements.*
+- ✅ **Parallelise the per-project loader** — *shipped.* `SolutionLoader.OpenPerProjectAsync` now loads projects across a bounded pool of isolated `MSBuildWorkspace` workers (each its own out-of-process `BuildHost`), with global path-dedup to curb redundant transitive loads, then re-stitches the results into one workspace. Confirmed via experiment that concurrent `OpenProjectAsync` on a *shared* workspace corrupts the solution, so isolation + re-stitch is required. Degree via `ROSLYN_CODELENS_LOAD_PARALLELISM` (default `min(CPU, 8)`). Design: [docs/plans/2026-06-18-parallel-project-loader-design.md](plans/2026-06-18-parallel-project-loader-design.md).
 - **Async `load_solution` with a load handle** — return immediately with `{ status: "loading", loadId }` and add a `get_load_status` tool. Tools needing compilations either wait or report "still loading" with progress. Lets the agent issue other queries (e.g. `list_solutions`) while a 10-minute open is in flight. *Note: bigger surface change — touches `MultiSolutionManager`, `SolutionManager`, and every tool's `EnsureLoaded()` semantics. Defer until #232's filter approach proves insufficient on its own.*
 
 ---

--- a/docs/plans/2026-06-18-parallel-project-loader-design.md
+++ b/docs/plans/2026-06-18-parallel-project-loader-design.md
@@ -1,0 +1,106 @@
+# Parallel project loader — design
+
+**Status:** approved (2026-06-18)
+**Issue:** [#232](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/232) — deferred item (a)
+**Theme:** Startup & loading performance (BACKLOG section 4)
+**Builds on:** [project-filter for `load_solution`](2026-06-17-project-filter-load-solution-design.md)
+
+## Problem
+
+`SolutionLoader.OpenPerProjectAsync` — the path used for the legacy-project fallback and for every filtered load — opens projects one at a time:
+
+```csharp
+foreach (var entry in classified)
+    await workspace.OpenProjectAsync(entry.Path);
+```
+
+On a 400-project solution this is the dominant wall-clock cost even after filtering. Each `OpenProjectAsync` runs a full MSBuild design-time build, and Roslyn 5.x runs those builds **out-of-process in a `BuildHost` worker** (note the `BuildHost-netcore` / `BuildHost-net472` folders shipped alongside the assembly). A single `MSBuildWorkspace` owns a single `BuildHost`, so the builds it dispatches are effectively serialised regardless of how we await them.
+
+## What the experiment showed
+
+Measured against the `FilterableSolution` fixture (6 projects, 20-core box):
+
+| Strategy | Wall-clock | Result | Verdict |
+|---|---|---|---|
+| Sequential, one shared workspace (today) | 10.4 s | 6 projects ✓ | correct, slow |
+| **Parallel** `OpenProjectAsync` on **one shared** workspace | 6.1 s | **16 projects** ✗ | **corrupts the solution** |
+| Parallel, **one workspace per project** | 5.3 s | each correct | fastest, but redundant work |
+
+Two findings drive the design:
+
+1. **Concurrent `OpenProjectAsync` on a shared workspace is unsafe.** The races between transitive loads produce duplicate `Project` entries (16 instead of 6). This is the documented "`MSBuildWorkspace` is not thread-safe for opens" hazard. Ruled out.
+2. **One `BuildHost` per workspace is the only way to get real build parallelism.** Isolated workspaces hit the wall-clock floor. The cost: opening project `A` transitively loads `A`'s dependencies *into A's workspace too*, so naïvely opening all N projects in N workspaces does far more than N builds (the fixture did 16 builds for 6 projects).
+
+## Approach: bounded pool of isolated workspaces + global path dedup + re-stitch
+
+```
+1. Assign a fresh ProjectId per target project path.
+2. Order targets roots-first (descending transitive-closure size).
+3. Bounded pool (degree = ROSLYN_CODELENS_LOAD_PARALLELISM, default min(CPU, 8)):
+     for each target not already captured:
+        open it in its OWN MSBuildWorkspace (own BuildHost)
+        capture EVERY in-set project that workspace loaded (the project + its
+          transitive deps) into a global ConcurrentDictionary<path, Project>,
+          keep-first-wins  ← curbs the redundant-build blow-up
+4. Re-stitch: rebuild each captured Project as a ProjectInfo into ONE fresh
+   AdhocWorkspace, rewiring ProjectReferences from the on-disk graph
+   (ProjectGraphReader, already used by the filter feature) mapped to the
+   ProjectIds assigned in step 1.
+5. Return that workspace's Solution + the skipped list.
+```
+
+### Why dedup curbs the blow-up
+
+The filter closure is *transitively closed*: an in-closure project only references other in-closure projects. So when a worker opens a "root" it transitively pulls its whole closure into that worker's workspace — and we capture all of them at once. Roots-first ordering means a few big opens populate the dictionary, and the many leaf projects are skipped before they are ever scheduled. Worst case (every project a root) degrades to the per-workspace numbers above; typical case approaches one build per project.
+
+### Why re-stitch is safe
+
+- The returned workspace is **discarded by every caller** (`(solution, _, skipped) = …`); downstream code consumes only `Solution` + `Compilations`. `LoadedSolution.Empty` already uses an `AdhocWorkspace`, so an adhoc-backed `Solution` is a supported shape.
+- Each captured `Project` keeps its own `ProjectId`/`DocumentId`s (globally-unique GUIDs), so cross-workspace id collisions can't happen — we dedup by **file path**, keeping one `Project` per path.
+- `Project.MetadataReferences` on an MSBuild-loaded project holds only *external* references (framework / NuGet); an in-set project reference is a `ProjectReference`, never a metadata one. We strip every `ProjectReference` (its ids are workspace-local and meaningless after re-stitch) and rebuild them from the on-disk graph → the only cross-project wiring we touch, and it's path-based so it's deterministic and cross-platform (reusing `ProjectGraphReader`'s separator normalisation).
+
+### Degree of parallelism
+
+`ROSLYN_CODELENS_LOAD_PARALLELISM` (int, > 0). Default `min(Environment.ProcessorCount, 8)` — each worker is a separate `BuildHost` **process**, so an unbounded fan-out on a 400-project solution would spawn dozens of processes and exhaust memory. `1` forces single-worker loading (deterministic; used by CI/tests and as an escape hatch). Mirrors the existing `ROSLYN_CODELENS_OPEN_PROJECT_TIMEOUT_SECONDS` convention.
+
+## Error handling & edge cases
+
+| Case | Behaviour |
+|---|---|
+| A worker's `OpenProjectAsync` throws | Record `SkippedProject(Failed)`, continue (unchanged semantics, now thread-safe) |
+| A worker times out (`RunWithTimeoutAsync` → null) | Record `SkippedProject(Timeout)`, continue |
+| User cancellation (outer `ct`) | Propagates `OperationCanceledException` out of the pool |
+| Non-SDK (legacy/missing/unknown) entry | Skipped up front, never scheduled (unchanged) |
+| In-set project references an out-of-set project | Reference dropped (can't happen for filtered loads — closure is closed; possible only for legacy fallback, matching today's behaviour) |
+| `degree = 1` | Single worker; still re-stitches, so the re-stitch path is exercised by default in tests |
+
+## Testing
+
+xUnit in `tests/RoslynCodeLens.Tests/`, against the existing `FilterableSolution` fixture.
+
+- **Re-stitch correctness** — `OpenAsync(filter)` returns the same project set and count as before; `ProjectReference` edges survive (e.g. `App.Api` still references `App.Domain`), so a cross-project `Compilation` resolves symbols across the boundary.
+- **Parity** — parallel (`degree>1`) and sequential (`degree=1`) loads produce identical project-name sets and skipped lists.
+- **Skipped-channel** — filtered-out projects still appear in `SkippedProject` with the `FilteredOut` reason; the perf change doesn't regress the filter contract.
+- **Determinism** — `GetCompilationLevels` / downstream tools work on the re-stitched solution (smoke via `find_references` across the App.Api→App.Domain edge).
+
+## Benchmark
+
+`benchmarks/SolutionLoadBenchmarks` compares `degree=1` vs `degree=N` `OpenAsync` over `FilterableSolution`, and accepts `ROSLYN_CODELENS_BENCH_SOLUTION` to point at a large real solution.
+
+Measured on the bundled fixture (ShortRun, 20-core box):
+
+| Method | Mean | Allocated |
+|---|---|---|
+| sequential (`parallelism=1`) | ~5.7 s | 4.6 MB |
+| parallel (default) | ~5.9 s | 11.9 MB |
+
+**The fixture shows no parallel win, and that is expected — not a regression.** Its six projects form a single funnel (`App.Api.Tests → App.Api → App.{Domain,Infrastructure} → Shared.Common`): one root transitively pulls in everything, so there is nothing to open concurrently. It is the worst case for this strategy. The extra allocation is the re-stitch materialising document text in memory.
+
+The win is real only when a solution has **multiple independent dependency roots** (the typical large solution: many services/apps over shared libraries) — those roots open on separate `BuildHost` processes in parallel. We can't represent that in a six-project fixture, so the 400-project payoff is reported qualitatively and the benchmark stands as the harness to confirm it on a real solution.
+
+Crucially, the cost is **scoped**: the default unfiltered load of a healthy solution still takes the monolithic `OpenSolutionAsync` fast path and never touches this code. The pool runs only for (a) filtered loads — which a user opts into precisely because the solution is large — and (b) the legacy-project fallback. So the re-stitch memory/time overhead is confined to the paths where parallelism can pay for it, and the common small-solution case is unchanged.
+
+## Out of scope
+
+- **Async `load_solution` with a load handle** (deferred item b) — still the bigger surface change; revisited next.
+- Shallow (no-transitive) project loading — no public `MSBuildWorkspace` API; the dedup strategy makes it unnecessary.

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -2,12 +2,14 @@ using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Text;
 
 namespace RoslynCodeLens;
 
 public class SolutionLoader
 {
     private const int DefaultOpenProjectTimeoutSec = 300;
+    private const int MaxDefaultParallelism = 8;
 
     internal static int GetOpenProjectTimeoutSec() =>
         int.TryParse(
@@ -15,6 +17,19 @@ public class SolutionLoader
             out var n) && n > 0
                 ? n
                 : DefaultOpenProjectTimeoutSec;
+
+    // Each worker opens projects in its own MSBuildWorkspace, which spins up a
+    // separate out-of-process BuildHost. That is the only way to get genuine
+    // build parallelism (one workspace serialises its builds through one
+    // BuildHost), but each process costs memory — so the fan-out is bounded.
+    // Override with ROSLYN_CODELENS_LOAD_PARALLELISM; 1 forces single-worker
+    // loading (deterministic, used by tests and as an escape hatch).
+    internal static int GetLoadParallelism() =>
+        int.TryParse(
+            Environment.GetEnvironmentVariable("ROSLYN_CODELENS_LOAD_PARALLELISM"),
+            out var n) && n > 0
+                ? n
+                : Math.Max(1, Math.Min(Environment.ProcessorCount, MaxDefaultParallelism));
 
     internal static async Task<T?> RunWithTimeoutAsync<T>(
         Func<CancellationToken, Task<T?>> work,
@@ -40,7 +55,7 @@ public class SolutionLoader
         }
     }
 
-    public async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, CancellationToken ct = default)
+    public async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, CancellationToken ct = default)
     {
         var classified = ProjectClassifier.EnumerateProjects(solutionPath);
 
@@ -104,59 +119,21 @@ public class SolutionLoader
         return (solution, workspace, Array.Empty<SkippedProject>());
     }
 
-    private static async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenPerProjectAsync(
+    private static async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenPerProjectAsync(
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
         CancellationToken ct)
     {
-        var workspace = MSBuildWorkspace.Create();
         var skipped = new List<SkippedProject>();
 
-        workspace.WorkspaceFailed += (_, e) =>
-        {
-            Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
-        };
-
+        // Non-SDK entries (legacy/missing/unknown) are never opened; report them
+        // up front, exactly as the old sequential loader did.
+        var targets = new List<ProjectClassifier.ClassifiedProject>(classified.Count);
         foreach (var entry in classified)
         {
             if (entry.Kind == ProjectClassifier.ProjectKind.SdkStyle)
             {
-                // Opening a project pulls in its transitive ProjectReferences, so a
-                // later entry may already be present. Skip it rather than letting
-                // OpenProjectAsync throw "already part of the workspace" (which would
-                // otherwise be misreported as a load failure).
-                if (workspace.CurrentSolution.Projects.Any(p =>
-                        string.Equals(p.FilePath, entry.Path, StringComparison.OrdinalIgnoreCase)))
-                {
-                    continue;
-                }
-
-                var timeoutSec = GetOpenProjectTimeoutSec();
-                Project? loaded;
-                try
-                {
-                    loaded = await RunWithTimeoutAsync<Project>(
-                        innerCt => workspace.OpenProjectAsync(entry.Path, cancellationToken: innerCt),
-                        timeoutSec,
-                        ct).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    await Console.Error.WriteLineAsync(
-                        $"[roslyn-codelens] Skipping project {entry.Name}: {ex.GetType().Name}: {ex.Message}").ConfigureAwait(false);
-                    skipped.Add(new SkippedProject(entry.Path, entry.Name, "Failed",
-                        $"{ex.GetType().Name}: {ex.Message}"));
-                    continue;
-                }
-
-                if (loaded is null)
-                {
-                    await Console.Error.WriteLineAsync(
-                        $"[roslyn-codelens] Timeout loading project {entry.Name} (exceeded {timeoutSec}s).").ConfigureAwait(false);
-                    skipped.Add(new SkippedProject(entry.Path, entry.Name, "Timeout",
-                        $"Project load exceeded {timeoutSec}s. " +
-                        $"Set ROSLYN_CODELENS_OPEN_PROJECT_TIMEOUT_SECONDS to override."));
-                }
+                targets.Add(entry);
             }
             else
             {
@@ -168,10 +145,242 @@ public class SolutionLoader
             }
         }
 
+        if (targets.Count == 0)
+        {
+            return (new AdhocWorkspace().CurrentSolution, new AdhocWorkspace(), skipped);
+        }
+
+        // On-disk ProjectReference graph, restricted to the target set. Used both
+        // to order roots-first (so a few big transitive opens populate the cache
+        // and the leaves are skipped before they are scheduled) and to re-wire
+        // references after re-stitch. Reuses the same lightweight XML reader and
+        // separator normalisation as the filter feature, so it is cross-platform.
+        var targetPaths = new HashSet<string>(targets.Select(t => t.Path), StringComparer.OrdinalIgnoreCase);
+        var graph = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in targets)
+        {
+            var refs = new List<string>();
+            foreach (var refPath in ProjectGraphReader.ReadProjectReferences(t.Path))
+                if (targetPaths.Contains(refPath))
+                    refs.Add(refPath);
+            graph[t.Path] = refs;
+        }
+
+        var ordered = OrderRootsFirst(targets, graph);
+
+        // path -> detached ProjectInfo (text materialised in-memory, ProjectReferences
+        // stripped). Keep-first wins: a project pulled in transitively by an earlier
+        // worker is captured once and not re-opened standalone.
+        var captured = new ConcurrentDictionary<string, ProjectInfo>(StringComparer.OrdinalIgnoreCase);
+        var failures = new ConcurrentDictionary<string, SkippedProject>(StringComparer.OrdinalIgnoreCase);
+
+        var degree = GetLoadParallelism();
+        var timeoutSec = GetOpenProjectTimeoutSec();
+        using var gate = new SemaphoreSlim(degree);
+        var loadedCount = 0;
+
+        var tasks = new List<Task>(ordered.Count);
+        foreach (var entry in ordered)
+        {
+            if (captured.ContainsKey(entry.Path))
+                continue;
+
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+            tasks.Add(Task.Run(async () =>
+            {
+                try
+                {
+                    // Re-check after acquiring the gate: an in-flight worker may have
+                    // captured this project transitively while we were queued.
+                    if (captured.ContainsKey(entry.Path))
+                        return;
+
+                    var index = Interlocked.Increment(ref loadedCount);
+                    await Console.Error.WriteLineAsync(
+                        $"[roslyn-codelens] Loading {index}/{targets.Count}: {entry.Name}").ConfigureAwait(false);
+
+                    using var ws = MSBuildWorkspace.Create();
+                    ws.WorkspaceFailed += (_, e) =>
+                        Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
+
+                    Project? loaded;
+                    try
+                    {
+                        loaded = await RunWithTimeoutAsync<Project>(
+                            innerCt => ws.OpenProjectAsync(entry.Path, cancellationToken: innerCt),
+                            timeoutSec,
+                            ct).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        await Console.Error.WriteLineAsync(
+                            $"[roslyn-codelens] Skipping project {entry.Name}: {ex.GetType().Name}: {ex.Message}").ConfigureAwait(false);
+                        failures[entry.Path] = new SkippedProject(entry.Path, entry.Name, "Failed",
+                            $"{ex.GetType().Name}: {ex.Message}");
+                        return;
+                    }
+
+                    if (loaded is null)
+                    {
+                        await Console.Error.WriteLineAsync(
+                            $"[roslyn-codelens] Timeout loading project {entry.Name} (exceeded {timeoutSec}s).").ConfigureAwait(false);
+                        failures[entry.Path] = new SkippedProject(entry.Path, entry.Name, "Timeout",
+                            $"Project load exceeded {timeoutSec}s. " +
+                            $"Set ROSLYN_CODELENS_OPEN_PROJECT_TIMEOUT_SECONDS to override.");
+                        return;
+                    }
+
+                    // Capture this project plus every in-set project the workspace
+                    // pulled in transitively, detaching each into a workspace-free
+                    // ProjectInfo before the worker workspace is disposed.
+                    foreach (var p in ws.CurrentSolution.Projects)
+                    {
+                        if (p.FilePath is null || !targetPaths.Contains(p.FilePath))
+                            continue;
+                        if (captured.ContainsKey(p.FilePath))
+                            continue;
+                        var info = await ToDetachedInfoAsync(p).ConfigureAwait(false);
+                        captured.TryAdd(p.FilePath, info);
+                    }
+                }
+                finally
+                {
+                    gate.Release();
+                }
+            }, ct));
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        // Re-stitch: rebuild every captured project into a single AdhocWorkspace,
+        // re-wiring ProjectReferences from the on-disk graph (their original ids
+        // were local to each worker workspace and are meaningless now).
+        var idByPath = new Dictionary<string, ProjectId>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (path, info) in captured)
+            idByPath[path] = info.Id;
+
+        var finalInfos = new List<ProjectInfo>(captured.Count);
+        foreach (var (path, info) in captured)
+        {
+            var projectRefs = new List<ProjectReference>();
+            foreach (var refPath in graph[path])
+                if (idByPath.TryGetValue(refPath, out var refId))
+                    projectRefs.Add(new ProjectReference(refId));
+            finalInfos.Add(info.WithProjectReferences(projectRefs));
+        }
+
+        // Any target SDK project that is neither captured nor already recorded as a
+        // failure could not be loaded — surface it through the same skip channel.
+        foreach (var t in targets)
+        {
+            if (captured.ContainsKey(t.Path))
+                continue;
+            skipped.Add(failures.TryGetValue(t.Path, out var f)
+                ? f
+                : new SkippedProject(t.Path, t.Name, "Failed", "Project could not be loaded."));
+        }
+
+        var workspace = new AdhocWorkspace();
+        var solutionInfo = SolutionInfo.Create(
+            SolutionId.CreateNewId(), VersionStamp.Create(), solutionPath, finalInfos);
+        workspace.AddSolution(solutionInfo);
+
         return (workspace.CurrentSolution, workspace, skipped);
     }
 
-    private static async Task<(Solution Solution, MSBuildWorkspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenFilteredAsync(
+    /// <summary>
+    /// Orders target projects by descending transitive in-set dependency count, so
+    /// dependency roots open first. Their transitive loads populate the capture
+    /// cache, letting leaf projects be skipped before they are ever scheduled.
+    /// Ordering affects only efficiency, never correctness (keep-first dedup).
+    /// </summary>
+    private static List<ProjectClassifier.ClassifiedProject> OrderRootsFirst(
+        IReadOnlyList<ProjectClassifier.ClassifiedProject> targets,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> graph)
+    {
+        int ClosureSize(string path)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var stack = new Stack<string>();
+            stack.Push(path);
+            while (stack.Count > 0)
+            {
+                var cur = stack.Pop();
+                if (!graph.TryGetValue(cur, out var refs))
+                    continue;
+                foreach (var r in refs)
+                    if (seen.Add(r))
+                        stack.Push(r);
+            }
+            return seen.Count;
+        }
+
+        return targets
+            .OrderByDescending(t => ClosureSize(t.Path))
+            .ThenBy(t => t.Name, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Detaches a workspace-loaded <see cref="Project"/> into a self-contained
+    /// <see cref="ProjectInfo"/> with document text materialised in memory and all
+    /// ProjectReferences stripped, so it survives disposal of its source workspace
+    /// and can be re-stitched into a fresh workspace. The project keeps its own
+    /// (globally-unique) id and document ids.
+    /// </summary>
+    private static async Task<ProjectInfo> ToDetachedInfoAsync(Project project)
+    {
+        var documents = new List<DocumentInfo>();
+        foreach (var d in project.Documents)
+            documents.Add(await ToDocumentInfoAsync(d, d.SourceCodeKind).ConfigureAwait(false));
+
+        var additional = new List<DocumentInfo>();
+        foreach (var d in project.AdditionalDocuments)
+            additional.Add(await ToDocumentInfoAsync(d, SourceCodeKind.Regular).ConfigureAwait(false));
+
+        var analyzerConfig = new List<DocumentInfo>();
+        foreach (var d in project.AnalyzerConfigDocuments)
+            analyzerConfig.Add(await ToDocumentInfoAsync(d, SourceCodeKind.Regular).ConfigureAwait(false));
+
+        return ProjectInfo.Create(
+                project.Id,
+                VersionStamp.Create(),
+                project.Name,
+                project.AssemblyName,
+                project.Language,
+                filePath: project.FilePath,
+                outputFilePath: project.OutputFilePath,
+                compilationOptions: project.CompilationOptions,
+                parseOptions: project.ParseOptions,
+                documents: documents,
+                projectReferences: Array.Empty<ProjectReference>(),
+                metadataReferences: project.MetadataReferences,
+                analyzerReferences: project.AnalyzerReferences,
+                additionalDocuments: additional)
+            .WithAnalyzerConfigDocuments(analyzerConfig)
+            .WithDefaultNamespace(project.DefaultNamespace);
+    }
+
+    private static async Task<DocumentInfo> ToDocumentInfoAsync(TextDocument document, SourceCodeKind kind)
+    {
+        var text = await document.GetTextAsync().ConfigureAwait(false);
+        var loader = TextLoader.From(
+            TextAndVersion.Create(text, VersionStamp.Create(), document.FilePath ?? document.Name));
+
+        return DocumentInfo.Create(
+            document.Id,
+            document.Name,
+            folders: document.Folders,
+            sourceCodeKind: kind,
+            loader: loader,
+            filePath: document.FilePath);
+    }
+
+    private static async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenFilteredAsync(
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
         ProjectFilter filter,

--- a/tests/RoslynCodeLens.Tests/ParallelLoaderTests.cs
+++ b/tests/RoslynCodeLens.Tests/ParallelLoaderTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Covers the parallel-pool + re-stitch loader (issue #232, deferred item a).
+/// The existing <see cref="SolutionLoaderFilterTests"/> already prove that filtered
+/// loads return the correct project *set* through this code path; these tests pin
+/// the behaviour that is new and risky: the references survive being re-stitched out
+/// of N isolated worker workspaces into one.
+/// </summary>
+public class ParallelLoaderTests
+{
+    private static string Slnx()
+    {
+        var path = Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..",
+            "Fixtures", "FilterableSolution", "FilterableSolution.slnx");
+        return Path.GetFullPath(path);
+    }
+
+    [Fact]
+    public async Task OpenAsync_RestitchedSolution_PreservesProjectReferenceEdges()
+    {
+        var loader = new SolutionLoader();
+        var filter = new ProjectFilter(Include: Array.Empty<string>(), RootProjects: new[] { "App.Api" });
+
+        var (solution, workspace, _) = await loader.OpenAsync(Slnx(), filter);
+        using var _ws = workspace;
+
+        var api = solution.Projects.Single(p => p.Name == "App.Api");
+
+        // Re-stitch must rebuild App.Api's two direct ProjectReferences as live
+        // references that resolve to the in-solution App.Domain / App.Infrastructure
+        // projects — not dangling ids from the worker workspace they were loaded in.
+        var referencedNames = api.ProjectReferences
+            .Select(r => solution.GetProject(r.ProjectId)?.Name)
+            .OrderBy(n => n)
+            .ToArray();
+
+        Assert.Equal(new[] { "App.Domain", "App.Infrastructure" }, referencedNames);
+    }
+
+    [Fact]
+    public async Task OpenAsync_RestitchedSolution_CompilationResolvesAcrossProjectReference()
+    {
+        var loader = new SolutionLoader();
+        var filter = new ProjectFilter(Include: Array.Empty<string>(), RootProjects: new[] { "App.Api" });
+
+        var (solution, workspace, _) = await loader.OpenAsync(Slnx(), filter);
+        using var _ws = workspace;
+
+        var api = solution.Projects.Single(p => p.Name == "App.Api");
+        var compilation = await api.GetCompilationAsync();
+        Assert.NotNull(compilation);
+
+        // If the re-stitched ProjectReference is wired correctly, the referenced
+        // project's public type is visible to App.Api's compilation.
+        var domainType = compilation!.GetTypeByMetadataName("App.Domain.Class1");
+        Assert.NotNull(domainType);
+
+        // And the compilation should have no unresolved-reference errors.
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public async Task OpenAsync_SingleWorker_MatchesParallelResult()
+    {
+        var loader = new SolutionLoader();
+        var filter = new ProjectFilter(Include: new[] { "App.*" }, RootProjects: Array.Empty<string>());
+
+        var parallelNames = await LoadNamesAsync(loader, filter, parallelism: null);
+        var singleNames = await LoadNamesAsync(loader, filter, parallelism: "1");
+
+        // Degree of parallelism is a performance knob only — it must never change
+        // which projects end up loaded.
+        Assert.Equal(parallelNames, singleNames);
+        Assert.Equal(
+            new[] { "App.Api", "App.Api.Tests", "App.Domain", "App.Infrastructure", "Shared.Common" },
+            singleNames);
+    }
+
+    private static async Task<string[]> LoadNamesAsync(SolutionLoader loader, ProjectFilter filter, string? parallelism)
+    {
+        const string Key = "ROSLYN_CODELENS_LOAD_PARALLELISM";
+        var previous = Environment.GetEnvironmentVariable(Key);
+        Environment.SetEnvironmentVariable(Key, parallelism);
+        try
+        {
+            var (solution, workspace, _) = await loader.OpenAsync(Slnx(), filter);
+            using var _ws = workspace;
+            return solution.Projects.Select(p => p.Name).OrderBy(n => n).ToArray();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Key, previous);
+        }
+    }
+
+    [Fact]
+    public void GetLoadParallelism_HonoursEnvironmentOverride()
+    {
+        const string Key = "ROSLYN_CODELENS_LOAD_PARALLELISM";
+        var previous = Environment.GetEnvironmentVariable(Key);
+        try
+        {
+            Environment.SetEnvironmentVariable(Key, "3");
+            Assert.Equal(3, SolutionLoader.GetLoadParallelism());
+
+            Environment.SetEnvironmentVariable(Key, "0");      // invalid -> default
+            Assert.True(SolutionLoader.GetLoadParallelism() >= 1);
+
+            Environment.SetEnvironmentVariable(Key, "notanumber");
+            Assert.True(SolutionLoader.GetLoadParallelism() >= 1);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Key, previous);
+        }
+    }
+}


### PR DESCRIPTION
## What

Finishes the **parallel project loader** — the first deferred companion of issue #232 (the second, an async load handle, stays deferred). The per-project loader path (legacy fallback + every *filtered* `load_solution`) opened projects sequentially (`foreach … await OpenProjectAsync`); this parallelises it.

## Why the obvious approach doesn't work

Roslyn 5.x runs MSBuild design-time builds **out-of-process in a `BuildHost`**, and a single `MSBuildWorkspace` owns a single `BuildHost` — so awaiting opens on one workspace serialises them. An experiment on the fixture confirmed that concurrent `OpenProjectAsync` on a **shared** workspace *corrupts the solution* (transitive-load races produced 16 projects for a 6-project closure). Genuine parallelism therefore needs one workspace (one `BuildHost`) per worker, then a re-stitch.

| Strategy | Wall-clock | Result |
|---|---|---|
| Sequential, shared workspace (old) | 10.4 s | 6 projects ✓ |
| Parallel, **shared** workspace | 6.1 s | **16 projects** ✗ corrupt |
| Parallel, one workspace per project | 5.3 s | each correct |

## How

- Bounded pool of isolated `MSBuildWorkspace` workers; each captures its project + the in-set projects it pulls in transitively into a global path-keyed cache (keep-first) to curb redundant transitive opens.
- Roots-first ordering so a few big opens populate the cache and leaf projects are skipped before scheduling.
- Re-stitch the captured projects into one `AdhocWorkspace`, rebuilding `ProjectReference`s from the on-disk graph (path-based, cross-platform, reusing `ProjectGraphReader`).
- `ROSLYN_CODELENS_LOAD_PARALLELISM` env var (default `min(CPU, 8)`; `1` = deterministic single-worker).

## Scope / honest caveat

The default unfiltered load of a healthy solution still takes the monolithic `OpenSolutionAsync` fast path and never touches this code — the overhead is confined to *filtered* loads (opted into precisely because the solution is large) and the legacy fallback. The bundled fixture is a single-funnel dependency graph (worst case for parallelism), so the benchmark shows parallel ≈ sequential there; the win materialises only with **multiple independent dependency roots** (the typical large solution). `SolutionLoadBenchmarks` accepts `ROSLYN_CODELENS_BENCH_SOLUTION` to point at a real one.

## Tests

All **589 tests pass**. New `ParallelLoaderTests` pin the re-stitch behaviour:
- `ProjectReference` edges survive re-stitch (resolve to the right in-solution projects)
- a cross-project compilation resolves a referenced type with **zero** compile errors
- degree=1 produces the identical project set to the parallel default

Design doc: `docs/plans/2026-06-18-parallel-project-loader-design.md`. Backlog item marked shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)