### PR TITLE
fix(find_uncovered_symbols): exclude indexers from coverage candidates

### DIFF
--- a/src/RoslynCodeLens/Tools/FindUncoveredSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindUncoveredSymbolsLogic.cs
@@ -199,6 +199,8 @@ public static class FindUncoveredSymbolsLogic
                     }
                     else if (member is IPropertySymbol property)
                     {
+                        if (property.IsIndexer)
+                            continue;
                         if (property.IsAbstract)
                             continue;
                         if (property.GetMethod is null && property.SetMethod is null)

--- a/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/FindUncoveredSymbolsToolTests.cs
@@ -39,6 +39,15 @@ public class FindUncoveredSymbolsToolTests
     }
 
     [Fact]
+    public void Result_Indexer_DoesNotAppearAsUncovered()
+    {
+        var result = FindUncoveredSymbolsLogic.Execute(_loaded, _resolver);
+
+        Assert.DoesNotContain(result.UncoveredSymbols, s =>
+            string.Equals(s.Symbol, "IndexerSample.this[]", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Result_FormalNameLength_AppearsAsProperty()
     {
         var result = FindUncoveredSymbolsLogic.Execute(_loaded, _resolver);


### PR DESCRIPTION
## Summary
Exclude indexers from `find_uncovered_symbols` candidates.
Indexers were being reported as uncovered properties despite being outside the
intended candidate surface. This also affected aggregate candidate counts and
coverage metrics.
## Changes
- exclude `IPropertySymbol` instances where `IsIndexer` is `true`
- add a regression test covering `IndexerSample.this[]`
## Validation
- `dotnet build --configuration Release`
- `dotnet test --configuration Release`
