### PR TITLE
fix(rebuild): serialize rebuild_solution with the watcher auto-rebuild

### DIFF
--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -15,7 +15,13 @@ public sealed class SolutionManager : IDisposable
     private readonly string? _solutionPath;
     private FileChangeTracker? _tracker;
     private readonly Lock _lock = new();
-    private volatile bool _rebuilding;
+
+    // Serializes every operation that produces a new loaded solution — the watcher-driven
+    // auto-rebuild (RebuildIfStale) and the explicit rebuild_solution (ForceReloadAsync). Only one
+    // runs at a time so neither can read _loaded, have the other swap + dispose its workspace, and
+    // then clobber the swap with a solution forked off a now-disposed workspace. Auto-rebuild
+    // acquires it opportunistically (skips if busy, returning current data); ForceReloadAsync waits.
+    private readonly SemaphoreSlim _rebuildGate = new(1, 1);
     private Task? _warmupTask;
     private Exception? _warmupException;
     private readonly Exception? _loadException;
@@ -191,39 +197,41 @@ public sealed class SolutionManager : IDisposable
         if (_tracker == null || !_tracker.HasStaleProjects)
             return;
 
-        lock (_lock)
-        {
-            // Double-check after acquiring lock
-            if (_tracker == null || !_tracker.HasStaleProjects || _rebuilding)
-                return;
-
-            _rebuilding = true;
-        }
-
-        // Drain (snapshot + clear) outside the lock so edits that land DURING this rebuild
-        // accumulate into the freshly-emptied tracker and trigger the next rebuild, instead of
-        // being wiped by a blanket clear afterwards (that silently dropped saves made during a
-        // multi-second rebuild). On failure we restore the drained state so it retries.
-        var snapshot = _tracker.DrainStale();
-        Console.Error.WriteLine(
-            $"[roslyn-codelens] Rebuilding {snapshot.StaleProjectIds.Count} stale project(s)...");
+        // Opportunistic acquire: if a rebuild or a full reload (ForceReloadAsync) is already
+        // running, skip and let this query return the current consistent data rather than start a
+        // competing rebuild.
+        if (!_rebuildGate.Wait(0))
+            return;
 
         try
         {
-            RebuildAsync(snapshot).GetAwaiter().GetResult();
-        }
-        catch (Exception ex)
-        {
-            _tracker.RestoreStale(snapshot);
+            // Re-check under the gate: another rebuild may have drained the stale state between the
+            // pre-check above and our acquiring the gate.
+            if (_tracker == null || !_tracker.HasStaleProjects)
+                return;
+
+            // Drain (snapshot + clear) so edits that land DURING this rebuild accumulate into the
+            // freshly-emptied tracker and trigger the next rebuild, instead of being wiped by a
+            // blanket clear afterwards (that silently dropped saves made during a multi-second
+            // rebuild). On failure we restore the drained state so it retries.
+            var snapshot = _tracker.DrainStale();
             Console.Error.WriteLine(
-                $"[roslyn-codelens] Rebuild failed: {ex}. Using cached data.");
+                $"[roslyn-codelens] Rebuilding {snapshot.StaleProjectIds.Count} stale project(s)...");
+
+            try
+            {
+                RebuildAsync(snapshot).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _tracker.RestoreStale(snapshot);
+                Console.Error.WriteLine(
+                    $"[roslyn-codelens] Rebuild failed: {ex}. Using cached data.");
+            }
         }
         finally
         {
-            lock (_lock)
-            {
-                _rebuilding = false;
-            }
+            _rebuildGate.Release();
         }
     }
 
@@ -416,6 +424,26 @@ public sealed class SolutionManager : IDisposable
         if (_solutionPath == null)
             throw new InvalidOperationException("No solution path configured. Cannot reload.");
 
+        // Hold the rebuild gate for the whole reload: wait for any in-progress auto-rebuild to
+        // finish, then keep it out (auto-rebuilds skip and serve current data) so none can clobber
+        // our swap or dispose a workspace we still reference.
+        await _rebuildGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return await ReloadAndSwapAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _rebuildGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Re-opens the solution from disk, recompiles everything, and swaps in the result, disposing
+    /// the superseded workspace/loader afterwards. Must be called while holding <see cref="_rebuildGate"/>.
+    /// </summary>
+    private async Task<(int ProjectCount, TimeSpan Elapsed)> ReloadAndSwapAsync()
+    {
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
         var solutionLoader = new SolutionLoader();
@@ -423,12 +451,12 @@ public sealed class SolutionManager : IDisposable
         SolutionLoader.SolutionOpen open;
         try
         {
-            open = await solutionLoader.OpenAsync(_solutionPath, null, analyzerLoader).ConfigureAwait(false);
+            open = await solutionLoader.OpenAsync(_solutionPath!, null, analyzerLoader).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             analyzerLoader.Dispose();
-            throw new InvalidOperationException(SolutionLoadFailure.Describe(_solutionPath, ex), ex);
+            throw new InvalidOperationException(SolutionLoadFailure.Describe(_solutionPath!, ex), ex);
         }
         var solution = open.Solution;
         var workspace = open.Workspace;

--- a/tests/RoslynCodeLens.Tests/IncrementalRebuildTests.cs
+++ b/tests/RoslynCodeLens.Tests/IncrementalRebuildTests.cs
@@ -127,6 +127,58 @@ public class IncrementalRebuildTests
         }
     }
 
+    [Fact]
+    public async Task ForceReload_ConcurrentWithAutoRebuilds_NeverClobbersOrCorruptsState()
+    {
+        // rebuild_solution (ForceReloadAsync) and the watcher-driven auto-rebuild both produce a new
+        // loaded solution. Before they were serialized, an auto-rebuild could read _loaded, have a
+        // concurrent ForceReload swap in a fresh solution and dispose the old workspace, then swap its
+        // own result back — discarding the reload and leaving _loaded forked off a disposed workspace.
+        // With the shared gate every query stays internally consistent under contention: the invariant
+        // "the cross-project reference always resolves and nothing throws" holds regardless of timing.
+        var consumerPath = FixtureFile("TestLib2", "CrossProjectGreeter.cs");
+
+        SolutionManager? manager = null;
+        try
+        {
+            manager = await CreateHealthyManagerAsync().ConfigureAwait(false);
+            var mgr = manager;
+
+            var stop = false;
+            Exception? readerError = null;
+            var minRefs = int.MaxValue;
+
+            // Reader thread: hammer auto-rebuilds (mark stale) + queries while the reloads run.
+            var reader = Task.Run(() =>
+            {
+                try
+                {
+                    while (!Volatile.Read(ref stop))
+                    {
+                        mgr.SimulateFileChangeForTest(consumerPath);
+                        var refs = CountReferences(mgr, "ICrossProjectOnly");
+                        minRefs = Math.Min(minRefs, refs);
+                    }
+                }
+                catch (Exception ex) { readerError = ex; }
+            });
+
+            for (var i = 0; i < 2; i++)
+                await mgr.ForceReloadAsync().ConfigureAwait(false);
+
+            Volatile.Write(ref stop, true);
+            await reader.ConfigureAwait(false);
+
+            Assert.Null(readerError); // a clobber/disposed-workspace access would surface here
+            Assert.True(minRefs > 0,
+                $"every concurrent query must resolve the cross-project reference (min observed={minRefs}).");
+        }
+        finally
+        {
+            manager?.Dispose();
+        }
+    }
+
     private static IReadOnlyList<SymbolReference> References(SolutionManager manager, string symbol)
     {
         var (loaded, resolver, metadata) = manager.GetAnalysisContext();


### PR DESCRIPTION
Follow-up to #282 / #283 / #288. The final race flagged during the edge-case pass.

## The race

`ForceReloadAsync` (the `rebuild_solution` tool) and the watcher-driven auto-rebuild (`RebuildIfStale`) both produce a new loaded solution, but nothing serialized them. The auto-rebuild guarded only against *other auto-rebuilds*, via a `_rebuilding` bool that `ForceReloadAsync` didn't check. So the two could interleave:

1. An incremental auto-rebuild reads `_loaded` (solution `S1`, off workspace `W0`).
2. `ForceReloadAsync` opens a fresh solution `S2`, swaps `_loaded = S2`, and **disposes `W0`**.
3. The auto-rebuild finishes, swaps `_loaded = S1.WithDocumentText(...)` back — **discarding the user's reload** and leaving `_loaded` forked off the now-disposed `W0` (and its disposed analyzer loader), with `_workspace` still pointing at `W2`.

Silent — `rebuild_solution` appears to succeed but its result is thrown away — same class as #282.

## Fix

Replace the `_rebuilding` bool with a `SemaphoreSlim(1,1)` gate that **both** paths take:

- **Auto-rebuild** acquires it *opportunistically* — `Wait(0)`; if a rebuild or reload is already running it skips and serves the current consistent data (preserves the non-blocking getter behavior).
- **`ForceReloadAsync`** acquires it *blocking* — waits for any in-progress auto-rebuild, then holds it for the whole reload so nothing can clobber the swap or dispose a workspace still in use.

Only one operation mutates the loaded solution at a time, so neither can read `_loaded` and have the other swap + dispose underneath it. The reload body is extracted into `ReloadAndSwapAsync` (documented as gate-held) to keep the gated method small.

The `SemaphoreSlim` is intentionally not disposed: it's used purely as an async lock (its `AvailableWaitHandle` is never touched, so there's no unmanaged resource), and disposing it at shutdown could race a `Release()` from an in-flight rebuild. The analyzer does not flag it.

## Test

Adds a contention guard: one thread hammers auto-rebuilds (mark stale) + `find_references` queries while the test forces full reloads on another. The assertion is an invariant that always holds under the fix — every query resolves the cross-project reference and nothing throws — so it can't false-fail, but it exercises the gate under real contention and guards against regressions that reintroduce concurrent mutation.

## Verification

45 tests pass (the new guard + all existing `IncrementalRebuildTests`, `FileChangeTracker*`, and `SolutionManagerTests`). Diff: `SolutionManager.cs` + one test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)