### PR TITLE
build: stop a running server that locks bin\Debug before a Debug build

### DIFF
--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -59,6 +59,24 @@
     <StampMcpVersion FilePath="$(MSBuildProjectDirectory)/.mcp/server.json" PackageVersion="$(Version)" />
   </Target>
 
+  <!--
+    A running Debug server (launched by `dotnet run` or an MCP client) keeps its own
+    bin\Debug DLLs (ModelContextProtocol.*, RoslynCodeLens.dll, ...) loaded, so a
+    rebuild fails on Windows with MSB3021 "being used by another process". Before a
+    Debug build, stop any RoslynCodeLens process started from THIS project's output so
+    the copy step can overwrite it. The MCP client relaunches the server on demand.
+
+    Scoped to this project's own bin\ so a server from another checkout/worktree is
+    left alone. Windows-only: on Linux/CI open files can be overwritten and no server
+    is running. Opt out with -p:StopLockingServerOnBuild=false. Never fails the build.
+  -->
+  <Target Name="StopLockingServer"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(OS)' == 'Windows_NT' and '$(Configuration)' == 'Debug' and '$(StopLockingServerOnBuild)' != 'false'">
+    <Exec ContinueOnError="true"
+          Command="powershell -NoProfile -NonInteractive -Command &quot;$p = Get-Process -Name RoslynCodeLens -ErrorAction SilentlyContinue | Where-Object { $_.Path -like '$(MSBuildProjectDirectory)\bin\*' }; if ($p) { $p | Stop-Process -Force -ErrorAction SilentlyContinue; Start-Sleep -Milliseconds 400 }&quot;" />
+  </Target>
+
   <!-- MSBuild.Locator requires these to be excluded from runtime -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="18.7.1" ExcludeAssets="runtime" PrivateAssets="all" />


### PR DESCRIPTION
## Problem

A running Debug server (`dotnet run`, or an MCP client that launched it) keeps its own `bin\Debug\net10.0` DLLs (`ModelContextProtocol.*`, `RoslynCodeLens.dll`, …) loaded. On Windows a rebuild then fails:

```
MSB3021: Unable to copy ... because it is being used by another process. The file is locked by: "RoslynCodeLens (34436)"
```

Same family as #254 (which shadow-copies *analyzer/generator* DLLs), but the main runtime DLLs are always locked while the process runs, so the remedy is to stop the process before a Debug rebuild.

## Change

A `BeforeBuild` MSBuild target that stops any `RoslynCodeLens` process started from **this project's own** `bin\` before building. The MCP client relaunches the server on demand.

Guards:
- **Windows-only** — Linux/CI overwrite open files and run no server.
- **Debug-only** — Release output isn't locked by the Debug-running server.
- **Scoped to this project's `bin\`** — a server from another checkout/worktree is left alone.
- **`ContinueOnError`** — never fails the build.
- **Opt out** with `-p:StopLockingServerOnBuild=false`.

## Verification

- Debug build with the server running (PID launched from `bin\Debug`): target stops it → **Build succeeded** (previously MSB3021).
- Debug build with no server: **no-op**, succeeds.
- Release build: target **skipped**, succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)