### PR TITLE
fix(loader): harden concurrent MSBuildWorkspace loads against dropped references (#263)

### DIFF
--- a/src/RoslynCodeLens/LoadedSolution.cs
+++ b/src/RoslynCodeLens/LoadedSolution.cs
@@ -10,6 +10,16 @@ public class LoadedSolution
     public IReadOnlyList<SkippedProject> SkippedProjects { get; init; } = Array.Empty<SkippedProject>();
     public bool IsEmpty => Compilations.IsEmpty;
 
+    /// <summary>
+    /// Reference-resolution failures reported by MSBuildWorkspace while loading (as
+    /// opposed to <see cref="SkippedProjects"/>, which are projects never opened).
+    /// Non-empty means the load is degraded — some projects opened with dropped
+    /// references, so results from those projects may be incomplete. Surfaced so
+    /// callers can warn instead of silently returning empty/partial results.
+    /// </summary>
+    public IReadOnlyList<string> LoadDiagnostics { get; init; } = Array.Empty<string>();
+    public bool Degraded => LoadDiagnostics.Count > 0;
+
     public static LoadedSolution Empty { get; } = CreateEmpty();
 
     private static LoadedSolution CreateEmpty()

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -135,6 +135,22 @@ public sealed class MultiSolutionManager : IDisposable
         }
     }
 
+    /// <summary>
+    /// Reference-resolution failures on the active solution (projects that opened with
+    /// dropped references). Non-empty means results from those projects may be incomplete.
+    /// </summary>
+    public IReadOnlyList<string> GetActiveLoadDiagnostics()
+    {
+        try
+        {
+            return Active.GetLoadedSolution().LoadDiagnostics;
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
     public string SetActiveSolution(string name)
     {
         var matches = _managers.Keys

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -32,6 +32,53 @@ public class SolutionLoader
                 ? n
                 : Math.Max(1, Math.Min(Environment.ProcessorCount, MaxDefaultParallelism));
 
+    // Concurrent MSBuildWorkspace design-time builds contend for the out-of-process
+    // BuildHost and can silently drop a project's references (partial or total),
+    // after which discovery/coverage over that project returns empty/wrong results.
+    // A single load in isolation is reliable; contention is the trigger. This
+    // process-wide gate caps how many design-time builds run at once ACROSS all
+    // concurrent loads, so independent load_solution calls (and each per-project
+    // worker) can't oversubscribe the BuildHost. Default equals the per-load
+    // parallelism, so a single load is never throttled; override with
+    // ROSLYN_CODELENS_MAX_CONCURRENT_LOADS.
+    internal static int GetMaxConcurrentBuildHosts() =>
+        int.TryParse(
+            Environment.GetEnvironmentVariable("ROSLYN_CODELENS_MAX_CONCURRENT_LOADS"),
+            out var n) && n > 0
+                ? n
+                : GetLoadParallelism();
+
+    // How many times to re-open a solution whose design-time build reported
+    // reference-resolution failures, on a fresh workspace. Each load is an
+    // independent draw, so a small number of retries clears the transient
+    // contention drop. 0 disables retry. Override with ROSLYN_CODELENS_LOAD_RETRIES.
+    internal static int GetLoadRetryCount() =>
+        int.TryParse(
+            Environment.GetEnvironmentVariable("ROSLYN_CODELENS_LOAD_RETRIES"),
+            out var n) && n >= 0
+                ? n
+                : 2;
+
+    private static readonly SemaphoreSlim s_buildHostGate = new(GetMaxConcurrentBuildHosts());
+
+    /// <summary>Result of opening a solution: the loaded workspace plus what could not
+    /// be loaded (<see cref="Skipped"/>) and reference-resolution failures on projects
+    /// that did load (<see cref="LoadDiagnostics"/>).</summary>
+    public readonly record struct SolutionOpen(
+        Solution Solution,
+        Workspace Workspace,
+        IReadOnlyList<SkippedProject> Skipped,
+        IReadOnlyList<string> LoadDiagnostics)
+    {
+        // Back-compat deconstruction for callers that predate LoadDiagnostics.
+        public void Deconstruct(out Solution solution, out Workspace workspace, out IReadOnlyList<SkippedProject> skipped)
+        {
+            solution = Solution;
+            workspace = Workspace;
+            skipped = Skipped;
+        }
+    }
+
     internal static async Task<T?> RunWithTimeoutAsync<T>(
         Func<CancellationToken, Task<T?>> work,
         int timeoutSec,
@@ -56,7 +103,7 @@ public class SolutionLoader
         }
     }
 
-    public async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenAsync(string solutionPath, ProjectFilter? filter = null, ShadowCopyAnalyzerAssemblyLoader? analyzerLoader = null, CancellationToken ct = default)
+    public async Task<SolutionOpen> OpenAsync(string solutionPath, ProjectFilter? filter = null, ShadowCopyAnalyzerAssemblyLoader? analyzerLoader = null, CancellationToken ct = default)
     {
         var classified = ProjectClassifier.EnumerateProjects(solutionPath);
 
@@ -80,47 +127,117 @@ public class SolutionLoader
             return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
         }
 
-        var workspace = MSBuildWorkspace.Create();
-        workspace.WorkspaceFailed += (_, e) =>
-        {
-            Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
-        };
-
         await Console.Error.WriteLineAsync($"[roslyn-codelens] Loading solution: {Path.GetFileName(solutionPath)}").ConfigureAwait(false);
 
-        Solution? solution;
-        try
+        // Re-open on a fresh workspace when the design-time build drops a project's
+        // references under contention (a load is an independent draw). Keep the least
+        // degraded attempt; if all attempts drop references, surface them rather than
+        // returning a silently-degraded solution.
+        var maxAttempts = GetLoadRetryCount() + 1;
+        MSBuildWorkspace? bestWorkspace = null;
+        Solution? bestSolution = null;
+        IReadOnlyList<string> bestDropped = Array.Empty<string>();
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
-            solution = await RunWithTimeoutAsync<Solution>(
-                innerCt => workspace.OpenSolutionAsync(solutionPath, cancellationToken: innerCt),
-                GetOpenProjectTimeoutSec(),
-                ct).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            // Fallback: solution-level open threw (often a legacy project we did not classify, or
-            // an SDK project with a broken import). Reuse per-project loading so we still surface
-            // whatever can be loaded plus a list of what was skipped.
-            workspace.Dispose();
-            await Console.Error.WriteLineAsync(
-                $"[roslyn-codelens] Solution-level load failed ({ex.GetType().Name}: {ex.Message}); falling back to per-project loading.")
-                .ConfigureAwait(false);
-            return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
+            var workspace = MSBuildWorkspace.Create();
+            workspace.WorkspaceFailed += (_, e) =>
+                Console.Error.WriteLine($"[roslyn-codelens] Warning: {e.Diagnostic.Message}");
+
+            Solution? solution;
+            try
+            {
+                await s_buildHostGate.WaitAsync(ct).ConfigureAwait(false);
+                try
+                {
+                    solution = await RunWithTimeoutAsync<Solution>(
+                        innerCt => workspace.OpenSolutionAsync(solutionPath, cancellationToken: innerCt),
+                        GetOpenProjectTimeoutSec(),
+                        ct).ConfigureAwait(false);
+                }
+                finally
+                {
+                    s_buildHostGate.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Fallback: solution-level open threw (often a legacy project we did not classify, or
+                // an SDK project with a broken import). Reuse per-project loading so we still surface
+                // whatever can be loaded plus a list of what was skipped.
+                workspace.Dispose();
+                bestWorkspace?.Dispose();
+                await Console.Error.WriteLineAsync(
+                    $"[roslyn-codelens] Solution-level load failed ({ex.GetType().Name}: {ex.Message}); falling back to per-project loading.")
+                    .ConfigureAwait(false);
+                return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
+            }
+
+            if (solution is null)
+            {
+                workspace.Dispose();
+                bestWorkspace?.Dispose();
+                await Console.Error.WriteLineAsync(
+                    $"[roslyn-codelens] Solution-level load timed out; falling back to per-project loading.")
+                    .ConfigureAwait(false);
+                return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
+            }
+
+            var dropped = FindProjectsWithDroppedReferences(solution);
+            if (dropped.Count == 0)
+            {
+                bestWorkspace?.Dispose();
+                if (analyzerLoader is not null)
+                    solution = RemapSolutionAnalyzers(solution, analyzerLoader);
+                return new SolutionOpen(solution, workspace, [], []);
+            }
+
+            // Degraded: retain the attempt with the fewest dropped projects.
+            if (bestSolution is null || dropped.Count < bestDropped.Count)
+            {
+                bestWorkspace?.Dispose();
+                bestWorkspace = workspace;
+                bestSolution = solution;
+                bestDropped = dropped;
+            }
+            else
+            {
+                workspace.Dispose();
+            }
+
+            if (attempt < maxAttempts)
+                await Console.Error.WriteLineAsync(
+                    $"[roslyn-codelens] {dropped.Count} project(s) loaded with dropped references; retrying ({attempt}/{maxAttempts - 1})...")
+                    .ConfigureAwait(false);
         }
 
-        if (solution is null)
+        await Console.Error.WriteLineAsync(
+            $"[roslyn-codelens] Solution remained degraded after {maxAttempts} attempt(s); {bestDropped.Count} project(s) have unresolved references and will be reported.")
+            .ConfigureAwait(false);
+
+        var finalSolution = analyzerLoader is not null
+            ? RemapSolutionAnalyzers(bestSolution!, analyzerLoader)
+            : bestSolution!;
+        return new SolutionOpen(finalSolution, bestWorkspace!, [], bestDropped);
+    }
+
+    /// <summary>
+    /// Detects projects whose references the design-time build dropped: a source-bearing
+    /// project with zero resolved metadata references. Every real SDK project resolves
+    /// the framework reference set, so zero is an unambiguous, false-positive-free signal
+    /// of a contention drop. (Partial drops — some references resolved, some not — are not
+    /// detectable this way; the concurrency gate is what keeps those rare.)
+    /// </summary>
+    private static IReadOnlyList<string> FindProjectsWithDroppedReferences(Solution solution)
+    {
+        List<string>? dropped = null;
+        foreach (var project in solution.Projects)
         {
-            workspace.Dispose();
-            await Console.Error.WriteLineAsync(
-                $"[roslyn-codelens] Solution-level load timed out; falling back to per-project loading.")
-                .ConfigureAwait(false);
-            return await OpenPerProjectAsync(solutionPath, classified, analyzerLoader, ct).ConfigureAwait(false);
+            if (project.DocumentIds.Count > 0 && project.MetadataReferences.Count == 0)
+                (dropped ??= new List<string>()).Add(
+                    $"{project.Name}: no metadata references resolved (design-time build dropped references)");
         }
-
-        if (analyzerLoader is not null)
-            solution = RemapSolutionAnalyzers(solution, analyzerLoader);
-
-        return (solution, workspace, Array.Empty<SkippedProject>());
+        return (IReadOnlyList<string>?)dropped ?? Array.Empty<string>();
     }
 
     private static Solution RemapSolutionAnalyzers(Solution solution, ShadowCopyAnalyzerAssemblyLoader loader)
@@ -136,7 +253,7 @@ public class SolutionLoader
         return solution;
     }
 
-    private static async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenPerProjectAsync(
+    private static async Task<SolutionOpen> OpenPerProjectAsync(
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
         ShadowCopyAnalyzerAssemblyLoader? analyzerLoader,
@@ -165,7 +282,7 @@ public class SolutionLoader
 
         if (targets.Count == 0)
         {
-            return (new AdhocWorkspace().CurrentSolution, new AdhocWorkspace(), skipped);
+            return new SolutionOpen(new AdhocWorkspace().CurrentSolution, new AdhocWorkspace(), skipped, []);
         }
 
         // On-disk ProjectReference graph, restricted to the target set. Used both
@@ -224,10 +341,21 @@ public class SolutionLoader
                     Project? loaded;
                     try
                     {
-                        loaded = await RunWithTimeoutAsync<Project>(
-                            innerCt => ws.OpenProjectAsync(entry.Path, cancellationToken: innerCt),
-                            timeoutSec,
-                            ct).ConfigureAwait(false);
+                        // Bound concurrent design-time builds across all in-flight loads so
+                        // independent workers/loads don't oversubscribe the BuildHost and
+                        // drop references.
+                        await s_buildHostGate.WaitAsync(ct).ConfigureAwait(false);
+                        try
+                        {
+                            loaded = await RunWithTimeoutAsync<Project>(
+                                innerCt => ws.OpenProjectAsync(entry.Path, cancellationToken: innerCt),
+                                timeoutSec,
+                                ct).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            s_buildHostGate.Release();
+                        }
                     }
                     catch (OperationCanceledException) when (ct.IsCancellationRequested)
                     {
@@ -307,7 +435,8 @@ public class SolutionLoader
             SolutionId.CreateNewId(), VersionStamp.Create(), solutionPath, finalInfos);
         workspace.AddSolution(solutionInfo);
 
-        return (workspace.CurrentSolution, workspace, skipped);
+        var dropped = FindProjectsWithDroppedReferences(workspace.CurrentSolution);
+        return new SolutionOpen(workspace.CurrentSolution, workspace, skipped, dropped);
     }
 
     /// <summary>
@@ -400,7 +529,7 @@ public class SolutionLoader
             filePath: document.FilePath);
     }
 
-    private static async Task<(Solution Solution, Workspace Workspace, IReadOnlyList<SkippedProject> Skipped)> OpenFilteredAsync(
+    private static async Task<SolutionOpen> OpenFilteredAsync(
         string solutionPath,
         IReadOnlyList<ProjectClassifier.ClassifiedProject> classified,
         ProjectFilter filter,
@@ -455,14 +584,13 @@ public class SolutionLoader
                     "Excluded by load_solution filter."));
         }
 
-        var (solution, workspace, perProjectSkipped) =
-            await OpenPerProjectAsync(solutionPath, inClosure, analyzerLoader, ct).ConfigureAwait(false);
+        var open = await OpenPerProjectAsync(solutionPath, inClosure, analyzerLoader, ct).ConfigureAwait(false);
 
-        var skipped = new List<SkippedProject>(filteredOut.Count + perProjectSkipped.Count);
+        var skipped = new List<SkippedProject>(filteredOut.Count + open.Skipped.Count);
         skipped.AddRange(filteredOut);
-        skipped.AddRange(perProjectSkipped);
+        skipped.AddRange(open.Skipped);
 
-        return (solution, workspace, skipped);
+        return open with { Skipped = skipped };
     }
 
     public async Task<ConcurrentDictionary<ProjectId, Compilation>> CompileAllParallelAsync(Solution solution)
@@ -497,17 +625,18 @@ public class SolutionLoader
 
     public async Task<LoadedSolution> LoadAsync(string solutionPath)
     {
-        var (solution, _, skipped) = await OpenAsync(solutionPath).ConfigureAwait(false);
-        var compilations = await CompileAllParallelAsync(solution).ConfigureAwait(false);
+        var open = await OpenAsync(solutionPath).ConfigureAwait(false);
+        var compilations = await CompileAllParallelAsync(open.Solution).ConfigureAwait(false);
 
         await Console.Error.WriteLineAsync(
-            $"[roslyn-codelens] Ready. {compilations.Count} projects compiled, {skipped.Count} skipped.").ConfigureAwait(false);
+            $"[roslyn-codelens] Ready. {compilations.Count} projects compiled, {open.Skipped.Count} skipped, {open.LoadDiagnostics.Count} degraded.").ConfigureAwait(false);
 
         return new LoadedSolution
         {
-            Solution = solution,
+            Solution = open.Solution,
             Compilations = compilations,
-            SkippedProjects = skipped
+            SkippedProjects = open.Skipped,
+            LoadDiagnostics = open.LoadDiagnostics
         };
     }
 

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -58,13 +58,10 @@ public sealed class SolutionManager : IDisposable
     {
         var solutionLoader = new SolutionLoader();
         var analyzerLoader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
-        Solution solution;
-        Workspace workspace;
-        IReadOnlyList<SkippedProject> skipped;
+        SolutionLoader.SolutionOpen open;
         try
         {
-            (solution, workspace, skipped) =
-                await solutionLoader.OpenAsync(solutionPath, filter, analyzerLoader).ConfigureAwait(false);
+            open = await solutionLoader.OpenAsync(solutionPath, filter, analyzerLoader).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -76,15 +73,16 @@ public sealed class SolutionManager : IDisposable
 
         var emptyLoaded = new LoadedSolution
         {
-            Solution = solution,
+            Solution = open.Solution,
             Compilations = new ConcurrentDictionary<ProjectId, Compilation>(),
-            SkippedProjects = skipped
+            SkippedProjects = open.Skipped,
+            LoadDiagnostics = open.LoadDiagnostics
         };
 
         var manager = new SolutionManager(emptyLoaded, solutionPath);
         manager._analyzerLoader = analyzerLoader;
-        manager._workspace = workspace;
-        manager._warmupTask = manager.WarmupAsync(solutionLoader, solution, skipped);
+        manager._workspace = open.Workspace;
+        manager._warmupTask = manager.WarmupAsync(solutionLoader, open.Solution, open.Skipped, open.LoadDiagnostics);
         return manager;
     }
 
@@ -93,7 +91,7 @@ public sealed class SolutionManager : IDisposable
         return new SolutionManager(LoadedSolution.Empty, null);
     }
 
-    private async Task WarmupAsync(SolutionLoader loader, Solution solution, IReadOnlyList<SkippedProject> skipped)
+    private async Task WarmupAsync(SolutionLoader loader, Solution solution, IReadOnlyList<SkippedProject> skipped, IReadOnlyList<string> loadDiagnostics)
     {
         try
         {
@@ -104,7 +102,8 @@ public sealed class SolutionManager : IDisposable
             {
                 Solution = solution,
                 Compilations = compilations,
-                SkippedProjects = skipped
+                SkippedProjects = skipped,
+                LoadDiagnostics = loadDiagnostics
             };
             var newResolver = new SymbolResolver(newLoaded);
             var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
@@ -238,8 +237,9 @@ public sealed class SolutionManager : IDisposable
         ShadowCopyAnalyzerAssemblyLoader? analyzerLoader;
         lock (_lock) { analyzerLoader = _analyzerLoader; }
 
-        var (solution, workspace, skipped) =
-            await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
+        var open = await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
+        var solution = open.Solution;
+        var workspace = open.Workspace;
         var compilations = new ConcurrentDictionary<ProjectId, Compilation>(_loaded.Compilations);
 
         var staleProjects = solution.Projects.Where(p => staleIds.Contains(p.Id)).ToList();
@@ -256,7 +256,8 @@ public sealed class SolutionManager : IDisposable
         {
             Solution = solution,
             Compilations = compilations,
-            SkippedProjects = skipped
+            SkippedProjects = open.Skipped,
+            LoadDiagnostics = open.LoadDiagnostics
         };
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
@@ -289,26 +290,26 @@ public sealed class SolutionManager : IDisposable
 
         var solutionLoader = new SolutionLoader();
         var analyzerLoader = new ShadowCopyAnalyzerAssemblyLoader(SharedCache);
-        Solution solution;
-        Workspace workspace;
-        IReadOnlyList<SkippedProject> skipped;
+        SolutionLoader.SolutionOpen open;
         try
         {
-            (solution, workspace, skipped) =
-                await solutionLoader.OpenAsync(_solutionPath, null, analyzerLoader).ConfigureAwait(false);
+            open = await solutionLoader.OpenAsync(_solutionPath, null, analyzerLoader).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             analyzerLoader.Dispose();
             throw new InvalidOperationException(SolutionLoadFailure.Describe(_solutionPath, ex), ex);
         }
+        var solution = open.Solution;
+        var workspace = open.Workspace;
         var compilations = await solutionLoader.CompileAllParallelAsync(solution).ConfigureAwait(false);
 
         var newLoaded = new LoadedSolution
         {
             Solution = solution,
             Compilations = compilations,
-            SkippedProjects = skipped
+            SkippedProjects = open.Skipped,
+            LoadDiagnostics = open.LoadDiagnostics
         };
         var newResolver = new SymbolResolver(newLoaded);
         var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);

--- a/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
+++ b/src/RoslynCodeLens/Tools/LoadSolutionTool.cs
@@ -49,6 +49,7 @@ public static class LoadSolutionTool
             {
                 var loadedPath = await manager.LoadSolutionAsync(path, filter).ConfigureAwait(false);
                 var skippedProjects = manager.GetActiveSkippedProjects();
+                var degraded = manager.GetActiveLoadDiagnostics();
                 var projectCount = manager.GetLoadedSolution().Solution.Projects.Count();
                 return new
                 {
@@ -59,20 +60,31 @@ public static class LoadSolutionTool
                         .Take(10)
                         .Select(s => new { s.Name, s.Kind, s.Reason })
                         .ToArray(),
+                    degradedProjects = degraded.Count,
+                    degraded = degraded.Take(10).ToArray(),
                 };
             });
         }
 
         var normalised = await manager.LoadSolutionAsync(path, filter).ConfigureAwait(false);
         var skipped = manager.GetActiveSkippedProjects();
+        var degraded = manager.GetActiveLoadDiagnostics();
         var loadedCount = manager.GetLoadedSolution().Solution.Projects.Count();
 
+        // A degraded load means MSBuildWorkspace dropped a project's references under
+        // contention; results from those projects may be incomplete. Warn rather than
+        // let tools silently return empty/partial results.
+        var degradedNote = degraded.Count > 0
+            ? $" ⚠ {degraded.Count} project(s) loaded with unresolved references (results for them may be incomplete): " +
+              $"{string.Join("; ", degraded.Take(5))}{(degraded.Count > 5 ? " …" : "")}. Retry load_solution to re-attempt."
+            : "";
+
         if (skipped.Count == 0)
-            return $"Loaded {loadedCount} project(s) from: {normalised}";
+            return $"Loaded {loadedCount} project(s) from: {normalised}.{degradedNote}";
 
         var summary = string.Join(", ", skipped.Take(10).Select(s => $"{s.Name} ({s.Kind})"));
         var ellipsis = skipped.Count > 10 ? $" and {skipped.Count - 10} more" : "";
         return $"Loaded {loadedCount} project(s) from: {normalised}; skipped {skipped.Count}: {summary}{ellipsis}. " +
-               "Call list_solutions for per-project reason details.";
+               $"Call list_solutions for per-project reason details.{degradedNote}";
     }
 }

--- a/tests/RoslynCodeLens.Tests/LoaderConcurrencyHardeningTests.cs
+++ b/tests/RoslynCodeLens.Tests/LoaderConcurrencyHardeningTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+
+namespace RoslynCodeLens.Tests;
+
+public class LoaderConcurrencyHardeningTests
+{
+    private static string FixturePath() => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+
+    [Fact]
+    public async Task CleanLoad_IsNotDegraded_AndHasNoLoadDiagnostics()
+    {
+        // Guards the false-positive risk: a healthy load emits a benign
+        // WorkspaceDiagnosticKind.Failure (NU1510 "will not be pruned"), so degradation
+        // must be judged by resolved references — not by diagnostics — or every load
+        // would be reported degraded.
+        var loaded = await new SolutionLoader().LoadAsync(FixturePath());
+
+        Assert.False(loaded.Degraded);
+        Assert.Empty(loaded.LoadDiagnostics);
+    }
+
+    [Fact]
+    public async Task OpenAsync_CleanLoad_ReportsNoDroppedReferences()
+    {
+        var open = await new SolutionLoader().OpenAsync(FixturePath());
+
+        Assert.Empty(open.LoadDiagnostics);
+        // Every source-bearing project resolved its framework references.
+        foreach (var project in open.Solution.Projects)
+            if (project.DocumentIds.Count > 0)
+                Assert.NotEmpty(project.MetadataReferences);
+    }
+
+    [Fact]
+    public void Degraded_ReflectsLoadDiagnostics()
+    {
+        var healthy = new LoadedSolution
+        {
+            Solution = new AdhocWorkspace().CurrentSolution,
+            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(),
+        };
+        Assert.False(healthy.Degraded);
+
+        var degraded = new LoadedSolution
+        {
+            Solution = new AdhocWorkspace().CurrentSolution,
+            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(),
+            LoadDiagnostics = new[] { "Foo: no metadata references resolved" },
+        };
+        Assert.True(degraded.Degraded);
+    }
+
+    [Fact]
+    public void MaxConcurrentBuildHosts_DefaultsToLoadParallelism()
+    {
+        Assert.Equal(SolutionLoader.GetLoadParallelism(), SolutionLoader.GetMaxConcurrentBuildHosts());
+    }
+
+    [Fact]
+    public void MaxConcurrentBuildHosts_HonoursEnvOverride()
+    {
+        const string key = "ROSLYN_CODELENS_MAX_CONCURRENT_LOADS";
+        var original = Environment.GetEnvironmentVariable(key);
+        try
+        {
+            Environment.SetEnvironmentVariable(key, "1");
+            Assert.Equal(1, SolutionLoader.GetMaxConcurrentBuildHosts());
+            Environment.SetEnvironmentVariable(key, "0"); // invalid -> falls back to default
+            Assert.Equal(SolutionLoader.GetLoadParallelism(), SolutionLoader.GetMaxConcurrentBuildHosts());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, original);
+        }
+    }
+
+    [Fact]
+    public void LoadRetryCount_DefaultsToTwo_AndHonoursEnvOverride()
+    {
+        Assert.Equal(2, SolutionLoader.GetLoadRetryCount());
+
+        const string key = "ROSLYN_CODELENS_LOAD_RETRIES";
+        var original = Environment.GetEnvironmentVariable(key);
+        try
+        {
+            Environment.SetEnvironmentVariable(key, "0"); // 0 is valid: disables retry
+            Assert.Equal(0, SolutionLoader.GetLoadRetryCount());
+            Environment.SetEnvironmentVariable(key, "5");
+            Assert.Equal(5, SolutionLoader.GetLoadRetryCount());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(key, original);
+        }
+    }
+}


### PR DESCRIPTION
Closes #263.

## Problem

Concurrent MSBuildWorkspace design-time builds contend for the out-of-process BuildHost and can **silently drop a project's references** (partial or total). After that, symbol-based tools (`find_tests_for_symbol`, `find_uncovered_symbols`, `find_callers`, metadata resolution, …) return empty/wrong results with no signal to the caller — the same nondeterminism behind #260.

**Measured** (loading the fixture solution and checking whether discovery resolves a known cross-project reference):

| Scenario | Degraded |
|---|---|
| Sequential (isolated) | 0 / 15 |
| 16-way concurrent, ungated | 2 / 16 (one total drop, one partial) |

So a single load is reliable; **contention is the trigger**.

## Fix (bound + retry + surface, per the direction agreed on #263)

- **Bound** — a process-wide semaphore (`s_buildHostGate`) caps concurrent design-time builds across *all* in-flight loads and per-project workers, so independent `load_solution` calls and workers can't oversubscribe the BuildHost. Default = per-load parallelism (a single load is never throttled); override with `ROSLYN_CODELENS_MAX_CONCURRENT_LOADS`.
- **Retry** — `OpenAsync` re-opens on a fresh workspace when a load returns with dropped references, keeping the least-degraded attempt (`ROSLYN_CODELENS_LOAD_RETRIES`, default 2). Each load is an independent draw, so retries clear the transient drop.
- **Surface** — `LoadedSolution` gains `LoadDiagnostics` / `Degraded`, threaded through `SolutionManager`; `load_solution` now warns *"N project(s) loaded with unresolved references (results for them may be incomplete). Retry load_solution…"* instead of silently returning partial results.

### Why detection is content-based, not diagnostic-based

I verified that **every healthy load emits a `WorkspaceDiagnosticKind.Failure` diagnostic** — the benign NU1510 *"PackageReference … will not be pruned"* wrapped as `Msbuild failed when processing the file …`. So diagnostic Kind is useless as a degradation signal (it would false-positive on every load). Degradation is instead judged by a false-positive-free content signal: **a source-bearing project with zero resolved metadata references** (every real SDK project resolves the framework set). Partial drops (some references resolved) aren't detectable this way — the gate is what keeps those rare. This limitation is documented in code.

## Verification

- **0 degraded across 48 concurrent loads** (3×16) with gate+retry — was 2/16 ungated.
- New `LoaderConcurrencyHardeningTests` (6): clean load is **not** flagged degraded (guards the NU1510 false-positive), `Degraded` semantics, env-override parsing.
- Loader/manager suites **58/58**; full suite **608/608 twice**.

The test-side flake was already fixed in #262; this hardens the product loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
