### PR TITLE
feat: rename_symbol — solution-wide safe rename via Roslyn Renamer

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -38,7 +38,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 ### High value
 
-- **`rename_symbol`** — solution-wide safe rename via the Roslyn `Renamer` API. Rename is *not* a code action, so `apply_code_action` cannot do it; today an agent renaming a symbol falls back to multi-file text edits — exactly the failure mode this server exists to prevent.
+- 🔧 **In flight: `rename_symbol`** — solution-wide safe rename via the Roslyn `Renamer` API. Rename is *not* a code action, so `apply_code_action` cannot do it; today an agent renaming a symbol falls back to multi-file text edits — exactly the failure mode this server exists to prevent. Design: [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
 - **`resolve_stack_trace`** — map a pasted runtime stack trace to file/line/symbol, undoing name mangling (async state machines, lambdas, generics, `<>c__DisplayClass`). Perfect fit for debugging workflows; nothing comparable today.
 - **`get_method_source` / `get_method_source_batch`** — return a method's source body by name. `analyze_method` gives signature + callers but not the body, so agents still `Read` whole files. Batch variant is very token-efficient.
 - **Reference kind classification on `find_references`** — tag each reference as read/write/invocation/cast/typeof/nameof/attribute, with an optional `kind` filter. Enhancement to the existing tool, not a new one; also subsumes a would-be `find_pattern_usages` (is/as/pattern-match sites).
@@ -59,7 +59,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 Active branches with no merged PR yet.
 
-_(none currently)_
+- **`rename_symbol`** — branch `feature/rename-symbol`, design [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -2,7 +2,7 @@
 
 Ideas for future tools, grouped by theme. Not committed work — captured here so they're not lost. Each entry is a starting point for a real design discussion.
 
-Last refreshed: 2026-05-04.
+Last refreshed: 2026-07-19.
 
 ---
 
@@ -16,7 +16,7 @@ Common .NET pain points that aren't covered by analyzers everyone has on by defa
 
 Small, focused queries that aren't currently expressible in one call.
 
-- **`find_duplicated_code`** — heuristic detection of repeated statement blocks across files. *Note: existing tools (JSCPD, SonarQube) cover this well; only worth doing if a Roslyn-semantic angle is identified.*
+- **`find_duplicated_code`** — heuristic detection of repeated statement blocks across files. *Note: existing tools (JSCPD, SonarQube) cover this well; only worth doing if a Roslyn-semantic angle is identified. SharpLensMcp ships this as `find_similar_code` using token-shingle fingerprints — a viable middle ground; would slot into `get_project_health` and the refactor-analysis skill.*
 
 ## 3. Generation & scaffolding (write-side)
 
@@ -31,6 +31,27 @@ Big-solution scenarios (400+ projects) where the structural open dominates wall-
 
 - ✅ **Parallelise the per-project loader** — *shipped.* `SolutionLoader.OpenPerProjectAsync` now loads projects across a bounded pool of isolated `MSBuildWorkspace` workers (each its own out-of-process `BuildHost`), with global path-dedup to curb redundant transitive loads, then re-stitches the results into one workspace. Confirmed via experiment that concurrent `OpenProjectAsync` on a *shared* workspace corrupts the solution, so isolation + re-stitch is required. Degree via `ROSLYN_CODELENS_LOAD_PARALLELISM` (default `min(CPU, 8)`). Design: [docs/plans/2026-06-18-parallel-project-loader-design.md](plans/2026-06-18-parallel-project-loader-design.md).
 - ✅ **Async `load_solution` with a load handle** — *shipped.* `load_solution` gained a `background: true` flag: it runs the load on the existing `BackgroundTaskStore` and returns a `taskId` immediately; the agent polls `get_task_status`. Turned out far smaller than feared — no `SolutionManager`/`EnsureLoaded` changes, because the new solution only becomes active once the background load finishes, so other tools never block on it. Reuses the background-task infra (which postdates this note) rather than a bespoke `get_load_status`. Design: [docs/plans/2026-06-18-async-load-solution-design.md](plans/2026-06-18-async-load-solution-design.md).
+
+## 5. Gaps identified from SharpLensMcp comparison (2026-07-19)
+
+Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-mcp/) (91 tools). Most of its catalog overlaps ours or is covered by `apply_code_action`; the items below are genuine gaps. Low-value items (`semantic_query`, `check_type_compatibility`, `find_interceptors`, `remove_unused_code`, `organize_usings`, `format_document_batch`) were considered and skipped — niche, or covered by `dotnet format` and existing find-tools.
+
+### High value
+
+- **`rename_symbol`** — solution-wide safe rename via the Roslyn `Renamer` API. Rename is *not* a code action, so `apply_code_action` cannot do it; today an agent renaming a symbol falls back to multi-file text edits — exactly the failure mode this server exists to prevent.
+- **`resolve_stack_trace`** — map a pasted runtime stack trace to file/line/symbol, undoing name mangling (async state machines, lambdas, generics, `<>c__DisplayClass`). Perfect fit for debugging workflows; nothing comparable today.
+- **`get_method_source` / `get_method_source_batch`** — return a method's source body by name. `analyze_method` gives signature + callers but not the body, so agents still `Read` whole files. Batch variant is very token-efficient.
+- **Reference kind classification on `find_references`** — tag each reference as read/write/invocation/cast/typeof/nameof/attribute, with an optional `kind` filter. Enhancement to the existing tool, not a new one; also subsumes a would-be `find_pattern_usages` (is/as/pattern-match sites).
+- **Exception-flow trio: `get_exception_flow`, `find_throw_sites`, `find_catch_blocks`** — "which exceptions can escape this method, and where are they caught," with derived-type awareness. We have zero exception analysis today.
+
+### Medium value
+
+- **`change_signature`** — add/remove/reorder parameters with all call sites updated. Like rename, not reachable via code actions.
+- **`get_extension_methods`** — which extension methods (including C# 14 extension blocks) apply to a given type. Not answerable with current tools.
+- **`get_instantiation_options`** — "how do I construct this type": accessible constructors, factory methods, DI registration. Pairs well with `generate_test_skeleton`.
+- **Cognitive complexity + nesting depth in `get_complexity_metrics`** — we only report cyclomatic; cognitive complexity is a better refactoring-priority signal. Enhancement to the existing tool.
+- **`check_architecture`** — enforce user-defined namespace/project dependency rules over the type graph (e.g. "Domain must not reference Infrastructure"). `find_circular_dependencies` only catches cycles; layering violations go undetected.
+- **`find_similar_code`** — folded into the existing `find_duplicated_code` entry in §2 above.
 
 ---
 

--- a/docs/plans/2026-07-19-rename-symbol-design.md
+++ b/docs/plans/2026-07-19-rename-symbol-design.md
@@ -1,0 +1,96 @@
+# `rename_symbol` — Design
+
+Date: 2026-07-19
+Status: Approved
+Origin: SharpLensMcp gap analysis (docs/BACKLOG.md §5). Rename is not a Roslyn code action, so `apply_code_action` cannot do it; today an agent renaming a symbol falls back to multi-file text edits — the exact failure mode this server exists to prevent.
+
+## Decisions (brainstorming outcomes)
+
+| Question | Decision |
+|---|---|
+| Symbol addressing | Name-based, same contract as `find_references` / `analyze_method` (`MyClass`, `Namespace.MyClass`, `MyClass.Member`), resolved via the shared `SymbolResolver`. |
+| Symbol kinds (v1) | Types + members (classes, interfaces, structs, records, enums, methods, properties, fields, events). Locals/parameters excluded — they need position addressing. |
+| Rename options | Expose `renameOverloads` (default `true`), `renameInStrings` (default `false`), `renameInComments` (default `true`). `RenameFile` deferred. |
+| Safety | Diagnostics-delta check: compare compiler error sets before/after the rename; new errors are reported as `Conflicts`. Apply mode refuses to write on conflicts unless `force=true`. Preview is the default. |
+| Implementation | Roslyn `Renamer.RenameSymbolAsync` (Approach A). Rejected: manual `find_references`-based edit composition (reimplements ctor/`nameof`/`cref`/override cascade Roslyn already handles); external tooling (nothing suitable exists headless). |
+
+## Tool contract
+
+```
+rename_symbol(
+  symbol: string,            // "MyClass", "Namespace.MyClass", or "MyClass.Member"
+  newName: string,           // bare identifier, e.g. "OrderProcessor"
+  renameOverloads: bool = true,
+  renameInStrings: bool = false,
+  renameInComments: bool = true,
+  preview: bool = true,      // like apply_code_action
+  force: bool = false        // apply despite reported conflicts
+)
+```
+
+Result — `RenameSymbolResult` (single-object shape, no list envelope, consistent with `apply_code_action`):
+
+- `Success` — operation computed without error
+- `OldName` — fully-qualified display string of the resolved symbol
+- `NewName`
+- `Applied` — whether files were written to disk
+- `Edits` — `IReadOnlyList<TextEdit>` (existing model), per file
+- `FilesChanged` — distinct file count
+- `Conflicts` — new compiler errors introduced by the rename: `{ Id, Message, File, Line }`
+- `Message` — human-readable status (e.g. refusal reason)
+
+## Resolution & validation
+
+Resolve via the shared `SymbolResolver` from `manager.GetAnalysisContext()`:
+
+- Types by full name, then simple name; members via the member index — identical semantics to `find_references`.
+- Multiple matches → `AmbiguousMatch` error with `details.matches` candidates.
+- No match → `SymbolNotFound`.
+- Symbol has no source location (metadata) → `InvalidArgument` ("cannot rename a metadata symbol").
+- `newName` fails `SyntaxFacts.IsValidIdentifier` → `InvalidArgument`.
+- Symbol resolves to a constructor → `InvalidArgument`, message directs the agent to rename the containing type (constructors follow the type automatically).
+
+## Execution & safety
+
+1. Take the current solution snapshot from the manager.
+2. `Renamer.RenameSymbolAsync(solution, symbol, new SymbolRenameOptions(renameOverloads, renameInStrings, renameInComments, RenameFile: false), newName)`.
+3. Diagnostics delta: for each project with changed documents, collect compiler errors (severity Error, **no analyzers** — cheap and deterministic) from the before and after compilations. Key by `Id + file + message`; errors present only in the after set become `Conflicts`. This compensates for the public Renamer API resolving conflicts best-effort without reporting the ones it couldn't.
+4. `preview=true` → return edits + conflicts, disk untouched.
+5. `preview=false` → if `Conflicts` non-empty and `force=false`, refuse (`Applied=false`, message explains `force`/preview options); otherwise write changed documents to disk.
+
+## Write path & watcher interplay
+
+Extract `ExtractTextEdits` and `WriteChangesToDiskAsync` from `CodeActionRunner` into a shared helper (`SolutionChangeWriter`) used by both `apply_code_action` and `rename_symbol` — no duplication, and the existing `apply_code_action` tests double as a regression net for the extraction.
+
+Disk writes flow through the existing pipeline: file watcher → in-place `WithDocumentText` update (#282) → serialized rebuild. No new sync machinery. File renames are excluded in v1, so there is no delete/create watcher churn.
+
+## Error handling
+
+Existing error envelope (`isError: true`, `{ code, message, details? }`): `SymbolNotFound`, `AmbiguousMatch`, `InvalidArgument`, `Internal`. No new codes.
+
+## Testing
+
+xUnit against the existing TestSolution fixture:
+
+- Rename a type — references, constructor, `nameof`, XML doc `cref` all cascade.
+- Rename a method with overloads — `renameOverloads` on/off behavior.
+- Rename a property; rename a field.
+- `renameInComments` on/off; `renameInStrings` on/off.
+- Collision rename (target name already exists in scope) — `Conflicts` populated; apply refused without `force`; `force=true` writes anyway.
+- Ambiguous simple name → `AmbiguousMatch` with candidates.
+- Unknown symbol → `SymbolNotFound`; metadata symbol → `InvalidArgument`; invalid identifier → `InvalidArgument`; constructor → `InvalidArgument`.
+- `preview=true` leaves disk untouched; `preview=false` writes files matching the returned `Edits`.
+- Existing `apply_code_action` suite passes after the `SolutionChangeWriter` extraction.
+
+## Out of scope (v1) — backlog "deferred" candidates
+
+- **File rename** (`Foo.cs` → `Bar.cs` via `RenameFile: true`) — delete+create watcher churn and git-mv semantics need their own design.
+- **Locals / parameters** — require position-based addressing.
+- **Cross-solution rename** — active solution only.
+- **Analyzer-diagnostic delta** — compiler errors only in v1.
+- **Overload-picking disambiguation** — v1 renames the whole overload group by default; a position override can come later if demand emerges.
+
+## Documentation follow-ups
+
+- SKILL.md: add `rename_symbol` to the write-side section (alongside `apply_code_action`), Red Flags table ("Let me edit N files to rename this symbol" → `rename_symbol`), Tool Quick Reference, and the metadata-support table (source-only).
+- docs/BACKLOG.md: move `rename_symbol` from §5 to "In flight", then "Recently shipped" on merge.

--- a/docs/plans/2026-07-19-rename-symbol-implementation.md
+++ b/docs/plans/2026-07-19-rename-symbol-implementation.md
@@ -1,0 +1,881 @@
+# rename_symbol Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A `rename_symbol` MCP tool that safely renames a type or member across the whole solution via Roslyn's `Renamer` API, with preview-by-default and a diagnostics-delta conflict check.
+
+**Architecture:** New `RenameSymbolLogic` (pure logic, testable) + thin `RenameSymbolTool` MCP wrapper, following the existing Tool/Logic split. Disk writing and `TextEdit` diffing are extracted from `CodeActionRunner` into a shared `SolutionChangeWriter` so both tools use one write path. Design doc: `docs/plans/2026-07-19-rename-symbol-design.md` (read it first).
+
+**Tech Stack:** .NET / C#, Roslyn (`Microsoft.CodeAnalysis.Rename.Renamer`, already available via the existing Workspaces dependency), xUnit with an `AdhocWorkspace`-based test helper (isolated from the shared `TestSolutionFixture` — no fixture source files are modified).
+
+**Working directory:** the `.worktrees/rename-symbol` worktree, branch `feature/rename-symbol`. All paths below are relative to that worktree root. Run all `dotnet` commands from the worktree root.
+
+**Conventions you must follow** (from the existing codebase):
+- Errors are thrown as `McpToolException(ToolErrorCode.X, message, detailsObject)` — see `src/RoslynCodeLens/Tools/AnalyzeMethodLogic.cs:14` for the pattern. The MCP layer converts them to the `{code, message, details}` envelope; logic code just throws.
+- Single-object results are plain records in `src/RoslynCodeLens/Models/` (no list envelope) — like `CodeActionResult`.
+- Tools are `[McpServerToolType]` static classes with `[McpServerTool(Name = "...")]` — copy the shape of `src/RoslynCodeLens/Tools/ApplyCodeActionTool.cs`.
+- Tests: xUnit, `Assert.*`, file-per-subject naming `<Subject>Tests.cs`.
+
+---
+
+### Task 1: Extract `SolutionChangeWriter` from `CodeActionRunner`
+
+Pure refactor. The existing `apply_code_action` tests are the regression net — no new tests.
+
+**Files:**
+- Create: `src/RoslynCodeLens/SolutionChangeWriter.cs`
+- Modify: `src/RoslynCodeLens/CodeActionRunner.cs` (remove `WriteChangesToDiskAsync` at ~line 155 and `ExtractTextEdits` at ~line 235, call the new helper instead)
+
+**Step 1: Create the shared helper**
+
+Move the two methods verbatim (public, renamed `ExtractTextEdits` → `ExtractTextEditsAsync`):
+
+```csharp
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Shared write path for tools that produce a changed Solution (apply_code_action,
+/// rename_symbol): diff extraction for previews and document writes for apply mode.
+/// </summary>
+public static class SolutionChangeWriter
+{
+    public static async Task<List<TextEdit>> ExtractTextEditsAsync(
+        Solution changedSolution, Solution originalSolution, CancellationToken ct)
+    {
+        // body of CodeActionRunner.ExtractTextEdits, unchanged
+    }
+
+    public static async Task WriteChangesToDiskAsync(
+        Solution changedSolution, Solution originalSolution, CancellationToken ct)
+    {
+        // body of CodeActionRunner.WriteChangesToDiskAsync, unchanged
+    }
+}
+```
+
+In `CodeActionRunner.ApplyActionAsync`, replace the two call sites:
+
+```csharp
+var edits = await SolutionChangeWriter.ExtractTextEditsAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+// ...
+await SolutionChangeWriter.WriteChangesToDiskAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+```
+
+**Step 2: Build and run the regression net**
+
+Run: `dotnet build src/RoslynCodeLens` → 0 errors.
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~ApplyCodeAction|FullyQualifiedName~CodeActionRunner"`
+Expected: PASS (all existing apply/code-action tests).
+
+**Step 3: Commit**
+
+```bash
+git add src/RoslynCodeLens/SolutionChangeWriter.cs src/RoslynCodeLens/CodeActionRunner.cs
+git commit -m "refactor: extract SolutionChangeWriter from CodeActionRunner"
+```
+
+---
+
+### Task 2: Result models
+
+**Files:**
+- Create: `src/RoslynCodeLens/Models/RenameConflict.cs`
+- Create: `src/RoslynCodeLens/Models/RenameSymbolResult.cs`
+
+**Step 1: Write the records**
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+/// <summary>A compiler error that would be introduced by applying the rename.</summary>
+public record RenameConflict(string Id, string Message, string File, int Line);
+```
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record RenameSymbolResult(
+    bool Success,
+    string OldName,
+    string NewName,
+    bool Applied,
+    IReadOnlyList<TextEdit> Edits,
+    int FilesChanged,
+    IReadOnlyList<RenameConflict> Conflicts,
+    string Message);
+```
+
+**Step 2: Build, commit**
+
+Run: `dotnet build src/RoslynCodeLens` → 0 errors.
+
+```bash
+git add src/RoslynCodeLens/Models/RenameConflict.cs src/RoslynCodeLens/Models/RenameSymbolResult.cs
+git commit -m "feat: add rename_symbol result models"
+```
+
+---
+
+### Task 3: `RenameTestWorkspace` test helper
+
+An `AdhocWorkspace`-based mini-solution builder so rename tests are isolated, fast, and never mutate the shared `TestSolutionFixture`. Precedent for `LoadedSolution` over `AdhocWorkspace`: `tests/RoslynCodeLens.Tests/LoaderConcurrencyHardeningTests.cs:40`.
+
+**Files:**
+- Create: `tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs`
+
+**Step 1: Write the helper**
+
+```csharp
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynCodeLens.Tests.Fixtures;
+
+/// <summary>
+/// Builds an in-memory single-project LoadedSolution + SymbolResolver from source
+/// strings. Pass absolute paths as file names when a test needs apply-mode disk writes.
+/// </summary>
+internal static class RenameTestWorkspace
+{
+    public static (LoadedSolution Loaded, SymbolResolver Resolver) Create(
+        params (string FilePath, string Source)[] files)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+                projectId, VersionStamp.Create(), "RenameProj", "RenameProj", LanguageNames.CSharp,
+                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithMetadataReferences(
+                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var solution = workspace.CurrentSolution.AddProject(projectInfo);
+        foreach (var (path, source) in files)
+        {
+            solution = solution.AddDocument(
+                DocumentId.CreateNewId(projectId), Path.GetFileName(path),
+                SourceText.From(source), filePath: path);
+        }
+
+        var compilation = solution.GetProject(projectId)!
+            .GetCompilationAsync().GetAwaiter().GetResult()!;
+
+        var loaded = new LoadedSolution
+        {
+            Solution = solution,
+            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(
+                [new KeyValuePair<ProjectId, Compilation>(projectId, compilation)]),
+        };
+        return (loaded, new SymbolResolver(loaded));
+    }
+}
+```
+
+**Step 2: Smoke-check it compiles and resolves**
+
+Add a temporary fact (deleted in Task 4 when real tests exist) or verify inline with the first Task 4 test — either way, by the end of Task 4 Step 2 the helper must be exercised. Run: `dotnet build tests/RoslynCodeLens.Tests` → 0 errors.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
+git commit -m "test: add AdhocWorkspace-based helper for rename tests"
+```
+
+---
+
+### Task 4: Validation and resolution errors (TDD)
+
+**Files:**
+- Create: `tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs`
+- Create: `src/RoslynCodeLens/Tools/RenameSymbolLogic.cs`
+
+**Step 1: Write the failing tests**
+
+Shared source used by most tests in this file — put it at the top of the test class:
+
+```csharp
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+public class RenameSymbolLogicTests
+{
+    private const string BasicSource = """
+        namespace RenameDemo;
+
+        public class Widget
+        {
+            public Widget() { }
+            public int Compute(int value) => value + 1;
+            public int Compute(int a, int b) => a + b;
+            // Widget appears in this comment.
+            public string Marker = "Widget in a string";
+            public string Describe() => nameof(Widget);
+        }
+
+        public class Gadget
+        {
+            public int Run() => new Widget().Compute(1);
+        }
+        """;
+
+    private static Task<RenameSymbolResult> RunAsync(
+        LoadedSolution loaded, SymbolResolver resolver, string symbol, string newName,
+        bool renameOverloads = true, bool renameInStrings = false, bool renameInComments = true,
+        bool preview = true, bool force = false)
+        => RenameSymbolLogic.ExecuteAsync(
+            loaded, resolver, symbol, newName,
+            renameOverloads, renameInStrings, renameInComments, preview, force,
+            CancellationToken.None);
+
+    [Fact]
+    public async Task InvalidIdentifier_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Widget", "123 bad name"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task UnknownSymbol_ThrowsSymbolNotFound()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "NoSuchType", "Whatever"));
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+    }
+
+    [Fact]
+    public async Task AmbiguousSimpleName_ThrowsAmbiguousMatch()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("A.cs", "namespace NsA; public class Dup { }"),
+            ("B.cs", "namespace NsB; public class Dup { }"));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Dup", "Renamed"));
+        Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
+    }
+
+    [Fact]
+    public void ConstructorTarget_ThrowsInvalidArgument()
+    {
+        var (loaded, _) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var compilation = loaded.Compilations.Values.First();
+        var widget = compilation.GetTypeByMetadataName("RenameDemo.Widget")!;
+        var ctor = widget.InstanceConstructors.First(c => !c.IsImplicitlyDeclared);
+
+        var ex = Assert.Throws<McpToolException>(
+            () => RenameSymbolLogic.ValidateRenameTarget(ctor, "Widget.Widget"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public void MetadataTarget_ThrowsInvalidArgument()
+    {
+        var (loaded, _) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var compilation = loaded.Compilations.Values.First();
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var ex = Assert.Throws<McpToolException>(
+            () => RenameSymbolLogic.ValidateRenameTarget(stringType, "System.String"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task MethodOverloadGroup_IsNotAmbiguous()
+    {
+        // Widget.Compute has two overloads; that is ONE rename target, not an ambiguity.
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget.Compute", "Calculate");
+        Assert.True(result.Success);
+    }
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolLogic"`
+Expected: FAIL — `RenameSymbolLogic` does not exist (compile error). That is the correct failure for this step.
+
+**Step 3: Write the implementation**
+
+`src/RoslynCodeLens/Tools/RenameSymbolLogic.cs` — complete file:
+
+```csharp
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Rename;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+public static class RenameSymbolLogic
+{
+    public static async Task<RenameSymbolResult> ExecuteAsync(
+        LoadedSolution loaded, SymbolResolver resolver,
+        string symbol, string newName,
+        bool renameOverloads, bool renameInStrings, bool renameInComments,
+        bool preview, bool force, CancellationToken ct)
+    {
+        if (!SyntaxFacts.IsValidIdentifier(newName))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{newName}' is not a valid C# identifier.", new { newName });
+        }
+
+        var target = ResolveSingleTarget(resolver, symbol);
+        ValidateRenameTarget(target, symbol);
+
+        var options = new SymbolRenameOptions(
+            RenameOverloads: renameOverloads,
+            RenameInStrings: renameInStrings,
+            RenameInComments: renameInComments,
+            RenameFile: false);
+
+        var renamed = await Renamer.RenameSymbolAsync(
+            loaded.Solution, target, options, newName, ct).ConfigureAwait(false);
+
+        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
+            renamed, loaded.Solution, ct).ConfigureAwait(false);
+        var conflicts = await ComputeConflictsAsync(loaded.Solution, renamed, ct).ConfigureAwait(false);
+        var filesChanged = edits.Select(e => e.FilePath)
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        var oldName = target.ToDisplayString();
+
+        if (preview)
+        {
+            return new RenameSymbolResult(true, oldName, newName, Applied: false,
+                edits, filesChanged, conflicts,
+                conflicts.Count > 0
+                    ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
+                    : "Preview only — no files written. Re-run with preview=false to apply.");
+        }
+
+        if (conflicts.Count > 0 && !force)
+        {
+            return new RenameSymbolResult(false, oldName, newName, Applied: false,
+                edits, filesChanged, conflicts,
+                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
+                "Inspect Conflicts, or re-run with force=true to apply anyway.");
+        }
+
+        await SolutionChangeWriter.WriteChangesToDiskAsync(
+            renamed, loaded.Solution, ct).ConfigureAwait(false);
+        return new RenameSymbolResult(true, oldName, newName, Applied: true,
+            edits, filesChanged, conflicts,
+            $"Renamed {oldName} to {newName} in {filesChanged} file(s).");
+    }
+
+    internal static ISymbol ResolveSingleTarget(SymbolResolver resolver, string symbol)
+    {
+        var matches = resolver.FindSymbols(symbol);
+        if (matches.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.SymbolNotFound,
+                $"Symbol '{symbol}' not found.", new { symbol });
+        }
+
+        // Overloads of one method are a single rename target (Renamer handles the
+        // group via RenameOverloads); everything else groups by full display string.
+        var groups = matches.GroupBy(GroupKey).ToList();
+        if (groups.Count > 1)
+        {
+            throw new McpToolException(ToolErrorCode.AmbiguousMatch,
+                $"Symbol '{symbol}' matched {groups.Count} distinct symbols. Use a more qualified name.",
+                new { matches = groups.Select(g => g.First().ToDisplayString()).ToList() });
+        }
+
+        return groups[0].First();
+    }
+
+    private static object GroupKey(ISymbol s) => s is IMethodSymbol m
+        ? (m.ContainingType?.ToDisplayString() ?? "", m.Name)
+        : s.ToDisplayString();
+
+    internal static void ValidateRenameTarget(ISymbol target, string symbol)
+    {
+        if (target is IMethodSymbol { MethodKind: MethodKind.Constructor or MethodKind.StaticConstructor })
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{symbol}' is a constructor — rename the containing type instead; constructors follow automatically.",
+                new { symbol });
+        }
+
+        if (!target.Locations.Any(l => l.IsInSource))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{symbol}' is a metadata symbol — only symbols defined in source can be renamed.",
+                new { symbol });
+        }
+    }
+
+    private static async Task<IReadOnlyList<RenameConflict>> ComputeConflictsAsync(
+        Solution original, Solution renamed, CancellationToken ct)
+    {
+        var conflicts = new List<RenameConflict>();
+        foreach (var change in renamed.GetChanges(original).GetProjectChanges())
+        {
+            var before = await change.OldProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            var after = await change.NewProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (before == null || after == null)
+                continue;
+
+            var beforeKeys = before.GetDiagnostics(ct)
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(DiagnosticKey)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var diag in after.GetDiagnostics(ct)
+                         .Where(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                if (beforeKeys.Contains(DiagnosticKey(diag)))
+                    continue;
+
+                var span = diag.Location.GetLineSpan();
+                conflicts.Add(new RenameConflict(
+                    diag.Id, diag.GetMessage(), span.Path,
+                    span.StartLinePosition.Line + 1));
+            }
+        }
+        return conflicts;
+    }
+
+    private static string DiagnosticKey(Diagnostic d)
+        => $"{d.Id}|{d.Location.GetLineSpan().Path}|{d.GetMessage()}";
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolLogic"`
+Expected: PASS (all 6). If `MethodOverloadGroup_IsNotAmbiguous` fails inside the Renamer call rather than at resolution, debug there — the resolution grouping is what this task owns; use superpowers:systematic-debugging before changing anything else.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/RenameSymbolLogic.cs tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+git commit -m "feat: rename_symbol resolution, validation, and core rename via Roslyn Renamer"
+```
+
+---
+
+### Task 5: Rename semantics — cascade and options (TDD)
+
+**Files:**
+- Modify: `tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs`
+
+All tests use `BasicSource` and preview mode; assert on the returned `Edits`. Helper for assertions — add to the test class:
+
+```csharp
+private static string ApplyEditsToSource(string source, IEnumerable<TextEdit> edits, string filePath)
+{
+    var text = Microsoft.CodeAnalysis.Text.SourceText.From(source);
+    var changes = edits
+        .Where(e => string.Equals(e.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+        .Select(e => new Microsoft.CodeAnalysis.Text.TextChange(
+            Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(
+                text.Lines[e.StartLine - 1].Start + e.StartColumn - 1,
+                text.Lines[e.EndLine - 1].Start + e.EndColumn - 1),
+            e.NewText));
+    return text.WithChanges(changes).ToString();
+}
+```
+
+**Step 1: Write the failing tests**
+
+```csharp
+[Fact]
+public async Task RenameType_CascadesToUsagesCtorAndNameof()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+
+    Assert.True(result.Success);
+    Assert.False(result.Applied);
+    Assert.Empty(result.Conflicts);
+
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("public class Sprocket", after, StringComparison.Ordinal);
+    Assert.Contains("public Sprocket()", after, StringComparison.Ordinal);          // ctor follows
+    Assert.Contains("new Sprocket().Compute(1)", after, StringComparison.Ordinal);  // usage follows
+    Assert.Contains("nameof(Sprocket)", after, StringComparison.Ordinal);           // nameof follows
+    Assert.DoesNotContain("class Widget", after, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task RenameInComments_OnByDefault_RewritesComment()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("// Sprocket appears in this comment.", after, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task RenameInComments_Off_LeavesComment()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", renameInComments: false);
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("// Widget appears in this comment.", after, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task RenameInStrings_OffByDefault_LeavesString()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("\"Widget in a string\"", after, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task RenameInStrings_On_RewritesString()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", renameInStrings: true);
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("\"Sprocket in a string\"", after, StringComparison.Ordinal);
+}
+
+[Fact]
+public async Task RenameOverloads_On_RenamesAllOverloadsAndCallSites()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+    var result = await RunAsync(loaded, resolver, "Widget.Compute", "Calculate");
+    var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+    Assert.Contains("public int Calculate(int value)", after, StringComparison.Ordinal);
+    Assert.Contains("public int Calculate(int a, int b)", after, StringComparison.Ordinal);
+    Assert.Contains(".Calculate(1)", after, StringComparison.Ordinal);
+    Assert.Empty(result.Conflicts);
+}
+```
+
+**Step 2: Run tests to verify they fail or pass**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolLogic"`
+Expected: PASS — Task 4's implementation already covers these; this task pins the semantics. If any FAIL, the Renamer options are wired wrong (e.g. positional order of `SymbolRenameOptions`): fix `RenameSymbolLogic`, do not weaken the test.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+git commit -m "test: pin rename_symbol cascade and option semantics"
+```
+
+---
+
+### Task 6: Conflict detection and force (TDD)
+
+**Files:**
+- Modify: `tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs`
+
+**Step 1: Write the failing tests**
+
+```csharp
+private const string CollisionSource = """
+    namespace RenameDemo;
+    public class First { }
+    public class Second { }
+    """;
+
+[Fact]
+public async Task CollidingRename_Preview_ReportsConflicts()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Types.cs", CollisionSource));
+    var result = await RunAsync(loaded, resolver, "First", "Second");
+
+    Assert.True(result.Success);
+    Assert.False(result.Applied);
+    Assert.NotEmpty(result.Conflicts);   // CS0101: duplicate type in namespace
+    Assert.Contains(result.Conflicts, c => string.Equals(c.Id, "CS0101", StringComparison.Ordinal));
+}
+
+[Fact]
+public async Task CollidingRename_Apply_RefusesWithoutForce()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Types.cs", CollisionSource));
+    var result = await RunAsync(loaded, resolver, "First", "Second", preview: false);
+
+    Assert.False(result.Success);
+    Assert.False(result.Applied);
+    Assert.NotEmpty(result.Conflicts);
+    Assert.Contains("force", result.Message, StringComparison.OrdinalIgnoreCase);
+}
+```
+
+Note: neither test writes to disk (in-memory documents with relative paths; the refusal path returns before writing). The `force=true` disk-write case is covered in Task 7 where real temp files exist.
+
+**Step 2: Run tests**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolLogic"`
+Expected: PASS (conflict logic shipped in Task 4; these pin it). If `CS0101` is not reported, debug `ComputeConflictsAsync` — likely the before/after key comparison.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+git commit -m "test: pin rename_symbol conflict detection and force refusal"
+```
+
+---### Task 7: Apply mode writes to disk (TDD)
+
+**Files:**
+- Modify: `tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs`
+
+**Step 1: Write the failing tests**
+
+Real temp files so `WriteChangesToDiskAsync` has somewhere to write. Always clean up.
+
+```csharp
+[Fact]
+public async Task Apply_WritesRenamedFilesToDisk()
+{
+    var dir = Directory.CreateTempSubdirectory("rename-apply-").FullName;
+    try
+    {
+        var path = Path.Combine(dir, "Widget.cs");
+        await File.WriteAllTextAsync(path, BasicSource);
+        var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false);
+
+        Assert.True(result.Success);
+        Assert.True(result.Applied);
+        var onDisk = await File.ReadAllTextAsync(path);
+        Assert.Contains("public class Sprocket", onDisk, StringComparison.Ordinal);
+        Assert.DoesNotContain("class Widget", onDisk, StringComparison.Ordinal);
+    }
+    finally
+    {
+        Directory.Delete(dir, recursive: true);
+    }
+}
+
+[Fact]
+public async Task Preview_LeavesDiskUntouched()
+{
+    var dir = Directory.CreateTempSubdirectory("rename-preview-").FullName;
+    try
+    {
+        var path = Path.Combine(dir, "Widget.cs");
+        await File.WriteAllTextAsync(path, BasicSource);
+        var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");   // preview: true
+
+        Assert.False(result.Applied);
+        Assert.Equal(BasicSource, await File.ReadAllTextAsync(path));
+    }
+    finally
+    {
+        Directory.Delete(dir, recursive: true);
+    }
+}
+
+[Fact]
+public async Task CollidingRename_ForceTrue_WritesAnyway()
+{
+    var dir = Directory.CreateTempSubdirectory("rename-force-").FullName;
+    try
+    {
+        var path = Path.Combine(dir, "Types.cs");
+        await File.WriteAllTextAsync(path, CollisionSource);
+        var (loaded, resolver) = RenameTestWorkspace.Create((path, CollisionSource));
+
+        var result = await RunAsync(loaded, resolver, "First", "Second", preview: false, force: true);
+
+        Assert.True(result.Applied);
+        Assert.NotEmpty(result.Conflicts);
+        Assert.Contains("class Second", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+    }
+    finally
+    {
+        Directory.Delete(dir, recursive: true);
+    }
+}
+```
+
+**Step 2: Run tests**
+
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolLogic"`
+Expected: PASS. The write path is `SolutionChangeWriter` (Task 1), already proven by the apply_code_action suite; failures here point at the preview/force gating in `ExecuteAsync`.
+
+**Step 3: Commit**
+
+```bash
+git add tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+git commit -m "test: pin rename_symbol apply-mode disk writes, preview isolation, and force"
+```
+
+---
+
+### Task 8: MCP tool wrapper + fixture integration test
+
+**Files:**
+- Create: `src/RoslynCodeLens/Tools/RenameSymbolTool.cs`
+- Create: `tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs`
+
+**Step 1: Write the tool wrapper**
+
+Copy the shape of `ApplyCodeActionTool` / `FindReferencesTool` (manager + `EnsureLoaded` + `GetAnalysisContext`):
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class RenameSymbolTool
+{
+    [McpServerTool(Name = "rename_symbol"),
+     Description("Safely rename a type or member across the entire solution (Roslyn Renamer). " +
+                 "Cascades to references, constructors, overrides, nameof, and XML doc crefs. " +
+                 "Defaults to preview mode (returns edits without writing files); set preview=false to apply. " +
+                 "New compiler errors the rename would introduce are reported as Conflicts, and apply mode " +
+                 "refuses to write them unless force=true. Locals/parameters and file renames are not supported.")]
+    public static async Task<RenameSymbolResult> Execute(
+        MultiSolutionManager manager,
+        [Description("Symbol to rename: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyMethod)")] string symbol,
+        [Description("New name — a bare C# identifier, e.g. 'OrderProcessor'")] string newName,
+        [Description("Rename all overloads of a method together (default: true; false renames a single arbitrary overload)")] bool renameOverloads = true,
+        [Description("Also rewrite occurrences inside string literals (default: false)")] bool renameInStrings = false,
+        [Description("Also rewrite occurrences inside comments (default: true)")] bool renameInComments = true,
+        [Description("Preview only — return edits without writing to disk (default: true)")] bool preview = true,
+        [Description("Apply even when Conflicts are reported (default: false)")] bool force = false,
+        CancellationToken ct = default)
+    {
+        manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
+        return await RenameSymbolLogic.ExecuteAsync(
+            context.Loaded, context.Resolver, symbol, newName,
+            renameOverloads, renameInStrings, renameInComments, preview, force, ct).ConfigureAwait(false);
+    }
+}
+```
+
+Check `manager.GetAnalysisContext()`'s actual member names against another tool (`src/RoslynCodeLens/Tools/FindReferencesTool.cs:22-23`) before assuming `context.Loaded` / `context.Resolver`.
+
+**Step 2: Write the integration test (failing first if wrapper doesn't compile)**
+
+One preview-only test against the real MSBuildWorkspace-loaded fixture, proving name-based end-to-end rename over a multi-project solution. Preview mode guarantees the shared fixture's files are never modified.
+
+```csharp
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+[Collection("TestSolution")]
+public class RenameSymbolFixtureTests
+{
+    private readonly TestSolutionFixture _fixture;
+
+    public RenameSymbolFixtureTests(TestSolutionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task PreviewRenameGreeter_ProducesEditsAcrossProjects()
+    {
+        var result = await RenameSymbolLogic.ExecuteAsync(
+            _fixture.Loaded, _fixture.Resolver, "Greeter", "Salutations",
+            renameOverloads: true, renameInStrings: false, renameInComments: true,
+            preview: true, force: false, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.Empty(result.Conflicts);
+        // Greeter is defined in TestLib and called from the xUnit/NUnit/MSTest fixture
+        // projects (see TestSolutionFixture health probe), so edits must span >1 project.
+        var projects = result.Edits
+            .Select(e => Path.GetFileName(Path.GetDirectoryName(e.FilePath)!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        Assert.True(projects.Count > 1,
+            $"Expected edits across multiple projects, got: {string.Join(", ", projects)}");
+    }
+}
+```
+
+**Step 3: Run**
+
+Run: `dotnet build src/RoslynCodeLens` → 0 errors.
+Run: `dotnet test tests/RoslynCodeLens.Tests --filter "FullyQualifiedName~RenameSymbolFixture"`
+Expected: PASS. (Fixture load takes a while on cold start — that is the shared fixture, not a hang.)
+
+**Step 4: Verify the shared fixture was not modified**
+
+Run: `git status --short tests/RoslynCodeLens.Tests/Fixtures/`
+Expected: no output. If fixture files changed, a test wrote to disk that must not — fix before committing.
+
+**Step 5: Commit**
+
+```bash
+git add src/RoslynCodeLens/Tools/RenameSymbolTool.cs tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs
+git commit -m "feat: expose rename_symbol MCP tool"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md`
+- Modify: `docs/BACKLOG.md`
+
+**Step 1: SKILL.md updates** (keep each addition in the file's existing voice; find sections by heading):
+
+1. **Red Flags table** (after the `apply_code_action`-adjacent rows): add
+   `| "Rename this class/method everywhere" / "Let me edit N files to change this name" | \`rename_symbol\` |`
+2. **Diagnostics section**, after the `apply_code_action` bullet list: add
+   `- \`rename_symbol\` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via apply_code_action). Preview by default; new-compiler-error conflicts reported; apply refuses on conflicts unless force=true.`
+3. **Tool Quick Reference table**: add
+   `| \`rename_symbol\` | "Rename this symbol everywhere" / "Change this name across the solution" |`
+4. **Metadata Support by Tool table**: add
+   `| \`rename_symbol\` | No — source only | Locals/parameters and file renames unsupported | |`
+
+**Step 2: BACKLOG.md update**
+
+In §5 High value: mark the `rename_symbol` bullet as in progress, e.g. prefix with `🔧 **In flight:**` and reference the design doc `docs/plans/2026-07-19-rename-symbol-design.md`. Add a line under `## In flight`: `- **\`rename_symbol\`** — branch \`feature/rename-symbol\`, design docs/plans/2026-07-19-rename-symbol-design.md`.
+
+**Step 3: Commit**
+
+```bash
+git add plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md docs/BACKLOG.md
+git commit -m "docs: document rename_symbol in skill and backlog"
+```
+
+---
+
+### Task 10: Full verification
+
+**Step 1: Full build + full test suite**
+
+Run: `dotnet build` → 0 errors, 0 warnings introduced by this branch.
+Run: `dotnet test` → all tests pass (known fixture flake auto-retries per `TestSolutionFixture`; a hard failure after 6 attempts is real).
+
+**Step 2: Clean tree check**
+
+Run: `git status --short` → only expected untracked/modified files (none, after commits).
+
+**Step 3: Wrap up**
+
+Use superpowers:verification-before-completion, then superpowers:finishing-a-development-branch (options: PR to `main` from `feature/rename-symbol`).
+
+---
+
+## Deviations
+
+Any deviation from this plan (API mismatch, failing assumption about Renamer behavior on AdhocWorkspace, `GetAnalysisContext` member names) gets noted in the final report and, if design-relevant, appended to the design doc's Out-of-scope/notes section.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -100,6 +100,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 | "Will this break consumers?" / "Show me breaking changes vs the previous release" / "Diff this build's API against baseline" | `find_breaking_changes` |
 | "Are there async bugs?" / "Find sync-over-async" / "Are we using `.Result` anywhere?" | `find_async_violations` |
 | "Are there resource leaks?" / "Find missing `using`" / "Is this disposable handled?" | `find_disposable_misuse` |
+| "Rename this class/method everywhere" / "Let me edit N files to change this name" | `rename_symbol` |
 
 **All of these mean: the MCP tool is the correct tool. Use it.**
 
@@ -199,6 +200,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 Solutions passed on the CLI at server startup are auto-trusted in session scope — `get_diagnostics(includeAnalyzers=true)` against them works without an extra prompt.
 - `get_code_actions` — all refactorings/fixes at a position (with optional range).
 - `apply_code_action` — execute a refactoring by title. Preview mode by default.
+- `rename_symbol` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via `apply_code_action`). Preview by default; new-compiler-error conflicts reported; apply refuses on conflicts unless `force=true`.
 - `analyze_data_flow` — variable lifecycle over a statement range (declared/read/written/captured/flows-in/out).
 - `analyze_control_flow` — reachability, returns, unreachable paths.
 
@@ -321,6 +323,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `get_code_fixes` | "How do I fix this warning?" |
 | `get_code_actions` | "What refactorings are available here?" |
 | `apply_code_action` | "Apply this refactoring" / "Extract method" |
+| `rename_symbol` | "Rename this symbol everywhere" / "Change this name across the solution" |
 | `find_unused_symbols` | "Any dead code?" |
 | `get_complexity_metrics` | "Which methods are too complex?" |
 | `find_naming_violations` | "Check naming conventions" |
@@ -385,6 +388,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_code_fixes` | No — source only | | |
 | `get_code_actions` | No — source only | | |
 | `apply_code_action` | No — source only | | |
+| `rename_symbol` | No — source only | Locals/parameters and file renames unsupported | |
 | `analyze_data_flow` | No — source only | | |
 | `analyze_control_flow` | No — source only | | |
 | `analyze_change_impact` | No — source only | | |

--- a/src/RoslynCodeLens/CodeActionRunner.cs
+++ b/src/RoslynCodeLens/CodeActionRunner.cs
@@ -57,11 +57,11 @@ public static class CodeActionRunner
                     "Action did not produce any applicable changes");
             }
 
-            var edits = await ExtractTextEdits(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+            var edits = await SolutionChangeWriter.ExtractTextEditsAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
 
             if (!preview)
             {
-                await WriteChangesToDiskAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+                await SolutionChangeWriter.WriteChangesToDiskAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
             }
 
             return new CodeActionResult(true, matchedAction.Title, edits);
@@ -152,34 +152,6 @@ public static class CodeActionRunner
         return (actions, codeFixTitles);
     }
 
-    private static async Task WriteChangesToDiskAsync(
-        Solution changedSolution, Solution originalSolution, CancellationToken ct)
-    {
-        foreach (var projectChange in changedSolution.GetChanges(originalSolution).GetProjectChanges())
-        {
-            foreach (var changedDocId in projectChange.GetChangedDocuments())
-            {
-                var changedDoc = changedSolution.GetDocument(changedDocId);
-                if (changedDoc?.FilePath == null) continue;
-
-                var text = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                await File.WriteAllTextAsync(changedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
-            }
-
-            foreach (var addedDocId in projectChange.GetAddedDocuments())
-            {
-                var addedDoc = changedSolution.GetDocument(addedDocId);
-                if (addedDoc?.FilePath == null) continue;
-
-                var dir = Path.GetDirectoryName(addedDoc.FilePath);
-                if (dir != null) Directory.CreateDirectory(dir);
-
-                var text = await addedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                await File.WriteAllTextAsync(addedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
-            }
-        }
-    }
-
     private static TextSpan CreateSpan(SourceText text, int line, int column, int? endLine, int? endColumn)
     {
         var startLine = Math.Max(0, line - 1);
@@ -230,52 +202,6 @@ public static class CodeActionRunner
             title.Contains(a.Title, StringComparison.OrdinalIgnoreCase));
 
         return match;
-    }
-
-    private static async Task<List<TextEdit>> ExtractTextEdits(
-        Solution changedSolution, Solution originalSolution, CancellationToken ct)
-    {
-        var edits = new List<TextEdit>();
-
-        foreach (var projectChange in changedSolution.GetChanges(originalSolution).GetProjectChanges())
-        {
-            foreach (var changedDocId in projectChange.GetChangedDocuments())
-            {
-                var originalDoc = originalSolution.GetDocument(changedDocId);
-                var changedDoc = changedSolution.GetDocument(changedDocId);
-                if (originalDoc == null || changedDoc == null) continue;
-
-                var originalText = await originalDoc.GetTextAsync(ct).ConfigureAwait(false);
-                var changedText = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                var changes = changedText.GetTextChanges(originalText);
-
-                foreach (var change in changes)
-                {
-                    var startPos = originalText.Lines.GetLinePosition(change.Span.Start);
-                    var endPos = originalText.Lines.GetLinePosition(change.Span.End);
-
-                    edits.Add(new TextEdit(
-                        originalDoc.FilePath ?? "",
-                        startPos.Line + 1, startPos.Character + 1,
-                        endPos.Line + 1, endPos.Character + 1,
-                        change.NewText ?? ""));
-                }
-            }
-
-            foreach (var addedDocId in projectChange.GetAddedDocuments())
-            {
-                var addedDoc = changedSolution.GetDocument(addedDocId);
-                if (addedDoc == null) continue;
-
-                var text = await addedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                edits.Add(new TextEdit(
-                    addedDoc.FilePath ?? "",
-                    1, 1, 1, 1,
-                    text.ToString()));
-            }
-        }
-
-        return edits;
     }
 
     private static CodeActionInfo ToCodeActionInfo(CodeAction action, HashSet<string> codeFixTitles)

--- a/src/RoslynCodeLens/Models/RenameConflict.cs
+++ b/src/RoslynCodeLens/Models/RenameConflict.cs
@@ -1,0 +1,4 @@
+namespace RoslynCodeLens.Models;
+
+/// <summary>A compiler error that would be introduced by applying the rename.</summary>
+public record RenameConflict(string Id, string Message, string File, int Line);

--- a/src/RoslynCodeLens/Models/RenameSymbolResult.cs
+++ b/src/RoslynCodeLens/Models/RenameSymbolResult.cs
@@ -1,0 +1,11 @@
+namespace RoslynCodeLens.Models;
+
+public record RenameSymbolResult(
+    bool Success,
+    string OldName,
+    string NewName,
+    bool Applied,
+    IReadOnlyList<TextEdit> Edits,
+    int FilesChanged,
+    IReadOnlyList<RenameConflict> Conflicts,
+    string Message);

--- a/src/RoslynCodeLens/SolutionChangeWriter.cs
+++ b/src/RoslynCodeLens/SolutionChangeWriter.cs
@@ -1,0 +1,85 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Shared write path for tools that produce a changed Solution (apply_code_action,
+/// rename_symbol): diff extraction for previews and document writes for apply mode.
+/// </summary>
+public static class SolutionChangeWriter
+{
+    public static async Task<List<TextEdit>> ExtractTextEditsAsync(
+        Solution changedSolution, Solution originalSolution, CancellationToken ct)
+    {
+        var edits = new List<TextEdit>();
+
+        foreach (var projectChange in changedSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var changedDocId in projectChange.GetChangedDocuments())
+            {
+                var originalDoc = originalSolution.GetDocument(changedDocId);
+                var changedDoc = changedSolution.GetDocument(changedDocId);
+                if (originalDoc == null || changedDoc == null) continue;
+
+                var originalText = await originalDoc.GetTextAsync(ct).ConfigureAwait(false);
+                var changedText = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
+                var changes = changedText.GetTextChanges(originalText);
+
+                foreach (var change in changes)
+                {
+                    var startPos = originalText.Lines.GetLinePosition(change.Span.Start);
+                    var endPos = originalText.Lines.GetLinePosition(change.Span.End);
+
+                    edits.Add(new TextEdit(
+                        originalDoc.FilePath ?? "",
+                        startPos.Line + 1, startPos.Character + 1,
+                        endPos.Line + 1, endPos.Character + 1,
+                        change.NewText ?? ""));
+                }
+            }
+
+            foreach (var addedDocId in projectChange.GetAddedDocuments())
+            {
+                var addedDoc = changedSolution.GetDocument(addedDocId);
+                if (addedDoc == null) continue;
+
+                var text = await addedDoc.GetTextAsync(ct).ConfigureAwait(false);
+                edits.Add(new TextEdit(
+                    addedDoc.FilePath ?? "",
+                    1, 1, 1, 1,
+                    text.ToString()));
+            }
+        }
+
+        return edits;
+    }
+
+    public static async Task WriteChangesToDiskAsync(
+        Solution changedSolution, Solution originalSolution, CancellationToken ct)
+    {
+        foreach (var projectChange in changedSolution.GetChanges(originalSolution).GetProjectChanges())
+        {
+            foreach (var changedDocId in projectChange.GetChangedDocuments())
+            {
+                var changedDoc = changedSolution.GetDocument(changedDocId);
+                if (changedDoc?.FilePath == null) continue;
+
+                var text = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
+                await File.WriteAllTextAsync(changedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
+            }
+
+            foreach (var addedDocId in projectChange.GetAddedDocuments())
+            {
+                var addedDoc = changedSolution.GetDocument(addedDocId);
+                if (addedDoc?.FilePath == null) continue;
+
+                var dir = Path.GetDirectoryName(addedDoc.FilePath);
+                if (dir != null) Directory.CreateDirectory(dir);
+
+                var text = await addedDoc.GetTextAsync(ct).ConfigureAwait(false);
+                await File.WriteAllTextAsync(addedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
@@ -1,0 +1,141 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Rename;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+public static class RenameSymbolLogic
+{
+    public static async Task<RenameSymbolResult> ExecuteAsync(
+        LoadedSolution loaded, SymbolResolver resolver,
+        string symbol, string newName,
+        bool renameOverloads, bool renameInStrings, bool renameInComments,
+        bool preview, bool force, CancellationToken ct)
+    {
+        if (!SyntaxFacts.IsValidIdentifier(newName))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{newName}' is not a valid C# identifier.", new { newName });
+        }
+
+        var target = ResolveSingleTarget(resolver, symbol);
+        ValidateRenameTarget(target, symbol);
+
+        var options = new SymbolRenameOptions(
+            RenameOverloads: renameOverloads,
+            RenameInStrings: renameInStrings,
+            RenameInComments: renameInComments,
+            RenameFile: false);
+
+        var renamed = await Renamer.RenameSymbolAsync(
+            loaded.Solution, target, options, newName, ct).ConfigureAwait(false);
+
+        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
+            renamed, loaded.Solution, ct).ConfigureAwait(false);
+        var conflicts = await ComputeConflictsAsync(loaded.Solution, renamed, ct).ConfigureAwait(false);
+        var filesChanged = edits.Select(e => e.FilePath)
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        var oldName = target.ToDisplayString();
+
+        if (preview)
+        {
+            return new RenameSymbolResult(true, oldName, newName, Applied: false,
+                edits, filesChanged, conflicts,
+                conflicts.Count > 0
+                    ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
+                    : "Preview only — no files written. Re-run with preview=false to apply.");
+        }
+
+        if (conflicts.Count > 0 && !force)
+        {
+            return new RenameSymbolResult(false, oldName, newName, Applied: false,
+                edits, filesChanged, conflicts,
+                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
+                "Inspect Conflicts, or re-run with force=true to apply anyway.");
+        }
+
+        await SolutionChangeWriter.WriteChangesToDiskAsync(
+            renamed, loaded.Solution, ct).ConfigureAwait(false);
+        return new RenameSymbolResult(true, oldName, newName, Applied: true,
+            edits, filesChanged, conflicts,
+            $"Renamed {oldName} to {newName} in {filesChanged} file(s).");
+    }
+
+    internal static ISymbol ResolveSingleTarget(SymbolResolver resolver, string symbol)
+    {
+        var matches = resolver.FindSymbols(symbol);
+        if (matches.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.SymbolNotFound,
+                $"Symbol '{symbol}' not found.", new { symbol });
+        }
+
+        // Overloads of one method are a single rename target (Renamer handles the
+        // group via RenameOverloads); everything else groups by full display string.
+        var groups = matches.GroupBy(GroupKey).ToList();
+        if (groups.Count > 1)
+        {
+            throw new McpToolException(ToolErrorCode.AmbiguousMatch,
+                $"Symbol '{symbol}' matched {groups.Count} distinct symbols. Use a more qualified name.",
+                new { matches = groups.Select(g => g.First().ToDisplayString()).ToList() });
+        }
+
+        return groups[0].First();
+    }
+
+    private static object GroupKey(ISymbol s) => s is IMethodSymbol m
+        ? (m.ContainingType?.ToDisplayString() ?? "", m.Name)
+        : s.ToDisplayString();
+
+    internal static void ValidateRenameTarget(ISymbol target, string symbol)
+    {
+        if (target is IMethodSymbol { MethodKind: MethodKind.Constructor or MethodKind.StaticConstructor })
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{symbol}' is a constructor — rename the containing type instead; constructors follow automatically.",
+                new { symbol });
+        }
+
+        if (!target.Locations.Any(l => l.IsInSource))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{symbol}' is a metadata symbol — only symbols defined in source can be renamed.",
+                new { symbol });
+        }
+    }
+
+    private static async Task<IReadOnlyList<RenameConflict>> ComputeConflictsAsync(
+        Solution original, Solution renamed, CancellationToken ct)
+    {
+        var conflicts = new List<RenameConflict>();
+        foreach (var change in renamed.GetChanges(original).GetProjectChanges())
+        {
+            var before = await change.OldProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            var after = await change.NewProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            if (before == null || after == null)
+                continue;
+
+            var beforeKeys = before.GetDiagnostics(ct)
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(DiagnosticKey)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var diag in after.GetDiagnostics(ct)
+                         .Where(d => d.Severity == DiagnosticSeverity.Error))
+            {
+                if (beforeKeys.Contains(DiagnosticKey(diag)))
+                    continue;
+
+                var span = diag.Location.GetLineSpan();
+                conflicts.Add(new RenameConflict(
+                    diag.Id, diag.GetMessage(), span.Path,
+                    span.StartLinePosition.Line + 1));
+            }
+        }
+        return conflicts;
+    }
+
+    private static string DiagnosticKey(Diagnostic d)
+        => $"{d.Id}|{d.Location.GetLineSpan().Path}|{d.GetMessage()}";
+}

--- a/src/RoslynCodeLens/Tools/RenameSymbolTool.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolTool.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class RenameSymbolTool
+{
+    [McpServerTool(Name = "rename_symbol"),
+     Description("Safely rename a type or member across the entire solution (Roslyn Renamer). " +
+                 "Cascades to references, constructors, overrides, nameof, and XML doc crefs. " +
+                 "Defaults to preview mode (returns edits without writing files); set preview=false to apply. " +
+                 "New compiler errors the rename would introduce are reported as Conflicts, and apply mode " +
+                 "refuses to write them unless force=true. Locals/parameters and file renames are not supported.")]
+    public static async Task<RenameSymbolResult> Execute(
+        MultiSolutionManager manager,
+        [Description("Symbol to rename: simple type (MyClass), fully qualified (Namespace.MyClass), or member (MyClass.MyMethod)")] string symbol,
+        [Description("New name — a bare C# identifier, e.g. 'OrderProcessor'")] string newName,
+        [Description("Rename all overloads of a method together (default: true; false renames a single arbitrary overload)")] bool renameOverloads = true,
+        [Description("Also rewrite occurrences inside string literals (default: false)")] bool renameInStrings = false,
+        [Description("Also rewrite occurrences inside comments (default: true)")] bool renameInComments = true,
+        [Description("Preview only — return edits without writing to disk (default: true)")] bool preview = true,
+        [Description("Apply even when Conflicts are reported (default: false)")] bool force = false,
+        CancellationToken ct = default)
+    {
+        manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
+        return await RenameSymbolLogic.ExecuteAsync(
+            context.Loaded, context.Resolver, symbol, newName,
+            renameOverloads, renameInStrings, renameInComments, preview, force, ct).ConfigureAwait(false);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
@@ -1,0 +1,44 @@
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynCodeLens.Tests.Fixtures;
+
+/// <summary>
+/// Builds an in-memory single-project LoadedSolution + SymbolResolver from source
+/// strings. Pass absolute paths as file names when a test needs apply-mode disk writes.
+/// </summary>
+internal static class RenameTestWorkspace
+{
+    public static (LoadedSolution Loaded, SymbolResolver Resolver) Create(
+        params (string FilePath, string Source)[] files)
+    {
+        var workspace = new AdhocWorkspace();
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(
+                projectId, VersionStamp.Create(), "RenameProj", "RenameProj", LanguageNames.CSharp,
+                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithMetadataReferences(
+                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+
+        var solution = workspace.CurrentSolution.AddProject(projectInfo);
+        foreach (var (path, source) in files)
+        {
+            solution = solution.AddDocument(
+                DocumentId.CreateNewId(projectId), Path.GetFileName(path),
+                SourceText.From(source), filePath: path);
+        }
+
+        var compilation = solution.GetProject(projectId)!
+            .GetCompilationAsync().GetAwaiter().GetResult()!;
+
+        var loaded = new LoadedSolution
+        {
+            Solution = solution,
+            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(
+                [new KeyValuePair<ProjectId, Compilation>(projectId, compilation)]),
+        };
+        return (loaded, new SymbolResolver(loaded));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs
@@ -1,0 +1,33 @@
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+[Collection("TestSolution")]
+public class RenameSymbolFixtureTests
+{
+    private readonly TestSolutionFixture _fixture;
+
+    public RenameSymbolFixtureTests(TestSolutionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task PreviewRenameGreeter_ProducesEditsAcrossProjects()
+    {
+        var result = await RenameSymbolLogic.ExecuteAsync(
+            _fixture.Loaded, _fixture.Resolver, "Greeter", "Salutations",
+            renameOverloads: true, renameInStrings: false, renameInComments: true,
+            preview: true, force: false, CancellationToken.None);
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.Empty(result.Conflicts);
+        // Greeter is defined in TestLib and called from the xUnit/NUnit/MSTest fixture
+        // projects (see TestSolutionFixture health probe), so edits must span >1 project.
+        var projects = result.Edits
+            .Select(e => Path.GetFileName(Path.GetDirectoryName(e.FilePath)!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        Assert.True(projects.Count > 1,
+            $"Expected edits across multiple projects, got: {string.Join(", ", projects)}");
+    }
+}

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+public class RenameSymbolLogicTests
+{
+    private const string BasicSource = """
+        namespace RenameDemo;
+
+        public class Widget
+        {
+            public Widget() { }
+            public int Compute(int value) => value + 1;
+            public int Compute(int a, int b) => a + b;
+            // Widget appears in this comment.
+            public string Marker = "Widget in a string";
+            public string Describe() => nameof(Widget);
+        }
+
+        public class Gadget
+        {
+            public int Run() => new Widget().Compute(1);
+        }
+        """;
+
+    private static Task<RenameSymbolResult> RunAsync(
+        LoadedSolution loaded, SymbolResolver resolver, string symbol, string newName,
+        bool renameOverloads = true, bool renameInStrings = false, bool renameInComments = true,
+        bool preview = true, bool force = false)
+        => RenameSymbolLogic.ExecuteAsync(
+            loaded, resolver, symbol, newName,
+            renameOverloads, renameInStrings, renameInComments, preview, force,
+            CancellationToken.None);
+
+    [Fact]
+    public async Task InvalidIdentifier_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Widget", "123 bad name"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task UnknownSymbol_ThrowsSymbolNotFound()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "NoSuchType", "Whatever"));
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+    }
+
+    [Fact]
+    public async Task AmbiguousSimpleName_ThrowsAmbiguousMatch()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("A.cs", "namespace NsA; public class Dup { }"),
+            ("B.cs", "namespace NsB; public class Dup { }"));
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Dup", "Renamed"));
+        Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
+    }
+
+    [Fact]
+    public void ConstructorTarget_ThrowsInvalidArgument()
+    {
+        var (loaded, _) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var compilation = loaded.Compilations.Values.First();
+        var widget = compilation.GetTypeByMetadataName("RenameDemo.Widget")!;
+        var ctor = widget.InstanceConstructors.First(c => !c.IsImplicitlyDeclared);
+
+        var ex = Assert.Throws<McpToolException>(
+            () => RenameSymbolLogic.ValidateRenameTarget(ctor, "Widget.Widget"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public void MetadataTarget_ThrowsInvalidArgument()
+    {
+        var (loaded, _) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var compilation = loaded.Compilations.Values.First();
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+
+        var ex = Assert.Throws<McpToolException>(
+            () => RenameSymbolLogic.ValidateRenameTarget(stringType, "System.String"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task MethodOverloadGroup_IsNotAmbiguous()
+    {
+        // Widget.Compute has two overloads; that is ONE rename target, not an ambiguity.
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget.Compute", "Calculate");
+        Assert.True(result.Success);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -208,4 +208,71 @@ public class RenameSymbolLogicTests
         Assert.NotEmpty(result.Conflicts);
         Assert.Contains("force", result.Message, StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task Apply_WritesRenamedFilesToDisk()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-apply-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false);
+
+            Assert.True(result.Success);
+            Assert.True(result.Applied);
+            var onDisk = await File.ReadAllTextAsync(path);
+            Assert.Contains("public class Sprocket", onDisk, StringComparison.Ordinal);
+            Assert.DoesNotContain("class Widget", onDisk, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Preview_LeavesDiskUntouched()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-preview-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");   // preview: true
+
+            Assert.False(result.Applied);
+            Assert.Equal(BasicSource, await File.ReadAllTextAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CollidingRename_ForceTrue_WritesAnyway()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-force-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Types.cs");
+            await File.WriteAllTextAsync(path, CollisionSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, CollisionSource));
+
+            var result = await RunAsync(loaded, resolver, "First", "Second", preview: false, force: true);
+
+            Assert.True(result.Applied);
+            Assert.NotEmpty(result.Conflicts);
+            Assert.Contains("class Second", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -178,4 +178,34 @@ public class RenameSymbolLogicTests
         Assert.Contains(".Calculate(1)", after, StringComparison.Ordinal);
         Assert.Empty(result.Conflicts);
     }
+
+    private const string CollisionSource = """
+        namespace RenameDemo;
+        public class First { }
+        public class Second { }
+        """;
+
+    [Fact]
+    public async Task CollidingRename_Preview_ReportsConflicts()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Types.cs", CollisionSource));
+        var result = await RunAsync(loaded, resolver, "First", "Second");
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.NotEmpty(result.Conflicts);   // CS0101: duplicate type in namespace
+        Assert.Contains(result.Conflicts, c => string.Equals(c.Id, "CS0101", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task CollidingRename_Apply_RefusesWithoutForce()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Types.cs", CollisionSource));
+        var result = await RunAsync(loaded, resolver, "First", "Second", preview: false);
+
+        Assert.False(result.Success);
+        Assert.False(result.Applied);
+        Assert.NotEmpty(result.Conflicts);
+        Assert.Contains("force", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -99,4 +99,83 @@ public class RenameSymbolLogicTests
         var result = await RunAsync(loaded, resolver, "Widget.Compute", "Calculate");
         Assert.True(result.Success);
     }
+
+    private static string ApplyEditsToSource(string source, IEnumerable<TextEdit> edits, string filePath)
+    {
+        var text = Microsoft.CodeAnalysis.Text.SourceText.From(source);
+        var changes = edits
+            .Where(e => string.Equals(e.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+            .Select(e => new Microsoft.CodeAnalysis.Text.TextChange(
+                Microsoft.CodeAnalysis.Text.TextSpan.FromBounds(
+                    text.Lines[e.StartLine - 1].Start + e.StartColumn - 1,
+                    text.Lines[e.EndLine - 1].Start + e.EndColumn - 1),
+                e.NewText));
+        return text.WithChanges(changes).ToString();
+    }
+
+    [Fact]
+    public async Task RenameType_CascadesToUsagesCtorAndNameof()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.Empty(result.Conflicts);
+
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("public class Sprocket", after, StringComparison.Ordinal);
+        Assert.Contains("public Sprocket()", after, StringComparison.Ordinal);
+        Assert.Contains("new Sprocket().Compute(1)", after, StringComparison.Ordinal);
+        Assert.Contains("nameof(Sprocket)", after, StringComparison.Ordinal);
+        Assert.DoesNotContain("class Widget", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenameInComments_OnByDefault_RewritesComment()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("// Sprocket appears in this comment.", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenameInComments_Off_LeavesComment()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", renameInComments: false);
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("// Widget appears in this comment.", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenameInStrings_OffByDefault_LeavesString()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("\"Widget in a string\"", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenameInStrings_On_RewritesString()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", renameInStrings: true);
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("\"Sprocket in a string\"", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task RenameOverloads_On_RenamesAllOverloadsAndCallSites()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget.Compute", "Calculate");
+        var after = ApplyEditsToSource(BasicSource, result.Edits, "Widget.cs");
+        Assert.Contains("public int Calculate(int value)", after, StringComparison.Ordinal);
+        Assert.Contains("public int Calculate(int a, int b)", after, StringComparison.Ordinal);
+        Assert.Contains(".Calculate(1)", after, StringComparison.Ordinal);
+        Assert.Empty(result.Conflicts);
+    }
 }

--- a/tests/RoslynCodeLens.Tests/RenameTestWorkspaceTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameTestWorkspaceTests.cs
@@ -1,0 +1,18 @@
+using RoslynCodeLens.Tests.Fixtures;
+
+namespace RoslynCodeLens.Tests;
+
+public class RenameTestWorkspaceTests
+{
+    [Fact]
+    public void Create_ResolvesTypeFromSource()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("Widget.cs", "namespace Demo; public class Widget { }"));
+
+        Assert.False(loaded.IsEmpty);
+        var symbols = resolver.FindSymbols("Widget");
+        Assert.Single(symbols);
+        Assert.Equal("Demo.Widget", symbols[0].ToDisplayString());
+    }
+}


### PR DESCRIPTION
## Summary
- New `rename_symbol` MCP tool: safe solution-wide rename of types and members via `Renamer.RenameSymbolAsync` — name-based addressing (same contract as `find_references`), preview-by-default, options for overloads/strings/comments
- Diagnostics-delta safety check: compiler errors introduced by the rename are returned as `Conflicts`; apply mode refuses to write on conflicts unless `force=true`
- Extracted `SolutionChangeWriter` from `CodeActionRunner` so `apply_code_action` and `rename_symbol` share one diff/write path
- Docs: SKILL.md coverage for the new tool; BACKLOG.md gains a SharpLensMcp gap-analysis section (this tool is its first item); design + implementation plan in `docs/plans/`

Origin: gap analysis vs sharplens-mcp — rename is not a Roslyn code action, so `apply_code_action` could never do it and agents fell back to multi-file text edits.

## Test Plan
- [x] 20 new tests (17 logic via isolated `AdhocWorkspace` helper, 1 helper smoke, 1 multi-project fixture integration, 1 workspace smoke) — all green
- [x] Full suite: 639/639 pass
- [x] `apply_code_action` regression net green after the `SolutionChangeWriter` extraction
- [x] Fixture-pristine check: preview-only integration test leaves `tests/RoslynCodeLens.Tests/Fixtures/` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)