### PR TITLE
fix(analyzers): shadow-copy analyzer/generator assemblies so bin\Debug stays unlocked (#254)

### DIFF
--- a/docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy-design.md
+++ b/docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy-design.md
@@ -1,0 +1,283 @@
+# Analyzer / Source-Generator DLL Lock — Shadow-Copy Loader
+
+**Date:** 2026-07-05
+**Status:** Design approved (loader scope resolved) — ready for implementation plan
+**Issue:** [#254](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues/254) — Source-generator/analyzer DLL is locked during background compilation, breaking `dotnet build` (MSB3027)
+**Upstream:** [dotnet/roslyn#78196](https://github.com/dotnet/roslyn/issues/78196)
+
+## Motivation
+
+When the server loads a solution containing a source generator (or analyzer), the generator
+assembly is locked on disk for the lifetime of the `roslyn-codelens` process. Any subsequent
+`dotnet build` of that solution fails with `MSB3027`/`MSB3021` because MSBuild cannot overwrite
+the locked DLL in `bin\Debug`. Developers can't build or test from the CLI while the server
+runs; the only recovery is killing the process.
+
+## Verified root cause
+
+All three mechanisms in the issue were confirmed against `main` (Roslyn **5.6.0**):
+
+1. **Eager background compilation takes the lock at startup.**
+   `SolutionManager.CreateAsync` → `WarmupAsync` ([SolutionManager.cs:81](../../src/RoslynCodeLens/SolutionManager.cs)) →
+   `CompileAllParallelAsync` runs `project.GetCompilationAsync()` for **every** project
+   ([SolutionLoader.cs:463](../../src/RoslynCodeLens/SolutionLoader.cs)). Executing the
+   compilation runs source generators, which loads + locks their assemblies — before any tool
+   is invoked.
+
+2. **`MSBuildWorkspace` uses the default (non-shadow-copying) analyzer loader.**
+   `MSBuildWorkspace.Create()` ([SolutionLoader.cs:82](../../src/RoslynCodeLens/SolutionLoader.cs),
+   [:202](../../src/RoslynCodeLens/SolutionLoader.cs)) is used with no custom
+   `IAnalyzerAssemblyLoader`, so generator DLLs load straight from `bin\Debug` and stay locked.
+   The per-project loader even copies `project.AnalyzerReferences` verbatim into the re-stitched
+   `AdhocWorkspace` ([SolutionLoader.cs:362](../../src/RoslynCodeLens/SolutionLoader.cs)),
+   carrying the locking references forward.
+
+3. **`unload_solution` cannot release it.**
+   `SolutionManager.Dispose()` ([SolutionManager.cs:293](../../src/RoslynCodeLens/SolutionManager.cs))
+   only disposes `_tracker` and `_peCache`. It does not even hold the `MSBuildWorkspace` — both
+   `CreateAsync` and `ForceReloadAsync` discard it (`(solution, _, skipped)`). And the default
+   loader loads analyzers into a **non-collectible** load context, so the assemblies survive
+   until process exit regardless.
+
+   **Bonus finding:** the `MSBuildWorkspace` from the solution-level path is leaked entirely
+   (never disposed), not just the analyzer lock.
+
+## Key constraint discovered (changes the suggested fix)
+
+The issue suggests `ShadowCopyAnalyzerAssemblyLoader`. **That type is `internal` in Roslyn
+5.6.0** — verified by reflecting over the full referenced surface (Common, CSharp, Workspaces,
+Features, CSharp.Features, Workspaces.MSBuild, Scripting): there is **no public shadow-copy
+loader and no public `IAnalyzerAssemblyLoader` implementation** at all.
+
+What *is* public:
+
+- `Microsoft.CodeAnalysis.IAnalyzerAssemblyLoader` — interface, exactly two members:
+  - `Assembly LoadFromPath(string fullPath)`
+  - `void AddDependencyLocation(string fullPath)`
+- `Microsoft.CodeAnalysis.Diagnostics.AnalyzerFileReference(string fullPath, IAnalyzerAssemblyLoader loader)` — ctor.
+
+**Conclusion:** we implement our own shadow-copying `IAnalyzerAssemblyLoader` (there is no
+built-in public one to reuse), and inject it by re-constructing each project's
+`AnalyzerFileReference`s with our loader.
+
+## Goals
+
+- CLI `dotnet build`/`dotnet test` of a loaded solution succeeds while the server is running.
+- Generated symbols and analyzer diagnostics remain available (no loss of semantic fidelity —
+  we shadow-copy generators, we do **not** disable them).
+- Analyzer assemblies are **deduplicated across solutions** (many/long-lived usage) rather than
+  copied+loaded once per solution.
+- `unload_solution` makes a best-effort release of analyzer assemblies (collectible load context).
+
+## Non-goals
+
+- Reusing Roslyn's internal loader via reflection (fragile across versions — rejected).
+- Guaranteeing synchronous unload of native/pinned generator assemblies (collectible ALC is
+  best-effort; some generators pin themselves — documented, not fixed here).
+- Changing the eager-warmup model as the *primary* fix (see Phase 4 — optional deferral only).
+
+## Loader scope decision (resolved)
+
+The server is used in a **many / long-lived** mode — a persistent process accumulating many
+solutions over a session. That rules out both pure options:
+
+- **Pure per-solution loader** duplicates the same analyzer (e.g. one popular generator version
+  shared by N loaded solutions) N× on disk and in memory — real bloat over a long session.
+- **Pure process-wide loader** dedups but never releases; a long-lived server's analyzer memory
+  only grows and `unload_solution` reclaims nothing.
+
+**Chosen: a refcounted shared cache behind a per-solution facade.** Analyzer assemblies are
+shared across solutions (dedup) but each distinct identity lives in its own collectible load
+context with a reference count, so the last solution to unload it triggers release (reclaim).
+
+Two sub-decisions, with rationale:
+
+- **Key = `(fullPath, fileLength, lastWriteTimeUtc)`.** The dominant dedup case is many solutions
+  referencing the *same* NuGet-restored analyzer path, so path alone carries most of the win;
+  `size + mtime` guards the rebuilt-`bin\Debug`-generator case. Content hashing buys cross-path
+  dedup that effectively never occurs for analyzers — **not** done (YAGNI).
+- **Self-contained per-identity ALC** (analyzer + its sibling deps shadow-copied into one entry
+  and resolved within that entry's ALC). We deliberately **do not** build a shared cross-ALC
+  dependency graph: cross-ALC type identity + resolution ordering + partial unload all having to
+  be correct at once is the classic source of load-context bugs, and it only dedups a *dependency*
+  lib shared between *different* analyzers — rare. Self-contained ALCs keep the dominant dedup
+  (same generator across many solutions = one identity = one ALC) at a fraction of the risk.
+
+**Isolation principle:** the caching strategy lives entirely behind the per-solution
+`IAnalyzerAssemblyLoader` facade. The load-path integration (Phase 2) and dispose wiring (Phase 3)
+depend only on the interface, never on the cache. Consequences: the build-lock fix (the actual
+bug) is testable with a trivial backing store; the shared cache + refcounting is a swappable
+component with its own tests; if unload-release proves to reclaim little in practice, the cache
+can be dialled back to dead-simple without touching the load paths.
+
+> **Reality check on release.** A collectible ALC only frees after GC drops every compilation and
+> symbol rooted in it, and a generator that spins up threads / registers statics / loads native
+> libs pins itself and never unloads. Refcount-zero is therefore a *request*; release is partial
+> and non-deterministic. We do **not** predicate the fix on reliable reclaim — the build-lock fix
+> (shadow copy) stands on its own.
+
+## Design
+
+### Phase 1 — Shadow-copy loader + shared cache
+
+Two collaborating types (new files under `src/RoslynCodeLens/`):
+
+**`SharedAnalyzerAssemblyCache`** — process-wide singleton, the swappable backing store:
+
+```csharp
+internal sealed class SharedAnalyzerAssemblyCache
+{
+    private readonly record struct AnalyzerKey(string FullPath, long Length, DateTime LastWriteUtc);
+    private sealed class Entry
+    {
+        public string ShadowDir = "";
+        public AssemblyLoadContext Alc = default!;   // isCollectible: true, one per identity
+        public int RefCount;
+        public Assembly? Root;
+    }
+    private readonly ConcurrentDictionary<AnalyzerKey, Entry> _entries = new();
+
+    public Assembly Acquire(string fullPath, IReadOnlyList<string> dependencyPaths);  // refcount++, create-on-first
+    public void Release(string fullPath);                                             // refcount--, Unload+delete at 0
+}
+```
+
+- **Self-contained ALC:** on first `Acquire`, shadow-copy the analyzer *and* its
+  `dependencyPaths` (the sibling DLLs supplied via `AddDependencyLocation`) into the entry's
+  shadow dir; the ALC's `Resolving` handler serves deps from that dir by simple name.
+- **Thread-safety:** `Acquire`/`Release` run under a per-entry lock (parallel warmup calls them
+  concurrently). Idempotent copy: reuse a byte-identical existing shadow file.
+- **Release:** at refcount 0, `Alc.Unload()` (best-effort — see reality check) and recursively
+  delete the shadow dir; drop the entry.
+
+**`ShadowCopyAnalyzerAssemblyLoader`** — thin per-solution facade implementing the public
+`IAnalyzerAssemblyLoader`, owned by one `SolutionManager`:
+
+```csharp
+internal sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader, IDisposable
+{
+    private readonly SharedAnalyzerAssemblyCache _cache;
+    private readonly ConcurrentBag<string> _dependencyLocations = new();  // seen via AddDependencyLocation
+    private readonly HashSet<string> _acquired = new(OrdinalIgnoreCase);  // for symmetric release
+
+    public void AddDependencyLocation(string fullPath) => _dependencyLocations.Add(fullPath);
+    public Assembly LoadFromPath(string fullPath)      // Acquire(fullPath, siblingDeps); track in _acquired
+    public void Dispose()                              // Release each path in _acquired
+}
+```
+
+The facade is the *only* thing the load paths know about; swapping `SharedAnalyzerAssemblyCache`
+for a trivial store changes nothing else.
+
+### Phase 2 — Inject the loader into both load paths
+
+Add a helper (in `SolutionLoader` or a small `AnalyzerReferenceRemapper`):
+
+```csharp
+// Rebuild every AnalyzerFileReference in a project to use `loader`.
+static IReadOnlyList<AnalyzerReference> Remap(IEnumerable<AnalyzerReference> refs, IAnalyzerAssemblyLoader loader)
+```
+
+For each `AnalyzerFileReference`, pre-call `loader.AddDependencyLocation(afr.FullPath)` for the
+whole project's analyzer set, then emit `new AnalyzerFileReference(afr.FullPath, loader)`.
+Non-file analyzer references (rare) pass through unchanged.
+
+Two application points — **one facade loader per loaded solution** (owned by `SolutionManager`,
+so its lifetime matches unload; it shares assemblies through the process-wide cache):
+
+- **Per-project / re-stitch path:** in `ToDetachedInfoAsync`
+  ([SolutionLoader.cs:349-365](../../src/RoslynCodeLens/SolutionLoader.cs)) pass
+  `analyzerReferences: Remap(project.AnalyzerReferences, loader)`.
+- **Solution-level path:** after `OpenSolutionAsync` succeeds
+  ([SolutionLoader.cs:93-96](../../src/RoslynCodeLens/SolutionLoader.cs)) and **before** warmup
+  compiles, rewrite each project:
+  `solution = solution.WithProjectAnalyzerReferences(projectId, Remap(...))` (or remove+add).
+  Because generators only execute at `GetCompilationAsync` time (during warmup, after open),
+  remapping between open and warmup is sufficient — the original is never loaded in-process.
+
+Threading the loader through requires `OpenAsync`/`OpenPerProjectAsync` to accept (or return) the
+loader. Cleanest: `SolutionManager.CreateAsync` constructs the loader, passes it into
+`loader.OpenAsync(...)`, and stores it for disposal.
+
+### Phase 3 — Own and dispose the workspace + loader
+
+- `SolutionManager` gains `private ShadowCopyAnalyzerAssemblyLoader? _analyzerLoader;` (the
+  per-solution facade) and `private Workspace? _workspace;` (stop discarding it).
+- `Dispose()` ([SolutionManager.cs:293](../../src/RoslynCodeLens/SolutionManager.cs)) also
+  disposes `_workspace` and `_analyzerLoader` — the facade `Release`s its acquired set, dropping
+  each shared-cache refcount and unloading + deleting any entry that hits zero. This is what
+  finally lets `unload_solution`
+  ([MultiSolutionManager.cs:226](../../src/RoslynCodeLens/MultiSolutionManager.cs)) release the
+  lock (best-effort; see reality check above).
+- `ForceReloadAsync` ([SolutionManager.cs:262](../../src/RoslynCodeLens/SolutionManager.cs)) must
+  dispose the previous workspace/loader before replacing them.
+
+### Phase 4 — (Optional) deferred warmup
+
+Secondary, not required for the fix: gate eager warmup behind an env var
+(`ROSLYN_CODELENS_EAGER_WARMUP`, default on) so users on generator-heavy solutions can defer the
+lock/CPU until first tool use. Compilation still happens lazily on first tool call, so this only
+moves the (now shadow-copied, harmless) lock later. Include only if cheap.
+
+## Testing
+
+New fixture: a minimal `netstandard2.0` **incremental source generator** referenced by a target
+project via `OutputItemType="Analyzer"` / `ReferenceOutputAssembly="false"` — under
+`tests/RoslynCodeLens.Tests/Fixtures/` (add it to the `<Compile Remove>` exclusion set in the
+test csproj, same as the other fixtures — see note below).
+
+1. **Unit — loader shadow-copies:** `LoadFromPath` returns an assembly whose `Location` is under
+   the shadow root, not the original path; second call returns the same instance.
+2. **Integration — lock released:** load the generator fixture solution, run warmup, then assert
+   the original generator DLL in `bin\Debug` **can be overwritten/deleted** (proves it is
+   unlocked). This is the direct regression test for #254.
+3. **Integration — semantics preserved:** a symbol emitted by the generator still resolves
+   through the normal tools (generated code is still compiled, just from a shadow copy).
+4. **Unit — dispose unloads:** after `SolutionManager.Dispose()`, the shadow directory is
+   deleted (best-effort) and no handle to the original remains.
+
+**Pre-req fix (separate, tiny):** the test csproj excludes `TestSolution`/`TestSolutionAlt`/
+`LegacySolution` from `<Compile Remove>` but **not** `FilterableSolution`; any new fixture
+solution must be added to that list or its generated `AssemblyInfo.cs` breaks the test compile
+(observed during investigation of #252). Add the new fixture — and `FilterableSolution` — to the
+exclusion set.
+
+## Risks & mitigations
+
+- **Custom loader correctness (dependency resolution).** Roslyn's internal loader handles edge
+  cases (native DLLs, culture resources, version redirects). Mitigate: resolve siblings by simple
+  name from the analyzer's own directory; log + fall through on miss. Generators with exotic
+  loading may still fail — acceptable, and no worse than a hard lock.
+- **Collectible ALC won't fully unload if a generator pins itself** (static state, unmanaged
+  handles). `unload_solution` release is therefore **best-effort**; document it. The build-lock
+  fix (shadow copy) does not depend on unload working.
+- **Shadow-copy disk/latency cost** at load: bounded by analyzer-set size; copies are per-solution
+  and cleaned on unload. Negligible vs. compilation cost.
+- **`WithProjectAnalyzerReferences` API shape** — verify the exact `Solution`/`Project` mutation
+  method at implementation time (remove+add is the fallback).
+
+## Rollout
+
+1. Land loader + injection + dispose (Phases 1-3) with the generator fixture and the four tests.
+2. `dotnet build` + `dotnet test` green; manually reproduce #254 against the fixture and confirm
+   a concurrent CLI build now succeeds.
+3. Optional Phase 4 in a follow-up if desired.
+4. Comment on #254 with the outcome and the `ShadowCopyAnalyzerAssemblyLoader`-is-internal note
+   (so future readers know why we rolled our own).
+
+## Resolved decisions
+
+- **Loader scope:** refcounted process-wide shared cache behind a per-solution facade (dedup +
+  best-effort release). See "Loader scope decision" above. Driven by many/long-lived usage.
+- **Cache key:** `(fullPath, fileLength, lastWriteTimeUtc)` — no content hashing.
+- **ALC granularity:** self-contained per analyzer identity — no shared cross-ALC dependency graph.
+- **Isolation:** caching strategy sits entirely behind the `IAnalyzerAssemblyLoader` facade, so the
+  build-lock fix and the cache are independently testable and the cache is swappable.
+
+## Remaining questions for the implementation plan
+
+- Exact `Solution`/`Project` mutation API for rewriting analyzer references
+  (`WithProjectAnalyzerReferences` vs remove+add) — verify against 5.6.0 at implementation time.
+- How the facade discovers an analyzer's sibling dependency paths for `Acquire` — from the
+  `AddDependencyLocation` calls Roslyn makes, vs. scanning the analyzer's directory. Confirm the
+  ordering (are all `AddDependencyLocation` calls made before the first `LoadFromPath`?).

--- a/docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy.md
+++ b/docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy.md
@@ -1,0 +1,749 @@
+# Analyzer / Generator DLL Lock — Shadow-Copy Loader Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop the server locking source-generator/analyzer DLLs in `bin\Debug` (issue #254) by loading analyzer assemblies from per-identity shadow copies through a refcounted process-wide cache, so a concurrent `dotnet build` succeeds while the server runs.
+
+**Architecture:** A `SharedAnalyzerAssemblyCache` (process singleton) shadow-copies each distinct analyzer identity into its own **collectible** `AssemblyLoadContext` and reference-counts it. A thin per-solution `ShadowCopyAnalyzerAssemblyLoader` facade (implements Roslyn's public `IAnalyzerAssemblyLoader`) is injected into every project's `AnalyzerFileReference`s on load and disposed on unload. All caching lives behind the facade interface so the load-path wiring never depends on it. See design: [2026-07-05-analyzer-dll-lock-shadow-copy-design.md](2026-07-05-analyzer-dll-lock-shadow-copy-design.md).
+
+**Tech Stack:** C# / .NET 10, Roslyn 5.6.0 (`Microsoft.CodeAnalysis.*`), `System.Runtime.Loader.AssemblyLoadContext`, xUnit.
+
+**Verified API facts (5.6.0):** `ShadowCopyAnalyzerAssemblyLoader` is **internal** (we roll our own). Public: `IAnalyzerAssemblyLoader { Assembly LoadFromPath(string); void AddDependencyLocation(string); }`, `AnalyzerFileReference(string fullPath, IAnalyzerAssemblyLoader loader)`, `AnalyzerFileReference.FullPath`, `Solution.WithProjectAnalyzerReferences(ProjectId, IEnumerable<AnalyzerReference>)`.
+
+**Conventions:** TDD (@superpowers:test-driven-development) — failing test first, minimal code, green, commit. Build: `dotnet build`. Test one class: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~<ClassName>"`. Analyzers (Meziantou/Roslynator etc.) run in-build and treat many things as warnings — keep new code clean (ConfigureAwait, StringComparison, etc.).
+
+---
+
+## Task 0: Pre-req — fix test-project fixture exclusion
+
+The test csproj excludes some fixture solutions from compile but **not** `FilterableSolution`; once any fixture project is built, its generated `AssemblyInfo.cs` gets globbed into the test compile and breaks it (observed while reviewing #252). We add a source-generator fixture later, so fix the glob now.
+
+**Files:**
+- Modify: `tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj`
+
+**Step 1: Edit the exclusion set**
+
+Replace the `Compile Remove` / `None Include` block so **all** fixture solution folders are covered:
+
+```xml
+  <ItemGroup>
+    <Compile Remove="Fixtures\TestSolution\**" />
+    <Compile Remove="Fixtures\TestSolutionAlt\**" />
+    <Compile Remove="Fixtures\LegacySolution\**" />
+    <Compile Remove="Fixtures\FilterableSolution\**" />
+    <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\FilterableSolution\**" CopyToOutputDirectory="Never" />
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+```
+
+**Step 2: Verify build still green**
+
+Run: `dotnet build tests/RoslynCodeLens.Tests`
+Expected: `Build succeeded. 0 Error(s)`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+git commit -m "build(test): exclude FilterableSolution fixture from compile"
+```
+
+---
+
+## Task 1: `SharedAnalyzerAssemblyCache` — shadow copy + collectible ALC + refcount
+
+The heart of the fix. Loads a DLL from a shadow copy so the original is never locked; dedups by identity; releases (unloads) at refcount zero. **These tests are the primary #254 regression guard and need no MSBuild.**
+
+**Files:**
+- Create: `src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs`
+- Test: `tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs`
+
+**Step 1: Write failing tests**
+
+```csharp
+using System.Runtime.CompilerServices;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class SharedAnalyzerAssemblyCacheTests : IDisposable
+{
+    private readonly string _tmp = Path.Combine(Path.GetTempPath(), "rcl-cache-test", Guid.NewGuid().ToString("N"));
+
+    public SharedAnalyzerAssemblyCacheTests() => Directory.CreateDirectory(_tmp);
+    public void Dispose() { try { Directory.Delete(_tmp, recursive: true); } catch { /* best effort */ } }
+
+    // Copy an arbitrary real assembly to act as a stand-in "analyzer" we are allowed to delete.
+    private string MakeFakeAnalyzer(string name)
+    {
+        var src = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+        var dst = Path.Combine(_tmp, name + ".dll");
+        File.Copy(src, dst, overwrite: true);
+        return dst;
+    }
+
+    [Fact]
+    public void Acquire_LoadsFromShadowCopy_NotOriginalPath()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Alpha");
+
+        var asm = cache.Acquire(original, Array.Empty<string>());
+
+        Assert.NotNull(asm);
+        Assert.NotEqual(
+            Path.GetFullPath(original),
+            Path.GetFullPath(asm.Location),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Acquire_LeavesOriginalFileUnlocked()   // THE #254 regression guard
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Beta");
+
+        cache.Acquire(original, Array.Empty<string>());
+
+        // If the original were locked (the bug), this throws IOException.
+        var ex = Record.Exception(() => File.Delete(original));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Acquire_SamePathTwice_DedupsToSameAssembly()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Gamma");
+
+        var a = cache.Acquire(original, Array.Empty<string>());
+        var b = cache.Acquire(original, Array.Empty<string>());
+
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void Release_UnloadsOnlyWhenRefCountReachesZero()
+    {
+        var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Delta");
+        var shadowDirBefore = Path.GetDirectoryName(cache.Acquire(original, Array.Empty<string>()).Location)!;
+        cache.Acquire(original, Array.Empty<string>());   // refcount = 2
+
+        cache.Release(original);                           // -> 1, still present
+        Assert.True(Directory.Exists(shadowDirBefore));
+
+        cache.Release(original);                           // -> 0, unloaded + shadow removed
+        ForceGc();
+        Assert.False(Directory.Exists(shadowDirBefore));
+        cache.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ForceGc()
+    {
+        for (var i = 0; i < 3; i++) { GC.Collect(); GC.WaitForPendingFinalizers(); }
+    }
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~SharedAnalyzerAssemblyCacheTests"`
+Expected: FAIL — `SharedAnalyzerAssemblyCache` does not exist (compile error).
+
+**Step 3: Implement**
+
+```csharp
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Process-wide cache of analyzer/generator assemblies loaded from shadow copies so the
+/// originals in bin\Debug stay unlocked (issue #254). Each distinct analyzer identity gets
+/// its own collectible AssemblyLoadContext and is reference-counted: when the last holder
+/// releases it, the ALC is unloaded (best-effort) and the shadow copy deleted.
+/// </summary>
+public sealed class SharedAnalyzerAssemblyCache : IDisposable
+{
+    private readonly record struct Key(string Path, long Length, DateTime LastWriteUtc);
+
+    private sealed class Entry
+    {
+        public required string ShadowDir { get; init; }
+        public required AssemblyLoadContext Alc { get; init; }
+        public required Assembly Root { get; init; }
+        public int RefCount;
+    }
+
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "roslyn-codelens-shadow", Guid.NewGuid().ToString("N"));
+    private readonly ConcurrentDictionary<Key, Entry> _entries = new();
+    private readonly Lock _gate = new();
+    private bool _disposed;
+
+    private static Key KeyFor(string fullPath)
+    {
+        var fi = new FileInfo(fullPath);
+        return new Key(Path.GetFullPath(fullPath), fi.Length, fi.LastWriteTimeUtc);
+    }
+
+    /// <summary>Load <paramref name="analyzerPath"/> from a shadow copy, incrementing its refcount.</summary>
+    /// <param name="dependencyPaths">Sibling dependency locations Roslyn reported for this analyzer.</param>
+    public Assembly Acquire(string analyzerPath, IReadOnlyList<string> dependencyPaths)
+    {
+        var key = KeyFor(analyzerPath);
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_entries.TryGetValue(key, out var existing))
+            {
+                existing.RefCount++;
+                return existing.Root;
+            }
+
+            var shadowDir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(shadowDir);
+            var shadowPath = ShadowCopy(analyzerPath, shadowDir);
+
+            var alc = new AssemblyLoadContext($"analyzer:{Path.GetFileName(analyzerPath)}", isCollectible: true);
+            alc.Resolving += (ctx, name) => ResolveDependency(ctx, name, analyzerPath, dependencyPaths, shadowDir);
+
+            var root = alc.LoadFromAssemblyPath(shadowPath);
+            _entries[key] = new Entry { ShadowDir = shadowDir, Alc = alc, Root = root, RefCount = 1 };
+            return root;
+        }
+    }
+
+    /// <summary>Decrement the refcount; at zero, unload the ALC and delete the shadow copy.</summary>
+    public void Release(string analyzerPath)
+    {
+        var key = KeyFor(analyzerPath);
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(key, out var entry))
+                return;
+            if (--entry.RefCount > 0)
+                return;
+
+            _entries.TryRemove(key, out _);
+            entry.Alc.Unload();
+            TryDeleteDir(entry.ShadowDir);
+        }
+    }
+
+    private static Assembly? ResolveDependency(
+        AssemblyLoadContext ctx, AssemblyName name, string analyzerPath,
+        IReadOnlyList<string> dependencyPaths, string shadowDir)
+    {
+        var file = name.Name + ".dll";
+
+        // Prefer the dependency locations Roslyn told us about, then the analyzer's own directory.
+        var candidate =
+            dependencyPaths.FirstOrDefault(p =>
+                string.Equals(Path.GetFileName(p), file, StringComparison.OrdinalIgnoreCase))
+            ?? Path.Combine(Path.GetDirectoryName(analyzerPath)!, file);
+
+        if (!File.Exists(candidate))
+            return null;
+
+        var shadow = ShadowCopy(candidate, shadowDir);
+        return ctx.LoadFromAssemblyPath(shadow);
+    }
+
+    private static string ShadowCopy(string source, string shadowDir)
+    {
+        var dest = Path.Combine(shadowDir, Path.GetFileName(source));
+        if (!File.Exists(dest))
+            File.Copy(source, dest, overwrite: false);
+        return dest;
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* shadow files may still be memory-mapped until GC; cleaned on next process run */ }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            foreach (var entry in _entries.Values)
+                entry.Alc.Unload();
+            _entries.Clear();
+            TryDeleteDir(_root);
+        }
+    }
+}
+```
+
+**Step 4: Run to verify pass**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~SharedAnalyzerAssemblyCacheTests"`
+Expected: PASS (4 tests). If `Release_Unloads...` flakes on shadow-dir deletion (mmap not yet released), keep the assertion but note best-effort; if it proves flaky in CI, relax to asserting the entry is gone rather than the directory.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs
+git commit -m "feat(analyzers): shadow-copy assembly cache with refcounted collectible ALC (#254)"
+```
+
+---
+
+## Task 2: `ShadowCopyAnalyzerAssemblyLoader` — per-solution facade
+
+Thin adapter implementing Roslyn's `IAnalyzerAssemblyLoader`, delegating to the shared cache and releasing its set on dispose. This is the only type the load paths reference.
+
+**Files:**
+- Create: `src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs`
+- Test: `tests/RoslynCodeLens.Tests/Analyzers/ShadowCopyAnalyzerAssemblyLoaderTests.cs`
+
+**Step 1: Write failing tests**
+
+```csharp
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class ShadowCopyAnalyzerAssemblyLoaderTests : IDisposable
+{
+    private readonly string _tmp = Path.Combine(Path.GetTempPath(), "rcl-facade-test", Guid.NewGuid().ToString("N"));
+    public ShadowCopyAnalyzerAssemblyLoaderTests() => Directory.CreateDirectory(_tmp);
+    public void Dispose() { try { Directory.Delete(_tmp, true); } catch { } }
+
+    private string MakeFake(string n)
+    {
+        var dst = Path.Combine(_tmp, n + ".dll");
+        File.Copy(typeof(System.Text.Json.JsonSerializer).Assembly.Location, dst, true);
+        return dst;
+    }
+
+    [Fact]
+    public void LoadFromPath_ReturnsShadowedAssembly_AndLeavesOriginalUnlocked()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var original = MakeFake("Facade1");
+        loader.AddDependencyLocation(original);
+
+        var asm = loader.LoadFromPath(original);
+
+        Assert.NotNull(asm);
+        Assert.Null(Record.Exception(() => File.Delete(original)));
+    }
+
+    [Fact]
+    public void Dispose_ReleasesAcquiredAssemblies()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFake("Facade2");
+        string shadowDir;
+        using (var loader = new ShadowCopyAnalyzerAssemblyLoader(cache))
+        {
+            loader.AddDependencyLocation(original);
+            shadowDir = Path.GetDirectoryName(loader.LoadFromPath(original).Location)!;
+        }
+        for (var i = 0; i < 3; i++) { GC.Collect(); GC.WaitForPendingFinalizers(); }
+        Assert.False(Directory.Exists(shadowDir));
+    }
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~ShadowCopyAnalyzerAssemblyLoaderTests"`
+Expected: FAIL — type does not exist.
+
+**Step 3: Implement**
+
+```csharp
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Per-solution <see cref="IAnalyzerAssemblyLoader"/> that loads analyzers through the process-wide
+/// <see cref="SharedAnalyzerAssemblyCache"/> (shadow copies, no bin\Debug lock — issue #254).
+/// Tracks what it acquired and releases it on <see cref="Dispose"/> so unload_solution can reclaim.
+/// </summary>
+public sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader, IDisposable
+{
+    private readonly SharedAnalyzerAssemblyCache _cache;
+    private readonly ConcurrentBag<string> _dependencyLocations = new();
+    private readonly ConcurrentDictionary<string, byte> _acquired = new(StringComparer.OrdinalIgnoreCase);
+
+    public ShadowCopyAnalyzerAssemblyLoader(SharedAnalyzerAssemblyCache cache) => _cache = cache;
+
+    public void AddDependencyLocation(string fullPath) => _dependencyLocations.Add(fullPath);
+
+    public Assembly LoadFromPath(string fullPath)
+    {
+        var full = Path.GetFullPath(fullPath);
+        var asm = _cache.Acquire(full, _dependencyLocations.ToArray());
+        _acquired.TryAdd(full, 0);
+        return asm;
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in _acquired.Keys)
+            _cache.Release(path);
+        _acquired.Clear();
+    }
+}
+```
+
+Note: `_acquired` is a set (dedups repeated `LoadFromPath` of the same path), so each path is released exactly once — matching the single net refcount this facade added per identity. (If Roslyn calls `LoadFromPath` for the same path twice on one loader, `Acquire` bumps the refcount twice but we release once; acceptable because the process-wide entry survives until *all* facades release — verify during Task 6 that repeated loads within one solution don't leak. If they can, switch `_acquired` to a count.)
+
+**Step 4: Run to verify pass**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~ShadowCopyAnalyzerAssemblyLoaderTests"`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs tests/RoslynCodeLens.Tests/Analyzers/ShadowCopyAnalyzerAssemblyLoaderTests.cs
+git commit -m "feat(analyzers): per-solution shadow-copy loader facade (#254)"
+```
+
+---
+
+## Task 3: Remap analyzer references + thread the loader through `SolutionLoader`
+
+Inject the facade into every project's `AnalyzerFileReference`s, on **both** load paths. Backward-compatible: when no loader is passed, behaviour is unchanged (existing tests unaffected).
+
+**Files:**
+- Create: `src/RoslynCodeLens/Analyzers/AnalyzerReferenceRemapper.cs`
+- Modify: `src/RoslynCodeLens/SolutionLoader.cs` (thread `IAnalyzerAssemblyLoader?` through `OpenAsync` → `OpenPerProjectAsync`/`OpenFilteredAsync`/`ToDetachedInfoAsync`, and remap the solution-level path)
+- Test: `tests/RoslynCodeLens.Tests/Analyzers/AnalyzerReferenceRemapperTests.cs`
+
+**Step 1: Write failing test for the remapper**
+
+```csharp
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class AnalyzerReferenceRemapperTests
+{
+    [Fact]
+    public void Remap_RewritesFileReferences_PreservingPaths()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var path = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+        var input = new AnalyzerReference[] { new AnalyzerFileReference(path, AnalyzerAssemblyLoader.Instance) };
+
+        var result = AnalyzerReferenceRemapper.Remap(input, loader);
+
+        var afr = Assert.IsType<AnalyzerFileReference>(Assert.Single(result));
+        Assert.Equal(path, afr.FullPath, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Remap_PassesThroughNonFileReferences()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var stub = new StubReference();
+
+        var result = AnalyzerReferenceRemapper.Remap(new AnalyzerReference[] { stub }, loader);
+
+        Assert.Same(stub, Assert.Single(result));
+    }
+
+    private sealed class StubReference : AnalyzerReference
+    {
+        public override string? FullPath => null;
+        public override object Id => "stub";
+        public override System.Collections.Immutable.ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => [];
+        public override System.Collections.Immutable.ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => [];
+    }
+}
+```
+
+> Note: `AnalyzerAssemblyLoader.Instance` in the test is only a placeholder existing loader for constructing the input. If that helper is not public in 5.6.0, construct the input `AnalyzerFileReference` with the `loader` under test instead — the assertion only checks `FullPath` is preserved.
+
+**Step 2: Run to verify failure**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~AnalyzerReferenceRemapperTests"`
+Expected: FAIL — remapper does not exist.
+
+**Step 3: Implement the remapper**
+
+```csharp
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Rebuilds a project's <see cref="AnalyzerFileReference"/>s so they resolve their assemblies
+/// through our <see cref="ShadowCopyAnalyzerAssemblyLoader"/> instead of the default (locking)
+/// MSBuildWorkspace loader. Non-file references are passed through unchanged.
+/// </summary>
+public static class AnalyzerReferenceRemapper
+{
+    public static IReadOnlyList<AnalyzerReference> Remap(
+        IEnumerable<AnalyzerReference> references, ShadowCopyAnalyzerAssemblyLoader loader)
+    {
+        var fileRefs = references
+            .OfType<AnalyzerFileReference>()
+            .ToList();
+
+        // Pre-register every analyzer path so cross-analyzer dependency resolution can find siblings.
+        foreach (var fr in fileRefs)
+            loader.AddDependencyLocation(fr.FullPath);
+
+        var result = new List<AnalyzerReference>();
+        foreach (var r in references)
+        {
+            result.Add(r is AnalyzerFileReference fr
+                ? new AnalyzerFileReference(fr.FullPath, loader)
+                : r);
+        }
+        return result;
+    }
+}
+```
+
+**Step 4: Run to verify pass** — `dotnet test ... --filter "...AnalyzerReferenceRemapperTests"` → PASS.
+
+**Step 5: Thread the loader through `SolutionLoader`**
+
+In `src/RoslynCodeLens/SolutionLoader.cs`:
+
+(a) `OpenAsync` signature — add the optional loader:
+```csharp
+public async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(
+    string solutionPath, ProjectFilter? filter = null,
+    ShadowCopyAnalyzerAssemblyLoader? analyzerLoader = null, CancellationToken ct = default)
+```
+Forward `analyzerLoader` into the two internal calls (`OpenFilteredAsync`, `OpenPerProjectAsync`) — add the same optional param to both, and to the private `OpenPerProjectAsync`/`OpenFilteredAsync` signatures.
+
+(b) Solution-level path — after the `solution is null` guard (before `return (solution, workspace, ...)`), remap when a loader is present:
+```csharp
+if (analyzerLoader is not null)
+    solution = RemapSolutionAnalyzers(solution, analyzerLoader);
+
+return (solution, workspace, Array.Empty<SkippedProject>());
+```
+with a private helper:
+```csharp
+private static Solution RemapSolutionAnalyzers(Solution solution, ShadowCopyAnalyzerAssemblyLoader loader)
+{
+    foreach (var project in solution.Projects)
+    {
+        if (project.AnalyzerReferences.Count == 0)
+            continue;
+        var remapped = AnalyzerReferenceRemapper.Remap(project.AnalyzerReferences, loader);
+        solution = solution.WithProjectAnalyzerReferences(project.Id, remapped);
+    }
+    return solution;
+}
+```
+
+(c) Per-project path — `ToDetachedInfoAsync` takes the loader and remaps:
+```csharp
+private static async Task<ProjectInfo> ToDetachedInfoAsync(Project project, ShadowCopyAnalyzerAssemblyLoader? loader)
+{
+    ...
+    analyzerReferences: loader is null
+        ? project.AnalyzerReferences
+        : AnalyzerReferenceRemapper.Remap(project.AnalyzerReferences, loader),
+    ...
+}
+```
+Thread `loader` from `OpenPerProjectAsync` into the `ToDetachedInfoAsync(p)` call site (the capture loop). Add `using RoslynCodeLens.Analyzers;`.
+
+**Step 6: Build + run the full analyzer test folder and the existing loader tests**
+
+Run: `dotnet build src/RoslynCodeLens` then
+`dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~Analyzers|FullyQualifiedName~SolutionLoader"`
+Expected: PASS; existing `SolutionLoader*`/`ProjectFilter*` tests unaffected (loader defaults to null).
+
+**Step 7: Commit**
+
+```bash
+git add src/RoslynCodeLens/Analyzers/AnalyzerReferenceRemapper.cs src/RoslynCodeLens/SolutionLoader.cs tests/RoslynCodeLens.Tests/Analyzers/AnalyzerReferenceRemapperTests.cs
+git commit -m "feat(loader): remap analyzer references through shadow-copy loader (#254)"
+```
+
+---
+
+## Task 4: `SolutionManager` owns the loader + workspace; dispose releases
+
+Give each solution its own facade loader over a shared cache, stop leaking the workspace, and release everything on unload.
+
+**Files:**
+- Modify: `src/RoslynCodeLens/SolutionManager.cs`
+- (No new tests here — behaviour is exercised end-to-end in Task 6; this task is wiring.)
+
+**Step 1: Add fields + a process-wide cache**
+
+At the top of `SolutionManager`:
+```csharp
+private static readonly SharedAnalyzerAssemblyCache SharedCache = new();
+private ShadowCopyAnalyzerAssemblyLoader? _analyzerLoader;
+private Workspace? _workspace;
+```
+Add `using RoslynCodeLens.Analyzers;`.
+
+> The static `SharedCache` is intentionally process-lifetime (never disposed) — it is the dedup layer; individual solutions release their entries via the facade. This is the "process-wide cache, per-solution facade" decision.
+
+**Step 2: Construct + store the loader in `CreateAsync`**
+
+Replace the discard with capture:
+```csharp
+var loader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
+Solution solution;
+Workspace workspace;
+IReadOnlyList<SkippedProject> skipped;
+try
+{
+    (solution, workspace, skipped) = await loader is null   // (always non-null; keeps shape)
+        ? default
+        : await new SolutionLoader().OpenAsync(solutionPath, filter, loader).ConfigureAwait(false);
+}
+```
+Simpler — just:
+```csharp
+var loader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
+(solution, workspace, skipped) =
+    await loaderInstance.OpenAsync(solutionPath, filter, loader).ConfigureAwait(false);
+```
+Then pass `loader`/`workspace` into the `SolutionManager` instance (extend the private ctor or assign after construction) so `WarmupAsync` compiles the already-remapped `solution`. Store `_analyzerLoader = loader; _workspace = workspace;`.
+
+Do the same capture in `ForceReloadAsync` ([SolutionManager.cs:262](../../src/RoslynCodeLens/SolutionManager.cs)): create a fresh loader, `OpenAsync(..., loader)`, and **dispose the previous** `_workspace`/`_analyzerLoader` before replacing them.
+
+**Step 3: Dispose releases**
+
+```csharp
+public void Dispose()
+{
+    _tracker?.Dispose();
+    _peCache.Dispose();
+    _workspace?.Dispose();
+    _analyzerLoader?.Dispose();   // Release() each acquired analyzer -> refcount--, unload at zero
+}
+```
+
+**Step 4: Build + run the existing manager/integration tests**
+
+Run: `dotnet build` then `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~SolutionManager|FullyQualifiedName~MultiSolution"`
+Expected: PASS (note: some coverage/metadata integration tests may fail *locally* due to the known MSBuildWorkspace load flake — confirm they pass in CI; they are unrelated to this change).
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/SolutionManager.cs
+git commit -m "feat(manager): own + dispose analyzer loader and workspace; release on unload (#254)"
+```
+
+---
+
+## Task 5: Source-generator fixture + end-to-end tests
+
+Prove (a) a loaded solution's generator DLL is unlocked, and (b) generated symbols still resolve.
+
+**Files:**
+- Create fixture generator: `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/SampleGenerator/SampleGenerator.csproj` + `HelloGenerator.cs`
+- Modify fixture consumer: add an `Analyzer` reference to `SampleGenerator` from `TestLib` (`.csproj`), so loading TestSolution loads the generator.
+- Test: `tests/RoslynCodeLens.Tests/Analyzers/GeneratorLockIntegrationTests.cs`
+
+**Step 1: Add the generator project**
+
+`SampleGenerator.csproj`:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <IsRoslynComponent>true</IsRoslynComponent>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>
+```
+`HelloGenerator.cs` — a trivial incremental generator emitting `namespace Generated { public static class Hello { public const string Message = "hi"; } }`.
+
+`TestLib.csproj` gains:
+```xml
+<ItemGroup>
+  <ProjectReference Include="..\SampleGenerator\SampleGenerator.csproj"
+      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+</ItemGroup>
+```
+Add `SampleGenerator` to the TestSolution `.sln`. (This fixture is compile-excluded by Task 0's glob.)
+
+**Step 2: Write the integration tests**
+
+```csharp
+[Collection("TestSolution")]
+public class GeneratorLockIntegrationTests
+{
+    private readonly TestSolutionFixture _fixture;
+    public GeneratorLockIntegrationTests(TestSolutionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void GeneratedSymbol_IsResolvable()
+    {
+        var loaded = _fixture.Loaded;   // fixture loads via SolutionManager (uses shadow loader)
+        var comp = loaded.Compilations.Values
+            .FirstOrDefault(c => c.GetTypeByMetadataName("Generated.Hello") is not null);
+        Assert.NotNull(comp);   // generator ran through the shadow copy; symbol exists
+    }
+}
+```
+> The direct "original DLL is deletable after load" property is already proven deterministically by `SharedAnalyzerAssemblyCacheTests.Acquire_LeavesOriginalFileUnlocked`. This fixture test adds the end-to-end confirmation that shadow-loading does **not** cost generated-symbol fidelity. If `TestSolutionFixture` does not currently execute generators (it may only `OpenAsync` without full warmup), extend it — or add a dedicated `SolutionManager.CreateAsync` load in this test — during implementation.
+
+**Step 3: Build + run**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~GeneratorLockIntegrationTests"`
+Expected: PASS. If it flakes locally on MSBuild load, verify in CI.
+
+**Step 4: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/Fixtures/TestSolution/SampleGenerator tests/RoslynCodeLens.Tests/Fixtures/TestSolution/*.sln tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestLib/TestLib.csproj tests/RoslynCodeLens.Tests/Analyzers/GeneratorLockIntegrationTests.cs
+git commit -m "test(analyzers): source-generator fixture proves shadow-load keeps symbols (#254)"
+```
+
+---
+
+## Task 6: Full verification + manual repro
+
+**Step 1: Full test suite** — `dotnet test` → all green (bar the pre-existing local MSBuild-load flakes; confirm CI green).
+
+**Step 2: Manual #254 repro** (@superpowers:verification-before-completion) — run the built server against a generator solution, wait for "Background compilation complete", then in another terminal `dotnet build` that solution. Expected: build succeeds (previously MSB3027). Document the observed output.
+
+**Step 3: Update CHANGELOG / docs** if the repo convention requires it; note the env-var-free behaviour change.
+
+**Step 4: Comment on #254** with the outcome and the "`ShadowCopyAnalyzerAssemblyLoader` is internal, so we rolled our own" note.
+
+**Step 5: Final commit / open PR** targeting `main` from `fix/analyzer-dll-lock-254`.
+
+---
+
+## Deferred (not in this plan)
+
+- **Phase 4 deferred/opt-in warmup** (`ROSLYN_CODELENS_EAGER_WARMUP`): compilation would still lazily lock on first tool use, so it only reduces the startup window; add later only if warranted.
+- **Cross-ALC shared dependency graph**: rejected (complexity vs. rare benefit) — see design doc.
+- **Content-hash cache key**: only if cross-path dedup is ever shown to matter.

--- a/src/RoslynCodeLens/Analyzers/AnalyzerReferenceRemapper.cs
+++ b/src/RoslynCodeLens/Analyzers/AnalyzerReferenceRemapper.cs
@@ -1,0 +1,32 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Rebuilds a project's <see cref="AnalyzerFileReference"/>s so they resolve their assemblies
+/// through our <see cref="ShadowCopyAnalyzerAssemblyLoader"/> instead of the default (locking)
+/// MSBuildWorkspace loader. Non-file references are passed through unchanged.
+/// </summary>
+public static class AnalyzerReferenceRemapper
+{
+    public static IReadOnlyList<AnalyzerReference> Remap(
+        IEnumerable<AnalyzerReference> references, ShadowCopyAnalyzerAssemblyLoader loader)
+    {
+        var materialized = references as ICollection<AnalyzerReference> ?? references.ToList();
+
+        // Pre-register every analyzer path so cross-analyzer dependency resolution can find siblings.
+        foreach (var r in materialized)
+            if (r is AnalyzerFileReference fr)
+                loader.AddDependencyLocation(fr.FullPath);
+
+        var result = new List<AnalyzerReference>(materialized.Count);
+        foreach (var r in materialized)
+        {
+            result.Add(r is AnalyzerFileReference fr
+                ? new AnalyzerFileReference(fr.FullPath, loader)
+                : r);
+        }
+        return result;
+    }
+}

--- a/src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 
 namespace RoslynCodeLens.Analyzers;
@@ -15,6 +16,7 @@ public sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader, 
     private readonly SharedAnalyzerAssemblyCache _cache;
     private readonly ConcurrentBag<string> _dependencyLocations = new();
     private readonly ConcurrentBag<SharedAnalyzerAssemblyCache.AnalyzerAssemblyHandle> _handles = new();
+    private int _disposed;
 
     public ShadowCopyAnalyzerAssemblyLoader(SharedAnalyzerAssemblyCache cache) => _cache = cache;
 
@@ -29,6 +31,11 @@ public sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader, 
 
     public void Dispose()
     {
+        // Release each acquired handle AT MOST ONCE, even under double/raced Dispose —
+        // a double release would decrement a shared refcount twice and could prematurely
+        // unload another live solution's analyzer ALC.
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
         foreach (var handle in _handles)
             _cache.Release(handle);
     }

--- a/src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs
+++ b/src/RoslynCodeLens/Analyzers/ShadowCopyAnalyzerAssemblyLoader.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Per-solution <see cref="IAnalyzerAssemblyLoader"/> that loads analyzers through the process-wide
+/// <see cref="SharedAnalyzerAssemblyCache"/> (shadow copies, no bin\Debug lock — issue #254).
+/// Keeps the handle from every acquire and releases them all on <see cref="Dispose"/>, so
+/// unload_solution can reclaim (best-effort).
+/// </summary>
+public sealed class ShadowCopyAnalyzerAssemblyLoader : IAnalyzerAssemblyLoader, IDisposable
+{
+    private readonly SharedAnalyzerAssemblyCache _cache;
+    private readonly ConcurrentBag<string> _dependencyLocations = new();
+    private readonly ConcurrentBag<SharedAnalyzerAssemblyCache.AnalyzerAssemblyHandle> _handles = new();
+
+    public ShadowCopyAnalyzerAssemblyLoader(SharedAnalyzerAssemblyCache cache) => _cache = cache;
+
+    public void AddDependencyLocation(string fullPath) => _dependencyLocations.Add(fullPath);
+
+    public Assembly LoadFromPath(string fullPath)
+    {
+        var (assembly, handle) = _cache.Acquire(Path.GetFullPath(fullPath), _dependencyLocations.ToArray());
+        _handles.Add(handle);
+        return assembly;
+    }
+
+    public void Dispose()
+    {
+        foreach (var handle in _handles)
+            _cache.Release(handle);
+    }
+}

--- a/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
+++ b/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Process-wide cache of analyzer/generator assemblies loaded from shadow copies so the
+/// originals in bin\Debug stay unlocked (issue #254). Each distinct analyzer identity gets
+/// its own collectible AssemblyLoadContext and is reference-counted: when the last holder
+/// releases it, the ALC is unloaded (best-effort) and the shadow copy deleted.
+/// </summary>
+public sealed class SharedAnalyzerAssemblyCache : IDisposable
+{
+    private readonly record struct Key(string Path, long Length, DateTime LastWriteUtc);
+
+    private sealed class Entry
+    {
+        public required string ShadowDir { get; init; }
+        public required AssemblyLoadContext Alc { get; init; }
+        public required Assembly Root { get; init; }
+        public int RefCount;
+    }
+
+    private readonly string _root =
+        Path.Combine(Path.GetTempPath(), "roslyn-codelens-shadow", Guid.NewGuid().ToString("N"));
+    private readonly ConcurrentDictionary<Key, Entry> _entries = new();
+    private readonly Lock _gate = new();
+    private bool _disposed;
+
+    private static Key KeyFor(string fullPath)
+    {
+        var fi = new FileInfo(fullPath);
+        return new Key(Path.GetFullPath(fullPath), fi.Length, fi.LastWriteTimeUtc);
+    }
+
+    /// <summary>Load <paramref name="analyzerPath"/> from a shadow copy, incrementing its refcount.</summary>
+    /// <param name="dependencyPaths">Sibling dependency locations Roslyn reported for this analyzer.</param>
+    public Assembly Acquire(string analyzerPath, IReadOnlyList<string> dependencyPaths)
+    {
+        var key = KeyFor(analyzerPath);
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_entries.TryGetValue(key, out var existing))
+            {
+                existing.RefCount++;
+                return existing.Root;
+            }
+
+            var shadowDir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(shadowDir);
+            var shadowPath = ShadowCopy(analyzerPath, shadowDir);
+
+            var alc = new AssemblyLoadContext($"analyzer:{Path.GetFileName(analyzerPath)}", isCollectible: true);
+            alc.Resolving += (ctx, name) => ResolveDependency(ctx, name, analyzerPath, dependencyPaths, shadowDir);
+
+            var root = alc.LoadFromAssemblyPath(shadowPath);
+            _entries[key] = new Entry { ShadowDir = shadowDir, Alc = alc, Root = root, RefCount = 1 };
+            return root;
+        }
+    }
+
+    /// <summary>Decrement the refcount; at zero, unload the ALC and delete the shadow copy.</summary>
+    public void Release(string analyzerPath)
+    {
+        var key = KeyFor(analyzerPath);
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(key, out var entry))
+                return;
+            if (--entry.RefCount > 0)
+                return;
+
+            _entries.TryRemove(key, out _);
+            entry.Alc.Unload();
+            TryDeleteDir(entry.ShadowDir);
+        }
+    }
+
+    private static Assembly? ResolveDependency(
+        AssemblyLoadContext ctx, AssemblyName name, string analyzerPath,
+        IReadOnlyList<string> dependencyPaths, string shadowDir)
+    {
+        var file = name.Name + ".dll";
+
+        // Prefer the dependency locations Roslyn told us about, then the analyzer's own directory.
+        var candidate =
+            dependencyPaths.FirstOrDefault(p =>
+                string.Equals(Path.GetFileName(p), file, StringComparison.OrdinalIgnoreCase))
+            ?? Path.Combine(Path.GetDirectoryName(analyzerPath)!, file);
+
+        if (!File.Exists(candidate))
+            return null;
+
+        var shadow = ShadowCopy(candidate, shadowDir);
+        return ctx.LoadFromAssemblyPath(shadow);
+    }
+
+    private static string ShadowCopy(string source, string shadowDir)
+    {
+        var dest = Path.Combine(shadowDir, Path.GetFileName(source));
+        if (!File.Exists(dest))
+            File.Copy(source, dest, overwrite: false);
+        return dest;
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* shadow files may still be memory-mapped until GC; cleaned on next process run */ }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            foreach (var entry in _entries.Values)
+                entry.Alc.Unload();
+            _entries.Clear();
+            TryDeleteDir(_root);
+        }
+    }
+}

--- a/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
+++ b/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
@@ -34,11 +34,17 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
         public int RefCount;
     }
 
+    private static readonly string ShadowParent =
+        Path.Combine(Path.GetTempPath(), "roslyn-codelens-shadow");
+
+    // Tagged with the process id so a later run can identify (and sweep) roots left by dead processes.
     private readonly string _root =
-        Path.Combine(Path.GetTempPath(), "roslyn-codelens-shadow", Guid.NewGuid().ToString("N"));
+        Path.Combine(ShadowParent, $"pid-{Environment.ProcessId}-{Guid.NewGuid():N}");
     private readonly ConcurrentDictionary<Key, Entry> _entries = new();
     private readonly Lock _gate = new();
     private bool _disposed;
+
+    public SharedAnalyzerAssemblyCache() => SweepDeadProcessRoots();
 
     private static Key KeyFor(string fullPath)
     {
@@ -103,7 +109,12 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
 
             _entries.TryRemove(handle.Key, out _);
             entry.Alc.Unload();
-            TryDeleteDir(entry.ShadowDir);
+            // Deliberately do NOT delete the shadow directory here. The just-unloaded assemblies
+            // may not be GC-collected yet, so they still appear in AppDomain.CurrentDomain.GetAssemblies()
+            // with Location pointing here; code that re-opens loaded assemblies by path (or Roslyn
+            // itself) would then hit a missing file. Shadow copies are reclaimed at process exit and
+            // swept on next startup (SweepDeadProcessRoots). This matches Roslyn's shadow-copy loader,
+            // which keeps its copies for the whole session.
         }
     }
 
@@ -159,7 +170,46 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
             foreach (var entry in _entries.Values)
                 entry.Alc.Unload();
             _entries.Clear();
-            TryDeleteDir(_root);
+            // Shadow files are intentionally left on disk (see Release) — the loaded assemblies may
+            // still be referenced. They are cleaned up by the next process's startup sweep.
         }
+    }
+
+    /// <summary>
+    /// Best-effort removal of shadow roots left behind by processes that are no longer running.
+    /// Runs at construction; never touches this process's own root or any live process's root.
+    /// </summary>
+    private static void SweepDeadProcessRoots()
+    {
+        try
+        {
+            if (!Directory.Exists(ShadowParent))
+                return;
+
+            foreach (var dir in Directory.EnumerateDirectories(ShadowParent))
+            {
+                var name = Path.GetFileName(dir);
+                if (!name.StartsWith("pid-", StringComparison.Ordinal))
+                    continue;
+
+                var rest = name.AsSpan("pid-".Length);
+                var dash = rest.IndexOf('-');
+                if (dash <= 0 || !int.TryParse(rest[..dash], out var pid))
+                    continue;
+
+                if (pid == Environment.ProcessId || IsProcessAlive(pid))
+                    continue;
+
+                try { Directory.Delete(dir, recursive: true); }
+                catch { /* another instance may be sweeping too, or files are pinned — best effort */ }
+            }
+        }
+        catch { /* hygiene only; never fail construction over cleanup */ }
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        try { using var _ = System.Diagnostics.Process.GetProcessById(pid); return true; }
+        catch { return false; }
     }
 }

--- a/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
+++ b/src/RoslynCodeLens/Analyzers/SharedAnalyzerAssemblyCache.cs
@@ -12,7 +12,19 @@ namespace RoslynCodeLens.Analyzers;
 /// </summary>
 public sealed class SharedAnalyzerAssemblyCache : IDisposable
 {
-    private readonly record struct Key(string Path, long Length, DateTime LastWriteUtc);
+    internal readonly record struct Key(string Path, long Length, DateTime LastWriteUtc);
+
+    /// <summary>
+    /// Opaque handle returned by <see cref="Acquire"/> that captures the cache key computed at
+    /// acquire time. <see cref="Release"/> takes this handle so it never has to touch the disk —
+    /// critical for #254, where a concurrent build may have already deleted or overwritten the
+    /// original analyzer DLL by the time we release.
+    /// </summary>
+    public readonly struct AnalyzerAssemblyHandle
+    {
+        internal Key Key { get; }
+        internal AnalyzerAssemblyHandle(Key key) => Key = key;
+    }
 
     private sealed class Entry
     {
@@ -31,12 +43,15 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
     private static Key KeyFor(string fullPath)
     {
         var fi = new FileInfo(fullPath);
-        return new Key(Path.GetFullPath(fullPath), fi.Length, fi.LastWriteTimeUtc);
+        // Normalize path casing so the same DLL referenced with different casing maps to one entry.
+        var normalized = Path.GetFullPath(fullPath).ToUpperInvariant();
+        return new Key(normalized, fi.Length, fi.LastWriteTimeUtc);
     }
 
     /// <summary>Load <paramref name="analyzerPath"/> from a shadow copy, incrementing its refcount.</summary>
     /// <param name="dependencyPaths">Sibling dependency locations Roslyn reported for this analyzer.</param>
-    public Assembly Acquire(string analyzerPath, IReadOnlyList<string> dependencyPaths)
+    /// <returns>The loaded root assembly and an opaque handle to pass back to <see cref="Release"/>.</returns>
+    public (Assembly Assembly, AnalyzerAssemblyHandle Handle) Acquire(string analyzerPath, IReadOnlyList<string> dependencyPaths)
     {
         var key = KeyFor(analyzerPath);
         lock (_gate)
@@ -45,34 +60,48 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
             if (_entries.TryGetValue(key, out var existing))
             {
                 existing.RefCount++;
-                return existing.Root;
+                return (existing.Root, new AnalyzerAssemblyHandle(key));
             }
 
             var shadowDir = Path.Combine(_root, Guid.NewGuid().ToString("N"));
-            Directory.CreateDirectory(shadowDir);
-            var shadowPath = ShadowCopy(analyzerPath, shadowDir);
+            AssemblyLoadContext? alc = null;
+            try
+            {
+                Directory.CreateDirectory(shadowDir);
+                var shadowPath = ShadowCopy(analyzerPath, shadowDir);
 
-            var alc = new AssemblyLoadContext($"analyzer:{Path.GetFileName(analyzerPath)}", isCollectible: true);
-            alc.Resolving += (ctx, name) => ResolveDependency(ctx, name, analyzerPath, dependencyPaths, shadowDir);
+                alc = new AssemblyLoadContext($"analyzer:{Path.GetFileName(analyzerPath)}", isCollectible: true);
+                alc.Resolving += (ctx, name) => ResolveDependency(ctx, name, analyzerPath, dependencyPaths, shadowDir);
 
-            var root = alc.LoadFromAssemblyPath(shadowPath);
-            _entries[key] = new Entry { ShadowDir = shadowDir, Alc = alc, Root = root, RefCount = 1 };
-            return root;
+                var root = alc.LoadFromAssemblyPath(shadowPath);
+                _entries[key] = new Entry { ShadowDir = shadowDir, Alc = alc, Root = root, RefCount = 1 };
+                return (root, new AnalyzerAssemblyHandle(key));
+            }
+            catch
+            {
+                // A bad image (or any failure) must not leak the collectible ALC or the shadow dir.
+                alc?.Unload();
+                TryDeleteDir(shadowDir);
+                throw;
+            }
         }
     }
 
-    /// <summary>Decrement the refcount; at zero, unload the ALC and delete the shadow copy.</summary>
-    public void Release(string analyzerPath)
+    /// <summary>
+    /// Decrement the refcount for the entry identified by <paramref name="handle"/>; at zero,
+    /// unload the ALC and delete the shadow copy. Performs no disk access, so it is safe even if
+    /// the original analyzer DLL has since been deleted or overwritten by a concurrent build.
+    /// </summary>
+    public void Release(AnalyzerAssemblyHandle handle)
     {
-        var key = KeyFor(analyzerPath);
         lock (_gate)
         {
-            if (!_entries.TryGetValue(key, out var entry))
+            if (!_entries.TryGetValue(handle.Key, out var entry))
                 return;
             if (--entry.RefCount > 0)
                 return;
 
-            _entries.TryRemove(key, out _);
+            _entries.TryRemove(handle.Key, out _);
             entry.Alc.Unload();
             TryDeleteDir(entry.ShadowDir);
         }
@@ -100,8 +129,18 @@ public sealed class SharedAnalyzerAssemblyCache : IDisposable
     private static string ShadowCopy(string source, string shadowDir)
     {
         var dest = Path.Combine(shadowDir, Path.GetFileName(source));
-        if (!File.Exists(dest))
+        if (File.Exists(dest))
+            return dest;
+
+        try
+        {
             File.Copy(source, dest, overwrite: false);
+        }
+        catch (IOException) when (File.Exists(dest))
+        {
+            // ResolveDependency runs outside _gate (during compilation), so a concurrent resolve
+            // may have produced this shadow already. "Already copied" is success.
+        }
         return dest;
     }
 

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens.Analyzers;
 
 namespace RoslynCodeLens;
 
@@ -55,13 +56,13 @@ public class SolutionLoader
         }
     }
 
-    public async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, CancellationToken ct = default)
+    public async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, ShadowCopyAnalyzerAssemblyLoader? analyzerLoader = null, CancellationToken ct = default)
     {
         var classified = ProjectClassifier.EnumerateProjects(solutionPath);
 
         if (filter is not null && filter.HasSeeds)
         {
-            return await OpenFilteredAsync(solutionPath, classified, filter, ct).ConfigureAwait(false);
+            return await OpenFilteredAsync(solutionPath, classified, filter, analyzerLoader, ct).ConfigureAwait(false);
         }
 
         var legacyOrMissing = classified
@@ -76,7 +77,7 @@ public class SolutionLoader
             await Console.Error.WriteLineAsync(
                 $"[roslyn-codelens] Detected {legacyOrMissing.Count(p => p.Kind == ProjectClassifier.ProjectKind.Legacy)} legacy non-SDK project(s) in {Path.GetFileName(solutionPath)}; loading SDK-style projects only.")
                 .ConfigureAwait(false);
-            return await OpenPerProjectAsync(solutionPath, classified, ct).ConfigureAwait(false);
+            return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
         }
 
         var workspace = MSBuildWorkspace.Create();
@@ -104,7 +105,7 @@ public class SolutionLoader
             await Console.Error.WriteLineAsync(
                 $"[roslyn-codelens] Solution-level load failed ({ex.GetType().Name}: {ex.Message}); falling back to per-project loading.")
                 .ConfigureAwait(false);
-            return await OpenPerProjectAsync(solutionPath, classified, ct).ConfigureAwait(false);
+            return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
         }
 
         if (solution is null)
@@ -113,15 +114,32 @@ public class SolutionLoader
             await Console.Error.WriteLineAsync(
                 $"[roslyn-codelens] Solution-level load timed out; falling back to per-project loading.")
                 .ConfigureAwait(false);
-            return await OpenPerProjectAsync(solutionPath, classified, ct).ConfigureAwait(false);
+            return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
         }
 
+        if (analyzerLoader is not null)
+            solution = RemapSolutionAnalyzers(solution, analyzerLoader);
+
         return (solution, workspace, Array.Empty<SkippedProject>());
+    }
+
+    private static Solution RemapSolutionAnalyzers(Solution solution, ShadowCopyAnalyzerAssemblyLoader loader)
+    {
+        foreach (var projectId in solution.ProjectIds)
+        {
+            var project = solution.GetProject(projectId)!;
+            if (project.AnalyzerReferences.Count == 0)
+                continue;
+            var remapped = AnalyzerReferenceRemapper.Remap(project.AnalyzerReferences, loader);
+            solution = solution.WithProjectAnalyzerReferences(projectId, remapped);
+        }
+        return solution;
     }
 
     private static async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenPerProjectAsync(
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
+        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader,
         CancellationToken ct)
     {
         var skipped = new List<SkippedProject>();
@@ -243,7 +261,7 @@ public class SolutionLoader
                             continue;
                         if (captured.ContainsKey(p.FilePath))
                             continue;
-                        var info = await ToDetachedInfoAsync(p).ConfigureAwait(false);
+                        var info = await ToDetachedInfoAsync(p, analyzerLoader).ConfigureAwait(false);
                         captured.TryAdd(p.FilePath, info);
                     }
                 }
@@ -332,7 +350,7 @@ public class SolutionLoader
     /// and can be re-stitched into a fresh workspace. The project keeps its own
     /// (globally-unique) id and document ids.
     /// </summary>
-    private static async Task<ProjectInfo> ToDetachedInfoAsync(Project project)
+    private static async Task<ProjectInfo> ToDetachedInfoAsync(Project project, ShadowCopyAnalyzerAssemblyLoader? loader)
     {
         var documents = new List<DocumentInfo>();
         foreach (var d in project.Documents)
@@ -359,7 +377,9 @@ public class SolutionLoader
                 documents: documents,
                 projectReferences: Array.Empty<ProjectReference>(),
                 metadataReferences: project.MetadataReferences,
-                analyzerReferences: project.AnalyzerReferences,
+                analyzerReferences: loader is null
+                    ? project.AnalyzerReferences
+                    : AnalyzerReferenceRemapper.Remap(project.AnalyzerReferences, loader),
                 additionalDocuments: additional)
             .WithAnalyzerConfigDocuments(analyzerConfig)
             .WithDefaultNamespace(project.DefaultNamespace);
@@ -384,6 +404,7 @@ public class SolutionLoader
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
         ProjectFilter filter,
+        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader,
         CancellationToken ct)
     {
         // Build a name -> referenced-project-names graph. References are read as
@@ -435,7 +456,7 @@ public class SolutionLoader
         }
 
         var (solution, workspace, perProjectSkipped) =
-            await OpenPerProjectAsync(solutionPath, inClosure, ct).ConfigureAwait(false);
+            await OpenPerProjectAsync(solutionPath, inClosure, analyzerLoader, ct).ConfigureAwait(false);
 
         var skipped = new List<SkippedProject>(filteredOut.Count + perProjectSkipped.Count);
         skipped.AddRange(filteredOut);

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using RoslynCodeLens.Analyzers;
 using RoslynCodeLens.Metadata;
 using RoslynCodeLens.Symbols;
 
@@ -21,6 +22,13 @@ public sealed class SolutionManager : IDisposable
     private readonly string? _loadFailureMessage;
     private readonly PEFileCache _peCache = new();
     private readonly IlDisassemblerAdapter _ilAdapter;
+
+    // Process-lifetime shared shadow-copy cache (never disposed): the cross-solution
+    // dedup layer. Individual solutions release their entries via their own facade
+    // analyzer loader on dispose (refcount--), so entries unload when the last owner goes.
+    private static readonly SharedAnalyzerAssemblyCache SharedCache = new();
+    private ShadowCopyAnalyzerAssemblyLoader? _analyzerLoader;
+    private Workspace? _workspace;
 
     private SolutionManager(LoadedSolution loaded, string? solutionPath)
     {
@@ -47,15 +55,19 @@ public sealed class SolutionManager : IDisposable
 
     public static async Task<SolutionManager> CreateAsync(string solutionPath, ProjectFilter? filter = null)
     {
-        var loader = new SolutionLoader();
+        var solutionLoader = new SolutionLoader();
+        var analyzerLoader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
         Solution solution;
+        Workspace workspace;
         IReadOnlyList<SkippedProject> skipped;
         try
         {
-            (solution, _, skipped) = await loader.OpenAsync(solutionPath, filter).ConfigureAwait(false);
+            (solution, workspace, skipped) =
+                await solutionLoader.OpenAsync(solutionPath, filter, analyzerLoader).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
+            analyzerLoader.Dispose();
             await Console.Error.WriteLineAsync(
                 $"[roslyn-codelens] {SolutionLoadFailure.Describe(solutionPath, ex)}").ConfigureAwait(false);
             return new SolutionManager(solutionPath, ex);
@@ -69,7 +81,9 @@ public sealed class SolutionManager : IDisposable
         };
 
         var manager = new SolutionManager(emptyLoaded, solutionPath);
-        manager._warmupTask = manager.WarmupAsync(loader, solution, skipped);
+        manager._analyzerLoader = analyzerLoader;
+        manager._workspace = workspace;
+        manager._warmupTask = manager.WarmupAsync(solutionLoader, solution, skipped);
         return manager;
     }
 
@@ -254,18 +268,22 @@ public sealed class SolutionManager : IDisposable
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
-        var loader = new SolutionLoader();
+        var solutionLoader = new SolutionLoader();
+        var analyzerLoader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
         Solution solution;
+        Workspace workspace;
         IReadOnlyList<SkippedProject> skipped;
         try
         {
-            (solution, _, skipped) = await loader.OpenAsync(_solutionPath).ConfigureAwait(false);
+            (solution, workspace, skipped) =
+                await solutionLoader.OpenAsync(_solutionPath, null, analyzerLoader).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
+            analyzerLoader.Dispose();
             throw new InvalidOperationException(SolutionLoadFailure.Describe(_solutionPath, ex), ex);
         }
-        var compilations = await loader.CompileAllParallelAsync(solution).ConfigureAwait(false);
+        var compilations = await solutionLoader.CompileAllParallelAsync(solution).ConfigureAwait(false);
 
         var newLoaded = new LoadedSolution
         {
@@ -276,15 +294,23 @@ public sealed class SolutionManager : IDisposable
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
+        var oldLoader = _analyzerLoader;
+        var oldWorkspace = _workspace;
         lock (_lock)
         {
             _loaded = newLoaded;
             _resolver = newResolver;
             _metadataResolver = newMetadataResolver;
+            _analyzerLoader = analyzerLoader;
+            _workspace = workspace;
         }
 
         _tracker?.UpdateMappings(newLoaded);
         _tracker?.ClearStale();
+
+        // Dispose the previous workspace/loader AFTER the state swap so nothing in-flight uses them.
+        oldWorkspace?.Dispose();
+        oldLoader?.Dispose();
 
         sw.Stop();
         return (newLoaded.Compilations.Count, sw.Elapsed);
@@ -294,5 +320,7 @@ public sealed class SolutionManager : IDisposable
     {
         _tracker?.Dispose();
         _peCache.Dispose();
+        _workspace?.Dispose();
+        _analyzerLoader?.Dispose();   // releases each acquired analyzer -> refcount--, unload at zero
     }
 }

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -227,8 +227,19 @@ public sealed class SolutionManager : IDisposable
 
     private async Task RebuildStaleProjects(IReadOnlySet<ProjectId> staleIds)
     {
-        var loader = new SolutionLoader();
-        var (solution, _, skipped) = await loader.OpenAsync(_solutionPath!).ConfigureAwait(false);
+        var solutionLoader = new SolutionLoader();
+
+        // Reuse this solution's existing shadow-copy analyzer loader so stale-project generators
+        // load from shadow copies (issue #254) instead of re-locking bin\Debug, and the returned
+        // solution stays remapped. Snapshot under _lock in case a concurrent reload swapped it.
+        // Do NOT create a fresh loader or dispose it here: this is a partial rebuild, the loader's
+        // already-acquired analyzers are still referenced by the retained non-stale compilations,
+        // and reusing dedups via the shared cache instead of churning ALCs on every edit.
+        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader;
+        lock (_lock) { analyzerLoader = _analyzerLoader; }
+
+        var (solution, workspace, skipped) =
+            await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
         var compilations = new ConcurrentDictionary<ProjectId, Compilation>(_loaded.Compilations);
 
         var staleProjects = solution.Projects.Where(p => staleIds.Contains(p.Id)).ToList();
@@ -250,14 +261,21 @@ public sealed class SolutionManager : IDisposable
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
+        Workspace? oldWorkspace;
         lock (_lock)
         {
             _loaded = newLoaded;
             _resolver = newResolver;
             _metadataResolver = newMetadataResolver;
+            oldWorkspace = _workspace;
+            _workspace = workspace;
         }
 
         _tracker!.UpdateMappings(newLoaded);
+
+        // Dispose the previous workspace AFTER the swap (fixes a pre-existing leak: each stale rebuild
+        // otherwise leaks a workspace + its out-of-process BuildHost). The analyzer loader is REUSED, not disposed.
+        oldWorkspace?.Dispose();
 
         await Console.Error.WriteLineAsync("[roslyn-codelens] Rebuild complete.").ConfigureAwait(false);
     }
@@ -295,13 +313,15 @@ public sealed class SolutionManager : IDisposable
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
 
-        var oldLoader = _analyzerLoader;
-        var oldWorkspace = _workspace;
+        ShadowCopyAnalyzerAssemblyLoader? oldLoader;
+        Workspace? oldWorkspace;
         lock (_lock)
         {
             _loaded = newLoaded;
             _resolver = newResolver;
             _metadataResolver = newMetadataResolver;
+            oldLoader = _analyzerLoader;
+            oldWorkspace = _workspace;
             _analyzerLoader = analyzerLoader;
             _workspace = workspace;
         }

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -29,6 +29,7 @@ public sealed class SolutionManager : IDisposable
     private static readonly SharedAnalyzerAssemblyCache SharedCache = new();
     private ShadowCopyAnalyzerAssemblyLoader? _analyzerLoader;
     private Workspace? _workspace;
+    private bool _disposed;
 
     private SolutionManager(LoadedSolution loaded, string? solutionPath)
     {
@@ -318,9 +319,26 @@ public sealed class SolutionManager : IDisposable
 
     public void Dispose()
     {
-        _tracker?.Dispose();
+        // Idempotent: snapshot the swappable state under _lock (ForceReloadAsync swaps
+        // _workspace/_analyzerLoader under the same lock), then dispose outside it. This
+        // avoids a double release of refcounted analyzer handles that could prematurely
+        // unload another live solution's analyzer ALC.
+        Workspace? workspace;
+        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader;
+        FileChangeTracker? tracker;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            workspace = _workspace;
+            analyzerLoader = _analyzerLoader;
+            tracker = _tracker;
+            _workspace = null;
+            _analyzerLoader = null;
+        }
+        tracker?.Dispose();
         _peCache.Dispose();
-        _workspace?.Dispose();
-        _analyzerLoader?.Dispose();   // releases each acquired analyzer -> refcount--, unload at zero
+        workspace?.Dispose();
+        analyzerLoader?.Dispose();   // releases each acquired analyzer -> refcount--, unload at zero
     }
 }

--- a/tests/RoslynCodeLens.Tests/Analyzers/AnalyzerReferenceRemapperTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/AnalyzerReferenceRemapperTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class AnalyzerReferenceRemapperTests
+{
+    [Fact]
+    public void Remap_RewritesFileReferences_PreservingPaths()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        using var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var path = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+        var input = new AnalyzerReference[] { new AnalyzerFileReference(path, loader) };
+
+        var result = AnalyzerReferenceRemapper.Remap(input, loader);
+
+        var afr = Assert.IsType<AnalyzerFileReference>(Assert.Single(result));
+        Assert.Equal(path, afr.FullPath, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Remap_PassesThroughNonFileReferences()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        using var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var stub = new StubReference();
+
+        var result = AnalyzerReferenceRemapper.Remap(new AnalyzerReference[] { stub }, loader);
+
+        Assert.Same(stub, Assert.Single(result));
+    }
+
+    private sealed class StubReference : AnalyzerReference
+    {
+        public override string? FullPath => null;
+        public override object Id => "stub";
+        public override System.Collections.Immutable.ImmutableArray<DiagnosticAnalyzer> GetAnalyzers(string language) => [];
+        public override System.Collections.Immutable.ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages() => [];
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Analyzers/GeneratorShadowLoadIntegrationTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/GeneratorShadowLoadIntegrationTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+/// <summary>
+/// End-to-end proof (no MSBuild) that a source generator loaded through
+/// <see cref="ShadowCopyAnalyzerAssemblyLoader"/> actually runs and produces symbols, while its
+/// original DLL on disk stays unlocked (issue #254). Uses Roslyn's real
+/// <see cref="AnalyzerFileReference"/> + <see cref="CSharpGeneratorDriver"/> generator-loading path.
+/// </summary>
+public class GeneratorShadowLoadIntegrationTests : IDisposable
+{
+    private readonly string _tmp = Path.Combine(Path.GetTempPath(), "rcl-gen-test", Guid.NewGuid().ToString("N"));
+
+    public GeneratorShadowLoadIntegrationTests() => Directory.CreateDirectory(_tmp);
+    public void Dispose() { try { Directory.Delete(_tmp, recursive: true); } catch { /* best effort */ } }
+
+    // Reference set that lets an incremental generator compile: every trusted-platform assembly
+    // (framework) plus the Roslyn assemblies the test process already has loaded.
+    private static IReadOnlyList<MetadataReference> GeneratorReferences()
+    {
+        var refs = new List<MetadataReference>();
+        var tpa = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var p in tpa)
+            if (p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                refs.Add(MetadataReference.CreateFromFile(p));
+        // Ensure the Roslyn generator API assemblies are referenced even if not in the TPA set.
+        refs.Add(MetadataReference.CreateFromFile(typeof(IIncrementalGenerator).Assembly.Location));  // Microsoft.CodeAnalysis
+        refs.Add(MetadataReference.CreateFromFile(typeof(CSharpSyntaxTree).Assembly.Location));        // Microsoft.CodeAnalysis.CSharp
+        return refs;
+    }
+
+    private string BuildGeneratorDll()
+    {
+        const string generatorSource = """
+            using Microsoft.CodeAnalysis;
+            [Generator]
+            public sealed class HelloGenerator : IIncrementalGenerator
+            {
+                public void Initialize(IncrementalGeneratorInitializationContext context)
+                {
+                    context.RegisterPostInitializationOutput(ctx =>
+                        ctx.AddSource("Hello.g.cs",
+                            "namespace Generated { public static class Hello { public const string Message = \"hi\"; } }"));
+                }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "HelloGen",
+            new[] { CSharpSyntaxTree.ParseText(generatorSource) },
+            GeneratorReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var dllPath = Path.Combine(_tmp, "HelloGen.dll");
+        var emit = compilation.Emit(dllPath);
+        Assert.True(emit.Success,
+            "generator failed to compile:\n" + string.Join("\n", emit.Diagnostics));
+        return dllPath;
+    }
+
+    [Fact]
+    public void ShadowLoadedGenerator_ProducesSymbol_AndLeavesDllUnlocked()
+    {
+        var genDll = BuildGeneratorDll();
+
+        using var cache = new SharedAnalyzerAssemblyCache();
+        using var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        loader.AddDependencyLocation(genDll);
+
+        var analyzerRef = new AnalyzerFileReference(genDll, loader);
+        var generators = analyzerRef.GetGenerators(LanguageNames.CSharp);
+        Assert.NotEmpty(generators);   // generator was loaded through the shadow loader
+
+        var user = CSharpCompilation.Create(
+            "User",
+            new[] { CSharpSyntaxTree.ParseText("public class C { }") },
+            new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        CSharpGeneratorDriver
+            .Create(generators)
+            .RunGeneratorsAndUpdateCompilation(user, out var output, out _);
+
+        Assert.NotNull(output.GetTypeByMetadataName("Generated.Hello"));   // semantic fidelity through shadow load
+
+        // The #254 property, proven end-to-end: the original generator DLL is not locked.
+        Assert.Null(Record.Exception(() => File.Delete(genDll)));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Analyzers/ShadowCopyAnalyzerAssemblyLoaderTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/ShadowCopyAnalyzerAssemblyLoaderTests.cs
@@ -1,0 +1,53 @@
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class ShadowCopyAnalyzerAssemblyLoaderTests : IDisposable
+{
+    private readonly string _tmp = Path.Combine(Path.GetTempPath(), "rcl-facade-test", Guid.NewGuid().ToString("N"));
+    public ShadowCopyAnalyzerAssemblyLoaderTests() => Directory.CreateDirectory(_tmp);
+    public void Dispose() { try { Directory.Delete(_tmp, true); } catch { /* best effort */ } }
+
+    private string MakeFake(string n)
+    {
+        var dst = Path.Combine(_tmp, n + ".dll");
+        File.Copy(typeof(System.Text.Json.JsonSerializer).Assembly.Location, dst, true);
+        return dst;
+    }
+
+    [Fact]
+    public void LoadFromPath_ReturnsShadowedAssembly_AndLeavesOriginalUnlocked()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var original = MakeFake("Facade1");
+        loader.AddDependencyLocation(original);
+
+        var asm = loader.LoadFromPath(original);
+
+        Assert.NotNull(asm);
+        Assert.Null(Record.Exception(() => File.Delete(original)));
+    }
+
+    [Fact]
+    public void Dispose_ReleasesAcquired_SoReacquireIsFresh()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFake("Facade2");
+
+        string dir1;
+        using (var loader = new ShadowCopyAnalyzerAssemblyLoader(cache))
+        {
+            loader.AddDependencyLocation(original);
+            dir1 = Path.GetDirectoryName(loader.LoadFromPath(original).Location)!;
+        }   // Dispose() releases the acquired handle -> entry removed at refcount zero
+
+        // A fresh loader must build a NEW shadow entry (proves the previous one was released,
+        // without depending on OS-level shadow-dir deletion, which is best-effort on Windows).
+        using var loader2 = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        loader2.AddDependencyLocation(original);
+        var dir2 = Path.GetDirectoryName(loader2.LoadFromPath(original).Location)!;
+
+        Assert.NotEqual(dir1, dir2);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs
@@ -25,7 +25,7 @@ public class SharedAnalyzerAssemblyCacheTests : IDisposable
         using var cache = new SharedAnalyzerAssemblyCache();
         var original = MakeFakeAnalyzer("Alpha");
 
-        var asm = cache.Acquire(original, Array.Empty<string>());
+        var (asm, _) = cache.Acquire(original, Array.Empty<string>());
 
         Assert.NotNull(asm);
         Assert.NotEqual(
@@ -53,8 +53,8 @@ public class SharedAnalyzerAssemblyCacheTests : IDisposable
         using var cache = new SharedAnalyzerAssemblyCache();
         var original = MakeFakeAnalyzer("Gamma");
 
-        var a = cache.Acquire(original, Array.Empty<string>());
-        var b = cache.Acquire(original, Array.Empty<string>());
+        var (a, _) = cache.Acquire(original, Array.Empty<string>());
+        var (b, _) = cache.Acquire(original, Array.Empty<string>());
 
         Assert.Same(a, b);
     }
@@ -64,13 +64,14 @@ public class SharedAnalyzerAssemblyCacheTests : IDisposable
     {
         var cache = new SharedAnalyzerAssemblyCache();
         var original = MakeFakeAnalyzer("Delta");
-        var shadowDirBefore = Path.GetDirectoryName(cache.Acquire(original, Array.Empty<string>()).Location)!;
-        cache.Acquire(original, Array.Empty<string>());   // refcount = 2
+        var (root, handle1) = cache.Acquire(original, Array.Empty<string>());
+        var shadowDirBefore = Path.GetDirectoryName(root.Location)!;
+        var (_, handle2) = cache.Acquire(original, Array.Empty<string>());   // refcount = 2
 
-        cache.Release(original);                           // -> 1, still present
+        cache.Release(handle1);                            // -> 1, still present
         Assert.True(Directory.Exists(shadowDirBefore));
 
-        cache.Release(original);                           // -> 0, entry unloaded + removed
+        cache.Release(handle2);                            // -> 0, entry unloaded + removed
         ForceGc();
 
         // The collectible ALC's unload is best-effort: on Windows the shadow DLL can stay
@@ -78,12 +79,26 @@ public class SharedAnalyzerAssemblyCacheTests : IDisposable
         // CAN prove is that the entry left the cache at refcount zero: a further Release is a
         // harmless no-op, and re-Acquire has to build a brand-new shadow dir (a live entry
         // would have deduped and returned the same path).
-        var noop = Record.Exception(() => cache.Release(original));
+        var noop = Record.Exception(() => cache.Release(handle2));
         Assert.Null(noop);
 
-        var shadowDirAfter = Path.GetDirectoryName(cache.Acquire(original, Array.Empty<string>()).Location)!;
+        var (reAsm, _) = cache.Acquire(original, Array.Empty<string>());
+        var shadowDirAfter = Path.GetDirectoryName(reAsm.Location)!;
         Assert.NotEqual(shadowDirBefore, shadowDirAfter, StringComparer.OrdinalIgnoreCase);
         cache.Dispose();
+    }
+
+    [Fact]
+    public void Release_AfterOriginalDeleted_DoesNotThrow()   // guards handle-based release (#254)
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Epsilon");
+
+        var (_, handle) = cache.Acquire(original, Array.Empty<string>());
+        File.Delete(original);   // simulate the concurrent build deleting the DLL
+
+        var ex = Record.Exception(() => cache.Release(handle));
+        Assert.Null(ex);         // must not throw FileNotFoundException
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/SharedAnalyzerAssemblyCacheTests.cs
@@ -1,0 +1,94 @@
+using System.Runtime.CompilerServices;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+public class SharedAnalyzerAssemblyCacheTests : IDisposable
+{
+    private readonly string _tmp = Path.Combine(Path.GetTempPath(), "rcl-cache-test", Guid.NewGuid().ToString("N"));
+
+    public SharedAnalyzerAssemblyCacheTests() => Directory.CreateDirectory(_tmp);
+    public void Dispose() { try { Directory.Delete(_tmp, recursive: true); } catch { /* best effort */ } }
+
+    // Copy an arbitrary real assembly to act as a stand-in "analyzer" we are allowed to delete.
+    private string MakeFakeAnalyzer(string name)
+    {
+        var src = typeof(System.Text.Json.JsonSerializer).Assembly.Location;
+        var dst = Path.Combine(_tmp, name + ".dll");
+        File.Copy(src, dst, overwrite: true);
+        return dst;
+    }
+
+    [Fact]
+    public void Acquire_LoadsFromShadowCopy_NotOriginalPath()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Alpha");
+
+        var asm = cache.Acquire(original, Array.Empty<string>());
+
+        Assert.NotNull(asm);
+        Assert.NotEqual(
+            Path.GetFullPath(original),
+            Path.GetFullPath(asm.Location),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Acquire_LeavesOriginalFileUnlocked()   // THE #254 regression guard
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Beta");
+
+        cache.Acquire(original, Array.Empty<string>());
+
+        // If the original were locked (the bug), this throws IOException.
+        var ex = Record.Exception(() => File.Delete(original));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Acquire_SamePathTwice_DedupsToSameAssembly()
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Gamma");
+
+        var a = cache.Acquire(original, Array.Empty<string>());
+        var b = cache.Acquire(original, Array.Empty<string>());
+
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void Release_UnloadsOnlyWhenRefCountReachesZero()
+    {
+        var cache = new SharedAnalyzerAssemblyCache();
+        var original = MakeFakeAnalyzer("Delta");
+        var shadowDirBefore = Path.GetDirectoryName(cache.Acquire(original, Array.Empty<string>()).Location)!;
+        cache.Acquire(original, Array.Empty<string>());   // refcount = 2
+
+        cache.Release(original);                           // -> 1, still present
+        Assert.True(Directory.Exists(shadowDirBefore));
+
+        cache.Release(original);                           // -> 0, entry unloaded + removed
+        ForceGc();
+
+        // The collectible ALC's unload is best-effort: on Windows the shadow DLL can stay
+        // memory-mapped past GC, so we cannot reliably assert the directory is gone. What we
+        // CAN prove is that the entry left the cache at refcount zero: a further Release is a
+        // harmless no-op, and re-Acquire has to build a brand-new shadow dir (a live entry
+        // would have deduped and returned the same path).
+        var noop = Record.Exception(() => cache.Release(original));
+        Assert.Null(noop);
+
+        var shadowDirAfter = Path.GetDirectoryName(cache.Acquire(original, Array.Empty<string>()).Location)!;
+        Assert.NotEqual(shadowDirBefore, shadowDirAfter, StringComparer.OrdinalIgnoreCase);
+        cache.Dispose();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ForceGc()
+    {
+        for (var i = 0; i < 3; i++) { GC.Collect(); GC.WaitForPendingFinalizers(); }
+    }
+}


### PR DESCRIPTION
Fixes #254.

## Problem

`MSBuildWorkspace` loads analyzer/source-generator assemblies **without shadow-copying**, and the server's eager background compilation runs generators at startup (`GetCompilationAsync` per project). So the generator DLLs in `bin\Debug` get locked for the process lifetime, and any concurrent `dotnet build` fails with `MSB3027`/`MSB3021`. `unload_solution` couldn't release the lock either (the workspace was leaked and the assemblies loaded into a non-collectible context).

Root cause confirmed against Roslyn 5.6.0. Note: the `ShadowCopyAnalyzerAssemblyLoader` the issue suggested is **`internal`** in Roslyn 5.6.0 (verified by reflecting over the full referenced surface — Common, CSharp, Workspaces, Features, Scripting), so this PR implements the public `IAnalyzerAssemblyLoader` interface itself.

## Approach

A refcounted, process-wide shadow-copy cache behind a per-solution loader facade (chosen for the many/long-lived multi-solution usage — dedups analyzers across solutions while still releasing per-analyzer on unload):

- **`SharedAnalyzerAssemblyCache`** — process singleton. Shadow-copies each distinct analyzer identity into its own **collectible** `AssemblyLoadContext`, reference-counted. Keyed by `(path, size, mtime)` so a rebuilt generator forms a new entry (hot-reload) while unchanged analyzers dedup across solutions. Handle-based `Acquire`/`Release` — `Release` takes an opaque handle capturing the key and never touches disk, so it's safe even after a concurrent build deleted/overwrote the original DLL.
- **`ShadowCopyAnalyzerAssemblyLoader`** — thin per-solution `IAnalyzerAssemblyLoader` facade over the cache; releases its acquired handles on `Dispose` (idempotent).
- **`AnalyzerReferenceRemapper`** — rebuilds each project's `AnalyzerFileReference`s to load through the facade.
- **`SolutionLoader`** — remaps on both load paths (solution-level + per-project), behind an optional param (default `null` = unchanged behavior).
- **`SolutionManager`** — owns a per-solution facade over the shared cache, captures+disposes the workspace (previously leaked), and releases the loader on unload. All **three** load paths route through it: initial load, `ForceReloadAsync`, and the stale-project auto-rebuild.

## Design & plan

- Design: `docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy-design.md`
- Plan: `docs/plans/2026-07-05-analyzer-dll-lock-shadow-copy.md`

## Tests

10 new tests, all green (no MSBuild dependency — deterministic locally):
- Cache: loads from shadow copy, **original DLL stays deletable while loaded** (the core #254 guard), dedup, refcount release, release-after-delete.
- Facade: shadow-load + unlock; dispose releases.
- Remapper: rewrites file refs preserving paths; passes non-file refs through.
- **Integration:** a real incremental generator loaded through the shadow loader runs via Roslyn's generator driver, produces `Generated.Hello`, and its DLL is deletable afterward — proving semantic fidelity + unlock end-to-end.

Full suite diffed against base commit `3083e00`: **identical failure set, zero new failures** (31 pre-existing local MSBuildWorkspace-load flakes; CI is green on `main`).

## Not done here

- **Manual MSBuild repro** (run server → concurrent `dotnet build`) was not executed — this dev machine hits the known local MSBuildWorkspace load flake. The deterministic integration test proves the unlock property through Roslyn's real generator machinery; a server-against-a-generator-solution repro should be confirmed in CI / a clean env before merge.
- Release-on-unload is **best-effort** by design: a collectible ALC only frees after GC drops the compilations/symbols rooting it, and a generator that pins itself (threads/statics/native libs) won't fully unload. The build-lock fix (shadow copy) does not depend on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)