### PR TITLE
ci: widen MCP Registry publish retry window for NuGet indexing lag

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -25,4 +25,22 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # Retry with backoff in case NuGet is still indexing the version the registry
+        # validates against (~25 min window). Safe to run any time: succeeds on the
+        # first attempt once the version is indexed.
+        run: |
+          max_attempts=15
+          delay=30
+          for attempt in $(seq 1 "$max_attempts"); do
+            if ./mcp-publisher publish; then
+              echo "Published to MCP Registry on attempt $attempt."
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet may still be indexing); retrying in ${delay}s"
+              sleep "$delay"
+              [ "$delay" -lt 120 ] && delay=$((delay + 30))
+            fi
+          done
+          echo "::error::MCP Registry publish failed after $max_attempts attempts (~25 min)."
+          exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,16 +76,27 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        # The registry validates by hitting NuGet's search API, which lags ~1-2 min
-        # behind the upload that the preceding `publish` job just performed. Retry
-        # so we don't fail the workflow on indexing latency.
+        # The registry validates the version against NuGet's search index, which for a
+        # NEW version can lag 5-15+ min behind the upload the `publish` job just did
+        # (new versions index far slower than updates to an existing package). The old
+        # 6x30s (~3 min) window was too short and failed the release on indexing lag
+        # (2.4.2). Retry with backoff over a ~25 min window so we ride it out.
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
         run: |
-          for attempt in 1 2 3 4 5 6; do
+          max_attempts=15
+          delay=30
+          for attempt in $(seq 1 "$max_attempts"); do
             if ./mcp-publisher publish; then
+              echo "Published $VERSION to MCP Registry on attempt $attempt."
               exit 0
             fi
-            echo "::warning::MCP Registry publish attempt $attempt failed; retrying in 30s"
-            sleep 30
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet is likely still indexing $VERSION); retrying in ${delay}s"
+              sleep "$delay"
+              # Ramp up to a 2 min cap so the total window is ~25 min without hammering.
+              [ "$delay" -lt 120 ] && delay=$((delay + 30))
+            fi
           done
-          echo "::error::MCP Registry publish failed after 6 attempts"
+          echo "::error::MCP Registry publish failed after $max_attempts attempts (~25 min). NuGet may still be indexing $VERSION; once nuget.org shows it, re-run the 'Publish to MCP Registry' workflow (Actions -> Publish to MCP Registry -> Run workflow)."
           exit 1


### PR DESCRIPTION
## Problem

The 2.4.2 release-please run failed at **Publish to MCP Registry** (the `publish` NuGet job and the GitHub release both succeeded):

```
registry validation failed for package 0 (RoslynCodeLens.Mcp):
NuGet package 'RoslynCodeLens.Mcp' exists but version 2.4.2 does not exist in the registry.
If you recently published the version, wait for validation to complete
...
MCP Registry publish failed after 6 attempts
```

The MCP registry validates the release version against **NuGet's search index**, which for a *new* version can lag **5–15+ min** behind the upload the preceding `publish` job just performed (new versions index far slower than updates). The retry window was **6 × 30s ≈ 3 min** — too short — so the release failed purely on indexing latency. Nothing was wrong with the package or `server.json` (release-please correctly bumped the root `server.json` to 2.4.2).

## Fix

Widen the retry to **15 attempts with 30s→120s backoff (~25 min total)** in both:
- the release pipeline step (`release-please.yml`), and
- the manual `workflow_dispatch` fallback (`publish-mcp-registry.yml`),

and point the failure message at the re-run workflow. Purely a timing/resilience change — no effect on the NuGet push or GitHub release.

## Remediating 2.4.2

2.4.2 is now in NuGet's search index, so the registry publish has been re-run to register the already-released 2.4.2 (independent of this merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)