### PR TITLE
fix: incremental rebuild returns consistent symbols after watcher edits (#282)

### DIFF
--- a/src/RoslynCodeLens/FileChangeTracker.cs
+++ b/src/RoslynCodeLens/FileChangeTracker.cs
@@ -8,6 +8,8 @@ public sealed class FileChangeTracker : IDisposable
     private readonly Dictionary<string, ProjectId> _fileToProject;
     private readonly Dictionary<ProjectId, List<ProjectId>> _reverseDeps;
     private readonly HashSet<ProjectId> _staleProjects = new();
+    private readonly HashSet<string> _changedDocumentPaths = new(StringComparer.OrdinalIgnoreCase);
+    private bool _requiresFullReload;
     private readonly FileSystemWatcher[] _watchers;
     private readonly Lock _lock = new();
     private Timer? _debounceTimer;
@@ -61,6 +63,30 @@ public sealed class FileChangeTracker : IDisposable
         lock (_lock) return new HashSet<ProjectId>(_staleProjects);
     }
 
+    /// <summary>
+    /// A consistent snapshot of what has gone stale since the last <see cref="ClearStale"/>:
+    /// the transitively-closed set of stale projects, the source documents whose on-disk
+    /// text changed (candidates for an in-place incremental rebuild via
+    /// <c>Solution.WithDocumentText</c>), and whether any change is structural — a project
+    /// file, an unknown/new file, etc. — and therefore needs a full solution reload rather
+    /// than an incremental document edit.
+    /// </summary>
+    public readonly record struct StaleSnapshot(
+        IReadOnlySet<ProjectId> StaleProjectIds,
+        IReadOnlyList<string> ChangedDocumentPaths,
+        bool RequiresFullReload);
+
+    public StaleSnapshot GetStaleSnapshot()
+    {
+        lock (_lock)
+        {
+            return new StaleSnapshot(
+                new HashSet<ProjectId>(_staleProjects),
+                _changedDocumentPaths.ToList(),
+                _requiresFullReload);
+        }
+    }
+
     public void MarkProjectStale(ProjectId projectId)
     {
         lock (_lock)
@@ -82,6 +108,20 @@ public sealed class FileChangeTracker : IDisposable
         lock (_lock)
         {
             _staleProjects.Clear();
+            _changedDocumentPaths.Clear();
+            _requiresFullReload = false;
+        }
+    }
+
+    /// <summary>
+    /// Synchronously classifies a single changed path, bypassing the file watcher and its
+    /// debounce timer. Test-only seam so the rebuild path can be exercised deterministically.
+    /// </summary>
+    internal void NotifyChangedPathForTest(string fullPath)
+    {
+        lock (_lock)
+        {
+            ClassifyChange(fullPath);
         }
     }
 
@@ -119,6 +159,37 @@ public sealed class FileChangeTracker : IDisposable
                 }
                 dependents.Add(project.Id);
             }
+        }
+    }
+
+    /// <summary>
+    /// Classifies one changed path and records its effect. Must be called under <see cref="_lock"/>.
+    /// A change to a known <c>.cs</c> document is incremental (its text can be re-applied in
+    /// place). A change to a project file, or to any file we don't recognise as a document
+    /// (a new source file, a <c>.props</c>/<c>.targets</c>, an MSBuild import), is structural
+    /// and forces a full reload so MSBuild re-evaluates. <c>.dll</c> changes are handled
+    /// separately via the PE-cache notification and are ignored here.
+    /// </summary>
+    private void ClassifyChange(string filePath)
+    {
+        if (filePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            return;
+
+        if (_fileToProject.TryGetValue(filePath, out var projectId))
+        {
+            MarkStaleTransitive(projectId);
+            if (filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+                _changedDocumentPaths.Add(filePath);
+            else
+                _requiresFullReload = true; // project file edit — needs MSBuild re-evaluation
+        }
+        else
+        {
+            // Unknown file (new source file, props/targets, unmapped import) — mark all
+            // projects stale and force a full reload.
+            _requiresFullReload = true;
+            foreach (var pid in _fileToProject.Values)
+                _staleProjects.Add(pid);
         }
     }
 
@@ -162,21 +233,7 @@ public sealed class FileChangeTracker : IDisposable
             _pendingChanges.Clear();
 
             foreach (var filePath in changes)
-            {
-                if (filePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                    continue; // DLL changes are handled below, outside the lock
-
-                if (_fileToProject.TryGetValue(filePath, out var projectId))
-                {
-                    MarkStaleTransitive(projectId);
-                }
-                else
-                {
-                    // Unknown file — mark all projects stale
-                    foreach (var pid in _fileToProject.Values)
-                        _staleProjects.Add(pid);
-                }
-            }
+                ClassifyChange(filePath);
         }
 
         // Notify DLL changes outside the lock

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -75,6 +75,13 @@ public sealed class MultiSolutionManager : IDisposable
     public LoadedSolution GetLoadedSolution() => Active.GetLoadedSolution();
     public SymbolResolver GetResolver() => Active.GetResolver();
     public MetadataSymbolResolver GetMetadataResolver() => Active.GetMetadataResolver();
+
+    /// <summary>
+    /// An internally-consistent (solution, resolver, metadata) snapshot from the active solution.
+    /// Tools needing more than one of these must use this rather than the individual getters,
+    /// which each rebuild independently and can diverge if a rebuild races between two calls.
+    /// </summary>
+    public SolutionAnalysisContext GetAnalysisContext() => Active.GetAnalysisContext();
     public IlDisassemblerAdapter GetIlDisassembler() => Active.GetIlDisassembler();
     public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
     public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();

--- a/src/RoslynCodeLens/SolutionAnalysisContext.cs
+++ b/src/RoslynCodeLens/SolutionAnalysisContext.cs
@@ -1,0 +1,15 @@
+using RoslynCodeLens.Metadata;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// An internally-consistent snapshot of a solution's analysis state: the loaded solution and
+/// both resolvers, all guaranteed to come from the same rebuild. Obtained via
+/// <see cref="SolutionManager.GetAnalysisContext"/> so callers never mix a solution with a
+/// resolver from a different snapshot (the identity mismatch behind #282).
+/// </summary>
+public readonly record struct SolutionAnalysisContext(
+    LoadedSolution Loaded,
+    SymbolResolver Resolver,
+    MetadataSymbolResolver Metadata);

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -201,13 +201,13 @@ public sealed class SolutionManager : IDisposable
         }
 
         // Rebuild outside the lock to avoid blocking other reads
-        var staleIds = _tracker.GetStaleProjectIds();
+        var snapshot = _tracker.GetStaleSnapshot();
         Console.Error.WriteLine(
-            $"[roslyn-codelens] Rebuilding {staleIds.Count} stale project(s)...");
+            $"[roslyn-codelens] Rebuilding {snapshot.StaleProjectIds.Count} stale project(s)...");
 
         try
         {
-            RebuildStaleProjects(staleIds).GetAwaiter().GetResult();
+            RebuildAsync(snapshot).GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {
@@ -224,24 +224,52 @@ public sealed class SolutionManager : IDisposable
         }
     }
 
-    private async Task RebuildStaleProjects(IReadOnlySet<ProjectId> staleIds)
+    private async Task RebuildAsync(FileChangeTracker.StaleSnapshot snapshot)
     {
-        var solutionLoader = new SolutionLoader();
+        // A pure .cs edit is applied to the existing Solution in place, preserving every
+        // ProjectId/DocumentId and keeping the recompiled symbols identity-consistent with
+        // loaded.Solution. Re-opening the solution (the #282 bug) minted fresh ProjectIds
+        // that no longer matched the tracker's stale ids or the retained compilations, so
+        // no project actually recompiled and SymbolFinder silently returned empty. Structural
+        // changes (project files, new files) still need MSBuild re-evaluation via a full reload.
+        if (!snapshot.RequiresFullReload
+            && await TryRebuildIncrementalAsync(snapshot.StaleProjectIds, snapshot.ChangedDocumentPaths).ConfigureAwait(false))
+        {
+            return;
+        }
 
-        // Reuse this solution's existing shadow-copy analyzer loader so stale-project generators
-        // load from shadow copies (issue #254) instead of re-locking bin\Debug, and the returned
-        // solution stays remapped. Snapshot under _lock in case a concurrent reload swapped it.
-        // Do NOT create a fresh loader or dispose it here: this is a partial rebuild, the loader's
-        // already-acquired analyzers are still referenced by the retained non-stale compilations,
-        // and reusing dedups via the shared cache instead of churning ALCs on every edit.
-        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader;
-        lock (_lock) { analyzerLoader = _analyzerLoader; }
+        await RebuildViaFullReloadAsync().ConfigureAwait(false);
+    }
 
-        var open = await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
-        var solution = open.Solution;
-        var workspace = open.Workspace;
+    /// <summary>
+    /// Applies the changed source files' current on-disk text to the existing solution via
+    /// <see cref="Solution.WithDocumentText(DocumentId, Microsoft.CodeAnalysis.Text.SourceText, PreservationMode)"/>,
+    /// then recompiles only the stale projects. Because the solution snapshot lineage is
+    /// preserved, the stale ids still resolve, unchanged projects reuse their carried-over
+    /// compilations, and the resulting symbols stay valid against the same solution — so
+    /// <c>SymbolFinder</c> works. Returns false (escalate to a full reload) if a changed file
+    /// can't be read or isn't a document in the current solution.
+    /// </summary>
+    private async Task<bool> TryRebuildIncrementalAsync(
+        IReadOnlySet<ProjectId> staleIds, IReadOnlyList<string> changedDocumentPaths)
+    {
+        var solution = _loaded.Solution;
+
+        foreach (var path in changedDocumentPaths)
+        {
+            var docIds = solution.GetDocumentIdsWithFilePath(path);
+            if (docIds.IsDefaultOrEmpty)
+                return false; // no longer a known document — reload so the graph re-evaluates
+
+            var text = await TryReadSourceTextAsync(path).ConfigureAwait(false);
+            if (text == null)
+                return false; // deleted or unreadable — reload
+
+            foreach (var docId in docIds)
+                solution = solution.WithDocumentText(docId, text);
+        }
+
         var compilations = new ConcurrentDictionary<ProjectId, Compilation>(_loaded.Compilations);
-
         var staleProjects = solution.Projects.Where(p => staleIds.Contains(p.Id)).ToList();
         var tasks = staleProjects.Select(async project =>
         {
@@ -251,6 +279,54 @@ public sealed class SolutionManager : IDisposable
                 compilations[project.Id] = compilation;
         });
         await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        var newLoaded = new LoadedSolution
+        {
+            Solution = solution,
+            Compilations = compilations,
+            SkippedProjects = _loaded.SkippedProjects,
+            LoadDiagnostics = _loaded.LoadDiagnostics
+        };
+        var newResolver = new SymbolResolver(newLoaded);
+        var newMetadataResolver = new MetadataSymbolResolver(newLoaded, newResolver);
+
+        lock (_lock)
+        {
+            _loaded = newLoaded;
+            _resolver = newResolver;
+            _metadataResolver = newMetadataResolver;
+        }
+
+        // Re-map file->project/document lookups against the new snapshot. Ids are preserved,
+        // but a fresh snapshot instance is now authoritative and future edits resolve against it.
+        _tracker!.UpdateMappings(newLoaded);
+
+        await Console.Error.WriteLineAsync("[roslyn-codelens] Rebuild complete (incremental).").ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Re-opens the solution from disk and recompiles every project. Used for structural
+    /// changes (project files, added/removed files) that require MSBuild re-evaluation, and
+    /// as the escalation path when an incremental edit can't be applied. Recompiling all
+    /// projects is required for correctness: a freshly opened solution has new ProjectIds, so
+    /// the old compilations cannot be mixed with it (mixing them was the #282 silent-empty bug).
+    /// </summary>
+    private async Task RebuildViaFullReloadAsync()
+    {
+        var solutionLoader = new SolutionLoader();
+
+        // Reuse this solution's existing shadow-copy analyzer loader so generators load from
+        // shadow copies (issue #254) instead of re-locking bin\Debug, and the returned solution
+        // stays remapped. Snapshot under _lock in case a concurrent reload swapped it. Do NOT
+        // dispose it here: its already-acquired analyzers are shared via the process-wide cache.
+        ShadowCopyAnalyzerAssemblyLoader? analyzerLoader;
+        lock (_lock) { analyzerLoader = _analyzerLoader; }
+
+        var open = await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
+        var solution = open.Solution;
+        var workspace = open.Workspace;
+        var compilations = await solutionLoader.CompileAllParallelAsync(solution).ConfigureAwait(false);
 
         var newLoaded = new LoadedSolution
         {
@@ -279,6 +355,57 @@ public sealed class SolutionManager : IDisposable
         oldWorkspace?.Dispose();
 
         await Console.Error.WriteLineAsync("[roslyn-codelens] Rebuild complete.").ConfigureAwait(false);
+    }
+
+    private static async Task<Microsoft.CodeAnalysis.Text.SourceText?> TryReadSourceTextAsync(string path)
+    {
+        // The file may still be locked by the editor that just wrote it; a couple of short
+        // retries clear that. A genuine failure (deleted, access denied) returns null so the
+        // caller escalates to a full reload rather than applying stale text.
+        const int attempts = 3;
+        for (var attempt = 0; attempt < attempts; attempt++)
+        {
+            try
+            {
+                await using var stream = new FileStream(
+                    path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                return Microsoft.CodeAnalysis.Text.SourceText.From(stream);
+            }
+            catch (IOException) when (attempt < attempts - 1)
+            {
+                await Task.Delay(50).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Test-only seam: classify a changed path synchronously (bypassing the file watcher's
+    /// debounce) so the incremental rebuild path can be exercised deterministically.
+    /// </summary>
+    internal void SimulateFileChangeForTest(string fullPath) => _tracker?.NotifyChangedPathForTest(fullPath);
+
+    /// <summary>
+    /// Rebuilds if stale, then snapshots the loaded solution and both resolvers under one lock
+    /// so they are guaranteed to come from the same swap. Tools that need more than one of these
+    /// must use this instead of the individual getters: each getter rebuilds independently, so a
+    /// watcher-driven rebuild racing between two getter calls could otherwise pair a solution with
+    /// a resolver built from a different snapshot — the same identity mismatch behind #282, just in
+    /// a narrow window.
+    /// </summary>
+    public SolutionAnalysisContext GetAnalysisContext()
+    {
+        ThrowIfLoadFailed();
+        _warmupTask?.GetAwaiter().GetResult();
+        if (_warmupException != null)
+            throw new InvalidOperationException("Solution warmup failed.", _warmupException);
+        RebuildIfStale();
+        lock (_lock)
+            return new SolutionAnalysisContext(_loaded, _resolver, _metadataResolver);
     }
 
     public async Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync()

--- a/src/RoslynCodeLens/Tools/AnalyzeChangeImpactTool.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeChangeImpactTool.cs
@@ -16,8 +16,7 @@ public static class AnalyzeChangeImpactTool
         [Description("Symbol name to analyze (type name, 'Type.Method', etc.)")] string symbol)
     {
         manager.EnsureLoaded();
-        var loaded = manager.GetLoadedSolution();
-        var resolver = manager.GetResolver();
-        return AnalyzeChangeImpactLogic.Execute(loaded, resolver, manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        return AnalyzeChangeImpactLogic.Execute(context.Loaded, context.Resolver, context.Metadata, symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
+++ b/src/RoslynCodeLens/Tools/AnalyzeMethodTool.cs
@@ -16,8 +16,7 @@ public static class AnalyzeMethodTool
         [Description("Method symbol (e.g. 'Greeter.Greet' or 'MyNamespace.MyClass.MyMethod')")] string symbol)
     {
         manager.EnsureLoaded();
-        var loaded = manager.GetLoadedSolution();
-        var resolver = manager.GetResolver();
-        return AnalyzeMethodLogic.Execute(loaded, resolver, manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        return AnalyzeMethodLogic.Execute(context.Loaded, context.Resolver, context.Metadata, symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAsyncViolationsTool.cs
@@ -18,8 +18,9 @@ public static class FindAsyncViolationsTool
     public static FindAsyncViolationsResult Execute(MultiSolutionManager manager)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindAsyncViolationsLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver());
+            context.Loaded,
+            context.Resolver);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindAttributeUsagesTool.cs
@@ -19,10 +19,11 @@ public static class FindAttributeUsagesTool
             int? limit = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         var raw = FindAttributeUsagesLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
-            manager.GetMetadataResolver(),
+            context.Loaded,
+            context.Resolver,
+            context.Metadata,
             attribute);
 
         var sorted = Sort(raw);

--- a/src/RoslynCodeLens/Tools/FindBreakingChangesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindBreakingChangesTool.cs
@@ -23,9 +23,10 @@ public static class FindBreakingChangesTool
         string baselinePath)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindBreakingChangesLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             baselinePath);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindCallersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCallersTool.cs
@@ -19,7 +19,8 @@ public static class FindCallersTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindCallersLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = FindCallersLogic.Execute(context.Loaded, context.Resolver, context.Metadata, symbol);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw);

--- a/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindCircularDependenciesTool.cs
@@ -19,7 +19,8 @@ public static class FindCircularDependenciesTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindCircularDependenciesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), level);
+        var context = manager.GetAnalysisContext();
+        var raw = FindCircularDependenciesLogic.Execute(context.Loaded, context.Resolver, level);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/FindDisposableMisuseTool.cs
+++ b/src/RoslynCodeLens/Tools/FindDisposableMisuseTool.cs
@@ -21,8 +21,9 @@ public static class FindDisposableMisuseTool
     public static FindDisposableMisuseResult Execute(MultiSolutionManager manager)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindDisposableMisuseLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver());
+            context.Loaded,
+            context.Resolver);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
+++ b/src/RoslynCodeLens/Tools/FindEventSubscribersTool.cs
@@ -29,10 +29,11 @@ public static class FindEventSubscribersTool
             int? limit = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         var raw = FindEventSubscribersLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
-            manager.GetMetadataResolver(),
+            context.Loaded,
+            context.Resolver,
+            context.Metadata,
             symbol);
 
         var sorted = Sort(raw);

--- a/src/RoslynCodeLens/Tools/FindGodObjectsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindGodObjectsTool.cs
@@ -39,9 +39,10 @@ public static class FindGodObjectsTool
         int minOutgoingNamespaces = 5)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindGodObjectsLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             project,
             minLines,
             minMembers,

--- a/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindImplementationsTool.cs
@@ -19,7 +19,8 @@ public static class FindImplementationsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindImplementationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = FindImplementationsLogic.Execute(context.Loaded, context.Resolver, context.Metadata, symbol);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindLargeClassesTool.cs
@@ -21,7 +21,8 @@ public static class FindLargeClassesTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindLargeClassesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, maxMembers, maxLines);
+        var context = manager.GetAnalysisContext();
+        var raw = FindLargeClassesLogic.Execute(context.Loaded, context.Resolver, project, maxMembers, maxLines);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindNamingViolationsTool.cs
@@ -19,7 +19,8 @@ public static class FindNamingViolationsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindNamingViolationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+        var context = manager.GetAnalysisContext();
+        var raw = FindNamingViolationsLogic.Execute(context.Loaded, context.Resolver, project);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw);

--- a/src/RoslynCodeLens/Tools/FindObsoleteUsageTool.cs
+++ b/src/RoslynCodeLens/Tools/FindObsoleteUsageTool.cs
@@ -27,9 +27,10 @@ public static class FindObsoleteUsageTool
         bool errorOnly = false)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindObsoleteUsageLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             project,
             errorOnly);
     }

--- a/src/RoslynCodeLens/Tools/FindReferencesTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesTool.cs
@@ -19,7 +19,8 @@ public static class FindReferencesTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindReferencesLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = FindReferencesLogic.Execute(context.Loaded, context.Resolver, context.Metadata, symbol);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw);

--- a/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
+++ b/src/RoslynCodeLens/Tools/FindReflectionUsageTool.cs
@@ -19,7 +19,8 @@ public static class FindReflectionUsageTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = FindReflectionUsageLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = FindReflectionUsageLogic.Execute(context.Loaded, context.Resolver, symbol);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw);

--- a/src/RoslynCodeLens/Tools/FindTestsForSymbolTool.cs
+++ b/src/RoslynCodeLens/Tools/FindTestsForSymbolTool.cs
@@ -16,9 +16,10 @@ public static class FindTestsForSymbolTool
         [Description("Maximum walk depth when transitive=true. Clamped to [1, 5]. Default 3.")] int maxDepth = 3)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindTestsForSymbolLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             symbol,
             transitive,
             maxDepth);

--- a/src/RoslynCodeLens/Tools/FindUncoveredSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindUncoveredSymbolsTool.cs
@@ -17,8 +17,9 @@ public static class FindUncoveredSymbolsTool
     public static FindUncoveredSymbolsResult Execute(MultiSolutionManager manager)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return FindUncoveredSymbolsLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver());
+            context.Loaded,
+            context.Resolver);
     }
 }

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsTool.cs
@@ -21,8 +21,9 @@ public static class FindUnusedSymbolsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         var (raw, filteredCounts) = FindUnusedSymbolsLogic.Execute(
-            manager.GetLoadedSolution(), manager.GetResolver(), project, includeInternal);
+            context.Loaded, context.Resolver, project, includeInternal);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw, filteredCounts);

--- a/src/RoslynCodeLens/Tools/GenerateTestSkeletonTool.cs
+++ b/src/RoslynCodeLens/Tools/GenerateTestSkeletonTool.cs
@@ -31,9 +31,10 @@ public static class GenerateTestSkeletonTool
         string? framework = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GenerateTestSkeletonLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             symbol,
             framework);
     }

--- a/src/RoslynCodeLens/Tools/GetCallGraphTool.cs
+++ b/src/RoslynCodeLens/Tools/GetCallGraphTool.cs
@@ -34,10 +34,11 @@ public static class GetCallGraphTool
         CancellationToken cancellationToken = default)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetCallGraphLogic.ExecuteAsync(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
-            manager.GetMetadataResolver(),
+            context.Loaded,
+            context.Resolver,
+            context.Metadata,
             symbol,
             direction,
             maxDepth,

--- a/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
+++ b/src/RoslynCodeLens/Tools/GetCodeFixesTool.cs
@@ -24,7 +24,8 @@ public static class GetCodeFixesTool
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
-        var raw = await GetCodeFixesLogic.ExecuteAsync(manager.GetLoadedSolution(), manager.GetResolver(), diagnosticId, filePath, line, trustStore, allowlist, ct).ConfigureAwait(false);
+        var context = manager.GetAnalysisContext();
+        var raw = await GetCodeFixesLogic.ExecuteAsync(context.Loaded, context.Resolver, diagnosticId, filePath, line, trustStore, allowlist, ct).ConfigureAwait(false);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetComplexityMetricsTool.cs
@@ -20,7 +20,8 @@ public static class GetComplexityMetricsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = GetComplexityMetricsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project, threshold);
+        var context = manager.GetAnalysisContext();
+        var raw = GetComplexityMetricsLogic.Execute(context.Loaded, context.Resolver, project, threshold);
 
         var sorted = Sort(raw);
         var summary = BuildSummary(raw, threshold);

--- a/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiRegistrationsTool.cs
@@ -19,7 +19,8 @@ public static class GetDiRegistrationsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = GetDiRegistrationsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = GetDiRegistrationsLogic.Execute(context.Loaded, context.Resolver, symbol);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
@@ -26,8 +26,9 @@ public static class GetDiagnosticsTool
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         var raw = await GetDiagnosticsLogic.ExecuteAsync(
-            manager.GetLoadedSolution(), manager.GetResolver(),
+            context.Loaded, context.Resolver,
             project, severity, includeAnalyzers, trustStore, allowlist, ct).ConfigureAwait(false);
 
         // Sort severity-first so truncated top-N keeps the most important diagnostics.

--- a/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
@@ -16,8 +16,7 @@ public static class GetFileOverviewTool
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();
-        var loaded = manager.GetLoadedSolution();
-        var resolver = manager.GetResolver();
-        return await GetFileOverviewLogic.ExecuteAsync(loaded, resolver, filePath, ct).ConfigureAwait(false);
+        var context = manager.GetAnalysisContext();
+        return await GetFileOverviewLogic.ExecuteAsync(context.Loaded, context.Resolver, filePath, ct).ConfigureAwait(false);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
+++ b/src/RoslynCodeLens/Tools/GetGeneratedCodeTool.cs
@@ -20,8 +20,9 @@ public static class GetGeneratedCodeTool
             int? limit = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         var raw = GetGeneratedCodeLogic.Execute(
-            manager.GetLoadedSolution(), manager.GetResolver(), generator, file);
+            context.Loaded, context.Resolver, generator, file);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/GetOperatorsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetOperatorsTool.cs
@@ -22,6 +22,7 @@ public static class GetOperatorsTool
         [Description("Type name (simple or fully qualified) — e.g. Vector2, MyApp.Money")] string symbol)
     {
         manager.EnsureLoaded();
-        return GetOperatorsLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        return GetOperatorsLogic.Execute(context.Resolver, context.Metadata, symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetOverloadsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetOverloadsTool.cs
@@ -23,9 +23,10 @@ public static class GetOverloadsTool
         string symbol)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetOverloadsLogic.Execute(
-            manager.GetResolver(),
-            manager.GetMetadataResolver(),
+            context.Resolver,
+            context.Metadata,
             symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetProjectHealthTool.cs
+++ b/src/RoslynCodeLens/Tools/GetProjectHealthTool.cs
@@ -28,9 +28,10 @@ public static class GetProjectHealthTool
         int hotspotsPerDimension = 5)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetProjectHealthLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             project,
             hotspotsPerDimension);
     }

--- a/src/RoslynCodeLens/Tools/GetPublicApiSurfaceTool.cs
+++ b/src/RoslynCodeLens/Tools/GetPublicApiSurfaceTool.cs
@@ -19,8 +19,9 @@ public static class GetPublicApiSurfaceTool
     public static GetPublicApiSurfaceResult Execute(MultiSolutionManager manager)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetPublicApiSurfaceLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver());
+            context.Loaded,
+            context.Resolver);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
@@ -19,7 +19,8 @@ public static class GetSourceGeneratorsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = GetSourceGeneratorsLogic.Execute(manager.GetLoadedSolution(), manager.GetResolver(), project);
+        var context = manager.GetAnalysisContext();
+        var raw = GetSourceGeneratorsLogic.Execute(context.Loaded, context.Resolver, project);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSymbolContextTool.cs
@@ -14,10 +14,11 @@ public static class GetSymbolContextTool
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetSymbolContextLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
-            manager.GetMetadataResolver(),
+            context.Loaded,
+            context.Resolver,
+            context.Metadata,
             symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTestSummaryTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTestSummaryTool.cs
@@ -25,9 +25,10 @@ public static class GetTestSummaryTool
         string? project = null)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return GetTestSummaryLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetResolver(),
+            context.Loaded,
+            context.Resolver,
             project);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeHierarchyTool.cs
@@ -14,6 +14,7 @@ public static class GetTypeHierarchyTool
         [Description("Type name (simple or fully qualified)")] string symbol)
     {
         manager.EnsureLoaded();
-        return GetTypeHierarchyLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        return GetTypeHierarchyLogic.Execute(context.Resolver, context.Metadata, symbol);
     }
 }

--- a/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetTypeOverviewTool.cs
@@ -16,9 +16,7 @@ public static class GetTypeOverviewTool
         [Description("Type name (simple name or fully qualified)")] string typeName)
     {
         manager.EnsureLoaded();
-        var loaded = manager.GetLoadedSolution();
-        var resolver = manager.GetResolver();
-        var metadata = manager.GetMetadataResolver();
-        return GetTypeOverviewLogic.Execute(loaded, resolver, metadata, typeName);
+        var context = manager.GetAnalysisContext();
+        return GetTypeOverviewLogic.Execute(context.Loaded, context.Resolver, context.Metadata, typeName);
     }
 }

--- a/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
+++ b/src/RoslynCodeLens/Tools/GoToDefinitionTool.cs
@@ -19,7 +19,8 @@ public static class GoToDefinitionTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = GoToDefinitionLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), symbol);
+        var context = manager.GetAnalysisContext();
+        var raw = GoToDefinitionLogic.Execute(context.Resolver, context.Metadata, symbol);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/PeekIlTool.cs
+++ b/src/RoslynCodeLens/Tools/PeekIlTool.cs
@@ -14,9 +14,10 @@ public static class PeekIlTool
         [Description("Fully-qualified method name with parameter types, e.g. 'Newtonsoft.Json.JsonConvert.SerializeObject(object)'")] string methodSymbol)
     {
         manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
         return PeekIlLogic.Execute(
-            manager.GetLoadedSolution(),
-            manager.GetMetadataResolver(),
+            context.Loaded,
+            context.Metadata,
             manager.GetIlDisassembler(),
             methodSymbol);
     }

--- a/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsTool.cs
@@ -20,7 +20,8 @@ public static class SearchSymbolsTool
             int? limit = null)
     {
         manager.EnsureLoaded();
-        var raw = SearchSymbolsLogic.Execute(manager.GetResolver(), manager.GetMetadataResolver(), query);
+        var context = manager.GetAnalysisContext();
+        var raw = SearchSymbolsLogic.Execute(context.Resolver, context.Metadata, query);
 
         var sorted = SortByMatchQuality(query, raw);
         var summary = BuildSummary(raw);

--- a/tests/RoslynCodeLens.Tests/IncrementalRebuildTests.cs
+++ b/tests/RoslynCodeLens.Tests/IncrementalRebuildTests.cs
@@ -1,0 +1,87 @@
+using RoslynCodeLens;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Regression tests for #282: after the file watcher picked up a .cs edit and triggered its
+/// incremental rebuild, every SymbolFinder-based tool (find_references, find_callers) returned
+/// totalCount:0 permanently. The rebuild re-opened the solution, minting fresh ProjectIds that
+/// no longer matched the retained compilations, so SymbolFinder was handed symbols foreign to
+/// the solution and silently returned empty. The fix applies source edits to the existing
+/// solution in place (Solution.WithDocumentText), preserving identity.
+/// </summary>
+public class IncrementalRebuildTests
+{
+    private static string SolutionPath => Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TestSolution", "TestSolution.slnx"));
+
+    [Fact]
+    public async Task IncrementalRebuild_AfterCsEdit_FindReferencesReflectsNewUsage()
+    {
+        // ICrossProjectOnly is declared in TestLib and used only in TestLib2/CrossProjectGreeter.cs
+        // — the exact cross-project shape from the #282 repro (a symbol from an unchanged project,
+        // referenced from the edited project).
+        var solutionDir = Path.GetDirectoryName(SolutionPath)!;
+        var consumerPath = Path.Combine(solutionDir, "TestLib2", "CrossProjectGreeter.cs");
+        var original = await File.ReadAllTextAsync(consumerPath).ConfigureAwait(false);
+
+        SolutionManager? manager = null;
+        try
+        {
+            int before;
+            (manager, before) = await CreateManagerWithBaselineAsync().ConfigureAwait(false);
+
+            // Edit the consumer on disk, adding a second implementation of the cross-project
+            // interface — one extra reference. (using TestLib; is already in the file.)
+            var edited = original +
+                "\n\npublic class ExtraCrossConsumer : ICrossProjectOnly\n{\n\tpublic string Execute() => \"extra\";\n}\n";
+            await File.WriteAllTextAsync(consumerPath, edited).ConfigureAwait(false);
+
+            manager.SimulateFileChangeForTest(consumerPath);
+
+            var (loaded, resolver, metadata) = manager.GetAnalysisContext();
+            var after = FindReferencesLogic.Execute(loaded, resolver, metadata, "ICrossProjectOnly");
+
+            Assert.True(
+                after.Count > before,
+                $"find_references for ICrossProjectOnly should reflect the new usage after an incremental " +
+                $"rebuild (before={before}, after={after.Count}). A count of 0 is the #282 silent-empty bug.");
+            Assert.Contains(after, r => r.File.Contains("CrossProjectGreeter", StringComparison.Ordinal));
+        }
+        finally
+        {
+            await File.WriteAllTextAsync(consumerPath, original).ConfigureAwait(false);
+            manager?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Creates a manager and returns the baseline find_references count for ICrossProjectOnly.
+    /// Retries on the MSBuildWorkspace design-time-build reference-drop flake (#260) so the
+    /// baseline is never a degraded zero.
+    /// </summary>
+    private static async Task<(SolutionManager Manager, int Baseline)> CreateManagerWithBaselineAsync()
+    {
+        const int maxAttempts = 6;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            var manager = await SolutionManager.CreateAsync(SolutionPath).ConfigureAwait(false);
+            await manager.WaitForWarmupAsync().ConfigureAwait(false);
+
+            var (loaded, resolver, metadata) = manager.GetAnalysisContext();
+            if (!loaded.Degraded)
+            {
+                var baseline = FindReferencesLogic.Execute(loaded, resolver, metadata, "ICrossProjectOnly");
+                if (baseline.Count > 0)
+                    return (manager, baseline.Count);
+            }
+
+            manager.Dispose();
+        }
+
+        throw new InvalidOperationException(
+            $"TestSolution failed to load healthily after {maxAttempts} attempts (baseline references for " +
+            "ICrossProjectOnly came back empty/degraded — the #260 MSBuildWorkspace reference-drop flake).");
+    }
+}


### PR DESCRIPTION
Fixes #282.

## Problem

After the file watcher picked up a `.cs` edit and triggered its incremental rebuild, every `SymbolFinder`-based tool (`find_references`, `find_callers`) returned `totalCount: 0` — **permanently, for the rest of the session** — until `rebuild_solution` was called explicitly. The failure was silent: the call succeeded in ~1 ms with a well-formed envelope, so an agent couldn't tell *"no usages"* from *"the index is broken"*. A single file save poisoned the session, right when the "what breaks if I change this?" question is asked.

## Root cause

The stale rebuild re-opened the solution via `SolutionLoader.OpenAsync`. A freshly created `MSBuildWorkspace` mints new `ProjectId`s on every load, so the tracker's stale ids (captured from the *previous* load) matched nothing — no project actually recompiled (note the missing `Recompiling:` log line in the report). The resulting `LoadedSolution` paired a **new** `Solution` with the **old** `Compilations`, and `SymbolFinder.FindReferencesAsync(target, loaded.Solution)` was handed a symbol foreign to that solution → silent empty. `go_to_definition`/`search_symbols` were unaffected because they read the resolver's in-memory index directly and never need symbol identity to line up with a `Solution`.

## Fix

- **Incremental in-place rebuild.** Source edits are applied to the existing solution via `Solution.WithDocumentText`, preserving `ProjectId`/`DocumentId` identity so stale ids still resolve, unchanged projects reuse their carried-over compilations, and recompiled symbols stay valid against the same solution. Only stale projects recompile.
- **Structural changes still full-reload.** Project-file / new-file changes escalate to a reopen + recompile-all, because a re-opened solution's fresh `ProjectId`s cannot be mixed with old compilations. `FileChangeTracker` now classifies each change and exposes `GetStaleSnapshot` (stale ids + changed document paths + `RequiresFullReload`).
- **Atomic analysis snapshot.** New `SolutionAnalysisContext` + `SolutionManager.GetAnalysisContext()` returns `(solution, resolver, metadata)` under one lock. All ~39 tools that fetched two or more of these getters now take one atomic snapshot, closing a related race where a rebuild completing *between* two separate getter calls could pair a solution with a resolver from a different snapshot — the same identity-mismatch class as #282, in a narrow window.

## Commits

1. `fix(rebuild)` — incremental rebuild path, tracker classification/snapshot, atomic accessor API, regression test.
2. `refactor(tools)` — route the 39 multi-getter tools through `GetAnalysisContext`.

Each commit builds independently.

## Tests

- New `IncrementalRebuildTests` reproduces the exact scenario: edit a consumer file to add a cross-project usage, drive the rebuild, and assert `find_references` reflects the new usage instead of collapsing to 0. It restores the fixture in `finally` and retries the initial load to dodge the known #260 MSBuild reference-drop flake.
- Full run green: **449 passed, 0 failed** (entire `Tools` test surface plus the rebuild/manager/tracker tests).

Relates to #263/#265 (same silent-empty class, different trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)