### PR TITLE
docs: align package/registry metadata with the evolved 57-tool surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 37 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 57 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MarcelRoozekrans/roslyn-codelens",
   "title": "Roslyn CodeLens",
-  "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
+  "description": "Roslyn MCP server: semantic .NET/C# intelligence - analysis, refactoring, tests, IL inspection.",
   "repository": {
     "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
     "source": "github"

--- a/src/RoslynCodeLens/.mcp/server.json
+++ b/src/RoslynCodeLens/.mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.marcelroozekrans/roslyn-codelens",
   "title": "Roslyn CodeLens",
-  "description": "Roslyn-based MCP server providing semantic code intelligence for .NET codebases.",
+  "description": "Roslyn MCP server: semantic .NET/C# intelligence - analysis, refactoring, tests, IL inspection.",
   "repository": {
     "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp",
     "source": "github"

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -8,11 +8,11 @@
     <ToolCommandName>roslyn-codelens-mcp</ToolCommandName>
     <PackageId>RoslynCodeLens.Mcp</PackageId>
     <Authors>Marcel Roozekrans</Authors>
-    <Description>Roslyn-based MCP server providing semantic code intelligence for .NET codebases</Description>
+    <Description>Roslyn-based MCP server that gives AI agents deep semantic understanding of .NET codebases — navigation, call graphs, diagnostics, refactoring, code-quality auditing, test intelligence, and IL/external-assembly inspection.</Description>
     <PackageProjectUrl>https://marcelroozekrans.github.io/roslyn-codelens-mcp/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MarcelRoozekrans/roslyn-codelens-mcp</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-<PackageTags>roslyn;mcp;code-analysis;dotnet-tool</PackageTags>
+    <PackageTags>roslyn;mcp;mcp-server;csharp;dotnet;dotnet-tool;code-analysis;code-intelligence;static-analysis;refactoring;diagnostics;code-quality</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageType>DotnetTool;McpServer</PackageType>


### PR DESCRIPTION
## Why

The solution has grown to **57 tools**, but the outward-facing metadata still described an earlier, narrower tool — naming only ~4 of ~10 categories (type hierarchies, call sites, DI, reflection) and omitting the big evolved areas: diagnostics & code fixes, code-quality auditing, test intelligence, and IL/external-assembly inspection. The README already documents all 57; this brings the package/registry metadata in line.

## Changes

- **NuGet `<Description>`** — broadened to convey the full breadth.
- **NuGet `PackageTags`** — 4 → 12 (adds `csharp`, `mcp-server`, `code-intelligence`, `static-analysis`, `refactoring`, `diagnostics`, `code-quality`, `dotnet`).
- **`server.json`** (registry + packaged copy) — reworded description, kept within the MCP registry's **100-char** cap (95 chars).
- **CLAUDE.md** — stale "37 code intelligence tools" → **57**.

Already applied directly (outside this PR): the **GitHub repo description** and **topics** (added `csharp`, `code-intelligence`, `static-analysis`, `mcp-server`, `dotnet-tool`, `ai-agents`).

NuGet tag/description changes take effect on the next release; the `server.json` description is validated on the next registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)