### PR TITLE
ci: stop publishing prereleases + fix flaky TestSolution fixture (#260)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,19 +25,6 @@ jobs:
       - name: Restore tools
         run: dotnet tool restore
 
-      - name: Compute CI package version
-        id: pkgver
-        run: |
-          SEMVER=$(dotnet gitversion /showvariable SemVer)
-          # Always append a CI prerelease suffix so a main-branch CI publish can never
-          # collide with the stable version that release-please publishes for a tag.
-          # See #225: a stable "2.2.1" got published from a regular push to main, then
-          # the release-please publish for the actual v2.2.1 silently no-op'd via
-          # --skip-duplicate, leaving the wrong build at the released version on NuGet.
-          CI_VERSION="${SEMVER}-ci.${{ github.run_number }}"
-          echo "version=$CI_VERSION" >> "$GITHUB_OUTPUT"
-          echo "CI package version: $CI_VERSION"
-
       - name: Restore
         run: dotnet restore
 
@@ -45,15 +32,7 @@ jobs:
         run: dotnet restore tests/RoslynCodeLens.Tests/Fixtures/TestSolution/TestSolution.slnx
 
       - name: Build
-        run: dotnet build --no-restore -c Release -p:Version=${{ steps.pkgver.outputs.version }}
+        run: dotnet build --no-restore -c Release
 
       - name: Test
         run: dotnet test --no-build -c Release --verbosity normal
-
-      - name: Pack
-        run: |
-          dotnet pack src/RoslynCodeLens/RoslynCodeLens.csproj --no-build -c Release -p:PackageVersion=${{ steps.pkgver.outputs.version }} -o ./artifacts
-
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/scripts/delist-prereleases.ps1
+++ b/scripts/delist-prereleases.ps1
@@ -1,0 +1,87 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Unlists ("delists") every prerelease of RoslynCodeLens.Mcp from NuGet.org.
+
+.DESCRIPTION
+    NuGet.org does NOT support hard deletes. `dotnet nuget delete` against
+    nuget.org UNLISTS the version: it is hidden from search and the version
+    list, but remains restorable by exact version. This is effectively
+    permanent and is a public-feed change — review the printed list first.
+
+    Fetches the live version index, selects every prerelease (any version
+    containing '-'), prints them, then unlists each one.
+
+.PREREQUISITES
+    - .NET SDK on PATH (`dotnet`)
+    - $env:NUGET_API_KEY set to an API key with the "Unlist package" scope
+      for RoslynCodeLens.Mcp. The key is read from the environment and never
+      printed.
+
+.EXAMPLE
+    $env:NUGET_API_KEY = "oy2..."          # do not commit this
+    ./scripts/delist-prereleases.ps1        # dry run: lists what would be delisted
+    ./scripts/delist-prereleases.ps1 -Execute
+#>
+[CmdletBinding()]
+param(
+    [string]$PackageId = "RoslynCodeLens.Mcp",
+    [string]$Source    = "https://api.nuget.org/v3/index.json",
+    # Safety: nothing is delisted unless -Execute is passed.
+    [switch]$Execute
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $env:NUGET_API_KEY) {
+    Write-Error "NUGET_API_KEY environment variable is not set. Set it to a key with the 'Unlist package' scope."
+    exit 1
+}
+
+$lower = $PackageId.ToLowerInvariant()
+$indexUrl = "https://api.nuget.org/v3-flatcontainer/$lower/index.json"
+Write-Host "Fetching versions from $indexUrl ..."
+$all = (Invoke-RestMethod -Uri $indexUrl).versions
+
+# A prerelease is any SemVer with a pre-release label (contains '-').
+$prereleases = @($all | Where-Object { $_ -like "*-*" } | Sort-Object)
+
+if ($prereleases.Count -eq 0) {
+    Write-Host "No prereleases found. Nothing to do."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "$($prereleases.Count) prerelease version(s) of $PackageId to delist:" -ForegroundColor Yellow
+$prereleases | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+
+if (-not $Execute) {
+    Write-Host "DRY RUN. Re-run with -Execute to actually unlist these versions." -ForegroundColor Cyan
+    exit 0
+}
+
+$failed = @()
+foreach ($v in $prereleases) {
+    Write-Host "Delisting $PackageId $v ..." -NoNewline
+    # --non-interactive: unlist on nuget.org without the confirm prompt.
+    dotnet nuget delete $PackageId $v `
+        --source $Source `
+        --api-key $env:NUGET_API_KEY `
+        --non-interactive
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host " done" -ForegroundColor Green
+    } else {
+        Write-Host " FAILED (exit $LASTEXITCODE)" -ForegroundColor Red
+        $failed += $v
+    }
+}
+
+Write-Host ""
+if ($failed.Count -eq 0) {
+    Write-Host "All $($prereleases.Count) prerelease(s) delisted." -ForegroundColor Green
+} else {
+    Write-Host "$($failed.Count) failed:" -ForegroundColor Red
+    $failed | ForEach-Object { Write-Host "  $_" }
+    exit 1
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
 using RoslynCodeLens;
 using RoslynCodeLens.Symbols;
+using RoslynCodeLens.TestDiscovery;
+using RoslynCodeLens.Tools;
 
 namespace RoslynCodeLens.Tests.Fixtures;
 
@@ -10,6 +13,23 @@ namespace RoslynCodeLens.Tests.Fixtures;
 /// </summary>
 public class TestSolutionFixture : IAsyncLifetime
 {
+    // Loading the fixture solution through MSBuildWorkspace is nondeterministic on
+    // this codebase: a design-time build occasionally drops a project's references,
+    // after which [Fact]/[Test]/[TestMethod] bind to error types or the test body's
+    // call into TestLib.Greeter no longer binds. Either way symbol-based discovery
+    // and coverage over the fixture silently return empty/wrong results — the flake
+    // behind #260 (and the long-standing "green in CI, red locally" fixture failures).
+    // Rather than hand tests a degraded solution, we probe the real discovery path
+    // after each load and retry on a fresh workspace until it is healthy. A load is an
+    // independent draw, so retries converge quickly; if every attempt fails we throw a
+    // precise diagnostic instead of letting tests fail with "Collection: []".
+    private const int MaxLoadAttempts = 6;
+
+    private static readonly TestFramework[] RequiredFrameworks =
+        [TestFramework.XUnit, TestFramework.NUnit, TestFramework.MSTest];
+
+    private static readonly string[] FixtureProjectDirs = ["XUnitFixture", "NUnitFixture", "MSTestFixture"];
+
     public string SolutionPath { get; private set; } = null!;
     public LoadedSolution Loaded { get; private set; } = null!;
     public SymbolResolver Resolver { get; private set; } = null!;
@@ -19,9 +39,108 @@ public class TestSolutionFixture : IAsyncLifetime
     {
         SolutionPath = Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
-        Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
-        Resolver = new SymbolResolver(Loaded);
-        Metadata = new MetadataSymbolResolver(Loaded, Resolver);
+
+        // Restore up front only when the assets are missing, so already-restored
+        // runs (CI, warm local checkouts) pay nothing.
+        await EnsureFixturesRestoredAsync(force: false).ConfigureAwait(false);
+
+        var problem = string.Empty;
+        for (var attempt = 1; attempt <= MaxLoadAttempts; attempt++)
+        {
+            Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
+            var resolver = new SymbolResolver(Loaded);
+            if (FixtureIsHealthy(Loaded, resolver, out problem))
+            {
+                Resolver = resolver;
+                Metadata = new MetadataSymbolResolver(Loaded, Resolver);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"TestSolution failed to load healthily after {MaxLoadAttempts} attempts: {problem}. " +
+            "This is the MSBuildWorkspace design-time build flake from #260 — a fixture project's references were " +
+            "dropped, so [Fact]/[Test]/[TestMethod] or the call into TestLib.Greeter did not bind and discovery returns nothing.");
+    }
+
+    /// <summary>
+    /// Probes the actual discovery and coverage paths — the same code the fixture's
+    /// tests exercise — rather than a shallow metadata check, because a dropped
+    /// reference can leave the framework/type resolvable via metadata while
+    /// cross-project reference finding still comes back empty. Two invariants, both
+    /// resting on the same test→TestLib.Greeter reference resolving:
+    ///   * Greeter.Greet has a direct test caller in every framework fixture; and
+    ///   * Greeter.Greet is not reported as uncovered.
+    /// A load that fails either dropped references — the caller retries on a fresh
+    /// workspace. Checking coverage as well as discovery matters: the two use slightly
+    /// different reference queries, and a load can satisfy one while degrading the other.
+    /// </summary>
+    private static bool FixtureIsHealthy(LoadedSolution loaded, SymbolResolver resolver, out string problem)
+    {
+        var discovery = FindTestsForSymbolLogic.Execute(loaded, resolver, "Greeter.Greet", transitive: false, maxDepth: 3);
+        var found = discovery.DirectTests.Select(t => t.Framework).ToHashSet();
+        var missing = RequiredFrameworks.Where(f => !found.Contains(f)).ToList();
+        if (missing.Count > 0)
+        {
+            problem = $"discovery for Greeter.Greet is missing framework(s) [{string.Join(", ", missing)}] " +
+                      $"(found {discovery.DirectTests.Count} direct test caller(s))";
+            return false;
+        }
+
+        var coverage = FindUncoveredSymbolsLogic.Execute(loaded, resolver);
+        if (coverage.UncoveredSymbols.Any(s => string.Equals(s.Symbol, "Greeter.Greet", StringComparison.Ordinal)))
+        {
+            problem = "Greeter.Greet is reported uncovered despite having test callers (coverage reference query degraded)";
+            return false;
+        }
+
+        problem = string.Empty;
+        return true;
+    }
+
+    private async Task EnsureFixturesRestoredAsync(bool force)
+    {
+        if (!force && FixturesRestored())
+            return;
+
+        await RunDotnetRestoreAsync(SolutionPath).ConfigureAwait(false);
+    }
+
+    private bool FixturesRestored()
+    {
+        var solutionDir = Path.GetDirectoryName(SolutionPath)!;
+        foreach (var dir in FixtureProjectDirs)
+        {
+            if (!File.Exists(Path.Combine(solutionDir, dir, "obj", "project.assets.json")))
+                return false;
+        }
+        return true;
+    }
+
+    private static async Task RunDotnetRestoreAsync(string solutionPath)
+    {
+        var psi = new ProcessStartInfo("dotnet", $"restore \"{solutionPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet restore' for the test fixtures.");
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet restore' for the test fixtures failed (exit {process.ExitCode}):\n" +
+                $"{await stdout.ConfigureAwait(false)}\n{await stderr.ConfigureAwait(false)}");
+        }
     }
 
     public Task DisposeAsync() => Task.CompletedTask;


### PR DESCRIPTION
## Summary

Two related changes coming out of #260 (the 2.4.1 publish failure):

1. **Stop publishing `-ci` prereleases** — `ci.yml` no longer packs/pushes a prerelease package on every push to `main`. CI is now build-and-test only; stable releases still publish via release-please. This also retires the #225 collision workaround, which only mattered while CI published. (The `NUGET_API_KEY` secret stays — release-please still needs it.)

2. **Self-heal the flaky `TestSolution` fixture load** — the root cause behind #260.

## Why #260 happened

The 2.4.1 publish job failed at the `Test` step (not the NuGet push, which was skipped): 5 `FindTestsForSymbol*`/`FindUncoveredSymbols` tests returned empty collections. The *identical commit* passed those same tests in `ci.yml` minutes earlier — a flake.

Root cause: the fixture `TestSolution` is loaded at runtime via MSBuildWorkspace but nothing in the test project builds/restores it. Two failure modes:
- **Unrestored locally** (`project.assets.json` missing) → design-time build resolves zero NuGet refs → deterministic local failure (the long-standing "green in CI, red locally" ~31 tests). CI hid this with a separate restore step.
- **Nondeterministic ref drops** even when restored → the test-framework ref or the `TestLib` ProjectReference drops, so `[Fact]/[Test]/[TestMethod]` bind to error types or `test → TestLib.Greeter` no longer binds → discovery/coverage silently return empty/wrong. Rare on CI, ~1-in-3 locally under contention.

## The fix

`TestSolutionFixture` now:
- **restores on demand** when the fixture assets are missing (self-sufficient locally; no-op on CI where assets already exist);
- after each load, **probes the real discovery + coverage paths** — `Greeter.Greet` must have a direct test caller in all three framework fixtures **and** must not be reported uncovered — and **retries on a fresh workspace** (up to 6×) until healthy;
- **throws a precise diagnostic** if every attempt drops references, instead of an opaque `Collection: []`.

A shallow `GetTypeByMetadataName` check was tried and rejected: a dropped reference can leave a type resolvable via metadata while cross-project reference finding still returns empty, so the probe exercises the same logic the tests do.

## Verification

- Affected subset: **20/20 green** across repeated runs (previously ~50% locally).
- Full suite: **602/602 green twice** locally (previously ~31 fixture tests failed locally).
- CI restore path unchanged and pays nothing (assets present → no child restore).

## Follow-up (not in this PR)

The underlying MSBuildWorkspace nondeterminism is a product-level robustness gap — the MCP server silently returns empty results on a bad load with only a stderr warning. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
