### PR TITLE
fix: harden rename_symbol — conflict gate, write safety, snapshot commit, generic lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 57 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 58 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -38,7 +38,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 ### High value
 
-- 🔧 **In flight: `rename_symbol`** — solution-wide safe rename via the Roslyn `Renamer` API. Rename is *not* a code action, so `apply_code_action` cannot do it; today an agent renaming a symbol falls back to multi-file text edits — exactly the failure mode this server exists to prevent. Design: [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
+- ✅ **`rename_symbol`** — *shipped* (PR #298; review-findings hardening in [docs/plans/2026-07-19-rename-review-fixes.md](plans/2026-07-19-rename-review-fixes.md)). Design: [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
 - **`resolve_stack_trace`** — map a pasted runtime stack trace to file/line/symbol, undoing name mangling (async state machines, lambdas, generics, `<>c__DisplayClass`). Perfect fit for debugging workflows; nothing comparable today.
 - **`get_method_source` / `get_method_source_batch`** — return a method's source body by name. `analyze_method` gives signature + callers but not the body, so agents still `Read` whole files. Batch variant is very token-efficient.
 - **Reference kind classification on `find_references`** — tag each reference as read/write/invocation/cast/typeof/nameof/attribute, with an optional `kind` filter. Enhancement to the existing tool, not a new one; also subsumes a would-be `find_pattern_usages` (is/as/pattern-match sites).
@@ -59,7 +59,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 Active branches with no merged PR yet.
 
-- **`rename_symbol`** — branch `feature/rename-symbol`, design [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
+_(none currently)_
 
 ---
 
@@ -69,6 +69,7 @@ Items previously in this backlog, now merged. Listed for orientation; do not re-
 
 | Tool | Theme | PR |
 |---|---|---|
+| `rename_symbol` | Refactoring | #298 |
 | `find_tests_for_symbol` | Test-aware | #116 |
 | `find_uncovered_symbols` | Test-aware | #124 |
 | `get_test_summary` | Test-aware | #152 |

--- a/docs/plans/2026-07-19-rename-review-fixes.md
+++ b/docs/plans/2026-07-19-rename-review-fixes.md
@@ -1,0 +1,44 @@
+# rename_symbol Review-Findings Fix Plan
+
+Date: 2026-07-19. Fixes the 10 findings from the post-merge high-effort review of PR #298 (merged as 74b8024). Branch `fix/rename-symbol-review-findings`. Executed as four work packages; TDD throughout.
+
+## Findings → fixes
+
+| # | Finding | Fix | Package |
+|---|---|---|---|
+| 1 | Apply overwrites files from stale snapshot, no lock vs watcher rebuild | On-disk freshness precheck (snapshot text vs current disk text) before writing; abort with per-file conflict list on mismatch | W2 |
+| 2 | `DiagnosticKey` Id\|Path\|Message wrong both directions | Count-based multiset diff keyed `(Id, FilePath)` — message drift irrelevant, count increase catches same-message-new-line | W1 |
+| 3 | Degraded load → silent incomplete rename | Refuse apply when `loaded.Degraded` unless `force`; warn in preview `Message` | W2 |
+| 4 | Non-atomic multi-file write; cancel can truncate a file | Write temp file + `File.Move(overwrite)` per doc; on any failure restore all already-written originals (captured up front) | W2 |
+| 5 | Post-apply staleness ≥ debounce window; renamed Solution discarded | After successful write, commit the renamed solution in-memory: update documents in place (`WithDocumentText`) + refresh cached compilations via the manager, so immediate queries see new text | W2 |
+| 6 | `Data.Repository` misses generic `Data.Repository<T>` | Secondary lookup keyed on generic-arity-stripped full name in `SymbolResolver.BuildTypeLookups`; dotted branch falls back to it (multiple arities → multiple matches → existing ambiguity path) | W3 |
+| 7 | Conflict scan misses textually-unchanged downstream projects | Scan changed projects ∪ their direct dependents (via `solution.GetProjectDependencyGraph().GetProjectsThatDirectlyDependOnThisProject`) | W1 |
+| 8 | Encoding/BOM rewritten (UTF-8 no BOM always) | Preserve original document's `SourceText.Encoding` when writing; fallback UTF-8-no-BOM only when null | W2 |
+| 9 | Conflict check recompiles old projects, whole-compilation diagnostics, sequential | Use `LoadedSolution.Compilations` cache for the before side; `Task.WhenAll` old/new per project and across projects (bounded); align suppressed-diagnostic policy with `GetDiagnosticsLogic` (`IsSuppressed` skipped) | W1 |
+| 10 | CLAUDE.md "57 tools" stale; BACKLOG in-flight entry stale | CLAUDE.md → 58; BACKLOG: move rename_symbol to Recently shipped (PR #298), drop in-flight entry, note this fix branch | W4 |
+
+## Package details
+
+### W1 — Conflict gate (`RenameSymbolLogic.ComputeConflictsAsync`)
+- New algorithm per scanned project: `before` = cached compilation (fallback `GetCompilationAsync`), `after` = forked project compilation; both diagnostics passes concurrent. Errors only, `!IsSuppressed`.
+- Multiset diff: group each side by `(Id, NormalizedPath)`; for groups where `afterCount > beforeCount`, report `afterCount - beforeCount` diagnostics from the after side (prefer ones whose line is not present in the before group).
+- Scan set: `GetProjectChanges()` projects ∪ direct dependents of those (deduped). Dependents use whole-compilation diagnostics (their trees didn't change).
+- Tests (AdhocWorkspace, two-project where needed): message-embeds-old-name no longer reported as conflict; same-Id-same-file-new-line collision IS reported; dependent-project break detected (multi-project workspace, project B referencing renamed A); suppressed diagnostics ignored.
+
+### W2 — Write path (`SolutionChangeWriter`, `RenameSymbolLogic`, manager commit)
+- `WriteChangesToDiskAsync` → returns a write report; per changed doc: read original doc's `SourceText` (encoding), verify current on-disk bytes/text still match the snapshot original (`File.ReadAllText` compare; missing file counts as mismatch) → collect mismatches and abort before writing anything if any; then write via temp file in same directory + `File.Move(temp, target, overwrite: true)`; on exception mid-loop restore every already-replaced file from its captured original text and rethrow with context.
+- Encoding: `originalText.Encoding ?? changedText.Encoding ?? new UTF8Encoding(false)`.
+- Post-write commit: new manager API (e.g. `SolutionManager.CommitDocumentTexts(IReadOnlyList<(DocumentId, SourceText)>)` exposed through `MultiSolutionManager`) that in-place-updates `_loaded.Solution`/`Compilations` under the same serialization the watcher rebuild uses (follow the #282/#288 in-place `WithDocumentText` pattern already in `SolutionManager`). rename_symbol calls it after a successful disk write; apply_code_action keeps current behavior (its window is small; wiring it up can follow).
+- Degraded guard in `ExecuteAsync`: preview → prepend warning w/ `LoadDiagnostics` count to `Message`; apply without `force` → refuse (`Success=false`) telling the user why.
+- Tests: freshness mismatch aborts without writing; failure mid-batch restores originals (simulate via read-only file); encoding preserved (UTF-8 BOM fixture file round-trips with BOM); post-commit immediate `FindSymbols`/references on the updated LoadedSolution sees the new name (unit-level via manager test seam); degraded refusal (LoadedSolution with LoadDiagnostics).
+- Keep `apply_code_action` green (it shares the writer; its callers adapt to the new return/abort semantics — behavior for clean disk state must be unchanged).
+
+### W3 — Resolver generic lookup (`SymbolResolver`)
+- `BuildTypeLookups`: additional `Dictionary<string, List<INamedTypeSymbol>>` keyed by full display name with generic args stripped per segment (`Data.Repository<T>` → `Data.Repository`; nested `Outer<T>.Inner` → `Outer.Inner`). Dotted branch of `FindNamedTypes`: exact `_typesByFullName` first, then stripped-name dict.
+- Tests: `FindSymbols("Data.Repository")` finds `Repository<T>`; two arities (`Repository<T>`, `Repository<T1,T2>`) → both returned (rename then reports AmbiguousMatch listing both); member lookup `Data.Repository.GetById` resolves; non-generic behavior unchanged.
+
+### W4 — Docs + verification
+- CLAUDE.md: "57" → "58 code intelligence tools".
+- BACKLOG.md: remove in-flight entry; §5 bullet 🔧 → ✅ shipped PR #298; add row to Recently shipped table (`rename_symbol` | Refactoring | #298).
+- SKILL.md: no change needed unless W1/W2 alters tool-visible behavior descriptions (degraded refusal + freshness abort → extend the rename_symbol bullet's one-liner).
+- Full `dotnet build` + `dotnet test` green; fixture-pristine check.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -200,7 +200,7 @@ Inspect an arbitrary DLL           → add a <ProjectReference> to a throwaway
 Solutions passed on the CLI at server startup are auto-trusted in session scope — `get_diagnostics(includeAnalyzers=true)` against them works without an extra prompt.
 - `get_code_actions` — all refactorings/fixes at a position (with optional range).
 - `apply_code_action` — execute a refactoring by title. Preview mode by default.
-- `rename_symbol` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via `apply_code_action`). Preview by default; new-compiler-error conflicts reported; apply refuses on conflicts unless `force=true`.
+- `rename_symbol` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via `apply_code_action`). Preview by default; new-compiler-error conflicts reported; apply refuses unless `force=true` on: conflicts, a degraded solution load, or files changed on disk since the snapshot (freshness refusal — run `rebuild_solution` and retry; `force` does not bypass freshness). After apply the in-memory snapshot updates immediately — follow-up queries see the new name without waiting for a rebuild. Generic types accept the arity-free qualified form (`Data.Repository` finds `Repository<T>`).
 - `analyze_data_flow` — variable lifecycle over a statement range (declared/read/written/captured/flows-in/out).
 - `analyze_control_flow` — reachability, returns, unreachable paths.
 

--- a/src/RoslynCodeLens/CodeActionRunner.cs
+++ b/src/RoslynCodeLens/CodeActionRunner.cs
@@ -61,7 +61,13 @@ public static class CodeActionRunner
 
             if (!preview)
             {
-                await SolutionChangeWriter.WriteChangesToDiskAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+                var write = await SolutionChangeWriter.WriteChangesToDiskAsync(applyOp.ChangedSolution, project.Solution, ct).ConfigureAwait(false);
+                if (!write.Written)
+                {
+                    return new CodeActionResult(false, matchedAction.Title, edits,
+                        $"Refused to write: {write.StaleFiles.Count} file(s) changed on disk after the solution snapshot was loaded: " +
+                        $"{string.Join(", ", write.StaleFiles)}. Run rebuild_solution and retry.");
+                }
             }
 
             return new CodeActionResult(true, matchedAction.Title, edits);

--- a/src/RoslynCodeLens/MultiSolutionManager.cs
+++ b/src/RoslynCodeLens/MultiSolutionManager.cs
@@ -86,6 +86,16 @@ public sealed class MultiSolutionManager : IDisposable
     public Task WaitForWarmupAsync() => Active.WaitForWarmupAsync();
     public Task<(int ProjectCount, TimeSpan Elapsed)> ForceReloadAsync() => Active.ForceReloadAsync();
 
+    /// <summary>
+    /// Commits already-written document texts to the active solution's in-memory snapshot
+    /// immediately (bypassing the file watcher's debounce). See
+    /// <see cref="SolutionManager.CommitDocumentTextsAsync"/>.
+    /// </summary>
+    public Task CommitDocumentTextsAsync(
+        IReadOnlyList<(Microsoft.CodeAnalysis.DocumentId Id, Microsoft.CodeAnalysis.Text.SourceText Text)> documents,
+        CancellationToken ct = default)
+        => Active.CommitDocumentTextsAsync(documents, ct);
+
     public IReadOnlyList<SolutionInfo> ListSolutions()
     {
         string? activeKey;

--- a/src/RoslynCodeLens/SolutionChangeWriter.cs
+++ b/src/RoslynCodeLens/SolutionChangeWriter.cs
@@ -99,8 +99,11 @@ public static class SolutionChangeWriter
     }
 
     /// <summary>One pending file write: target path, new content, encoding to write with, and the
-    /// pre-write on-disk bytes for rollback (null for added documents that had no file).</summary>
-    private sealed record WritePlan(
+    /// pre-write on-disk bytes for rollback (null for added documents that had no file).
+    /// Internal (with <see cref="WriteAllWithRollback"/>) so tests can exercise the rollback
+    /// path deterministically — after the freshness precheck, a mid-batch failure is only
+    /// reachable through platform-dependent races at the public API level.</summary>
+    internal sealed record WritePlan(
         string FilePath, DocumentId DocumentId, SourceText NewText,
         Encoding Encoding, byte[]? OriginalBytes);
 
@@ -211,7 +214,7 @@ public static class SolutionChangeWriter
     /// deleted, so the batch either fully applies or leaves the tree as it was. Cancellation
     /// DURING a temp-file write is harmless for that file: its target hasn't been touched yet.
     /// </summary>
-    private static void WriteAllWithRollback(List<WritePlan> plans, CancellationToken ct)
+    internal static void WriteAllWithRollback(List<WritePlan> plans, CancellationToken ct)
     {
         var replaced = new List<WritePlan>();
         string? tempPath = null;

--- a/src/RoslynCodeLens/SolutionChangeWriter.cs
+++ b/src/RoslynCodeLens/SolutionChangeWriter.cs
@@ -1,7 +1,21 @@
+using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using RoslynCodeLens.Models;
 
 namespace RoslynCodeLens;
+
+/// <summary>
+/// Outcome of <see cref="SolutionChangeWriter.WriteChangesToDiskAsync"/>. Either the batch was
+/// refused because files changed on disk after the solution snapshot was taken (<see cref="Written"/>
+/// false, <see cref="StaleFiles"/> lists the offenders and nothing was touched), or every document
+/// was written and <see cref="Documents"/> lists the written (id, text) pairs so callers can commit
+/// them to the in-memory solution.
+/// </summary>
+public sealed record SolutionWriteResult(
+    bool Written,
+    IReadOnlyList<string> StaleFiles,
+    IReadOnlyList<(DocumentId Id, SourceText Text)> Documents);
 
 /// <summary>
 /// Shared write path for tools that produce a changed Solution (apply_code_action,
@@ -55,18 +69,71 @@ public static class SolutionChangeWriter
         return edits;
     }
 
-    public static async Task WriteChangesToDiskAsync(
+    /// <summary>
+    /// Writes every changed/added document to disk as one guarded batch:
+    /// <list type="number">
+    /// <item>Freshness precheck (finding 1): each target's current on-disk content must still match
+    /// the snapshot text the edit was computed from. Any mismatch — or a missing/unreadable file —
+    /// aborts the whole batch before anything is written, returning the stale paths.</item>
+    /// <item>Atomic-ish write with rollback (finding 4): texts go to a same-directory temp file
+    /// first, then replace the target via <see cref="File.Move(string, string, bool)"/>; any
+    /// mid-batch failure (including cancellation between files) restores every already-replaced
+    /// file from bytes captured during the precheck.</item>
+    /// <item>Encoding preservation (finding 8): each write uses the original document's
+    /// SourceText.Encoding (falling back to the changed text's encoding, then UTF-8 without BOM),
+    /// so BOM presence and charset follow what was on disk.</item>
+    /// </list>
+    /// </summary>
+    public static async Task<SolutionWriteResult> WriteChangesToDiskAsync(
         Solution changedSolution, Solution originalSolution, CancellationToken ct)
     {
+        var (plans, staleFiles) = await BuildWritePlansAsync(
+            changedSolution, originalSolution, ct).ConfigureAwait(false);
+
+        if (staleFiles.Count > 0)
+            return new SolutionWriteResult(false, staleFiles, []);
+
+        WriteAllWithRollback(plans, ct);
+        return new SolutionWriteResult(true, [],
+            plans.Select(p => (p.DocumentId, p.NewText)).ToList());
+    }
+
+    /// <summary>One pending file write: target path, new content, encoding to write with, and the
+    /// pre-write on-disk bytes for rollback (null for added documents that had no file).</summary>
+    private sealed record WritePlan(
+        string FilePath, DocumentId DocumentId, SourceText NewText,
+        Encoding Encoding, byte[]? OriginalBytes);
+
+    private static async Task<(List<WritePlan> Plans, List<string> StaleFiles)> BuildWritePlansAsync(
+        Solution changedSolution, Solution originalSolution, CancellationToken ct)
+    {
+        var plans = new List<WritePlan>();
+        var staleFiles = new List<string>();
+
         foreach (var projectChange in changedSolution.GetChanges(originalSolution).GetProjectChanges())
         {
             foreach (var changedDocId in projectChange.GetChangedDocuments())
             {
+                var originalDoc = originalSolution.GetDocument(changedDocId);
                 var changedDoc = changedSolution.GetDocument(changedDocId);
-                if (changedDoc?.FilePath == null) continue;
+                if (originalDoc?.FilePath == null || changedDoc == null) continue;
 
-                var text = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                await File.WriteAllTextAsync(changedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
+                var originalText = await originalDoc.GetTextAsync(ct).ConfigureAwait(false);
+                var changedText = await changedDoc.GetTextAsync(ct).ConfigureAwait(false);
+
+                // Read the current bytes once: they serve both the freshness comparison and,
+                // if the batch later fails, a byte-exact rollback restore.
+                var currentBytes = await TryReadAllBytesAsync(originalDoc.FilePath, ct).ConfigureAwait(false);
+                if (currentBytes == null || !MatchesSnapshot(currentBytes, originalText))
+                {
+                    staleFiles.Add(originalDoc.FilePath);
+                    continue;
+                }
+
+                plans.Add(new WritePlan(
+                    originalDoc.FilePath, changedDocId, changedText,
+                    originalText.Encoding ?? changedText.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    currentBytes));
             }
 
             foreach (var addedDocId in projectChange.GetAddedDocuments())
@@ -74,12 +141,148 @@ public static class SolutionChangeWriter
                 var addedDoc = changedSolution.GetDocument(addedDocId);
                 if (addedDoc?.FilePath == null) continue;
 
-                var dir = Path.GetDirectoryName(addedDoc.FilePath);
-                if (dir != null) Directory.CreateDirectory(dir);
+                // An added document has no snapshot original: any file already at its path is
+                // content the snapshot doesn't know about, so writing would clobber it — stale.
+                if (File.Exists(addedDoc.FilePath))
+                {
+                    staleFiles.Add(addedDoc.FilePath);
+                    continue;
+                }
 
                 var text = await addedDoc.GetTextAsync(ct).ConfigureAwait(false);
-                await File.WriteAllTextAsync(addedDoc.FilePath, text.ToString(), ct).ConfigureAwait(false);
+                plans.Add(new WritePlan(
+                    addedDoc.FilePath, addedDocId, text,
+                    text.Encoding ?? new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    OriginalBytes: null));
             }
         }
+
+        return (plans, staleFiles);
+    }
+
+    /// <summary>
+    /// Freshness comparison semantics: the snapshot text was itself loaded from this file
+    /// (MSBuildWorkspace's file loader and the incremental rebuild both use
+    /// SourceText.From(stream), which preserves line endings exactly), so an ordinal
+    /// comparison would normally suffice. Newlines are still normalized on both sides first
+    /// so that a line-ending-only divergence (a git autocrlf checkout or an editor EOL
+    /// conversion between load and apply — plausible on Windows) doesn't spuriously veto
+    /// every write: EOL drift alone is not the "someone edited this file" conflict this
+    /// check exists to catch, and overwriting it with snapshot-derived text is acceptable.
+    /// </summary>
+    private static bool MatchesSnapshot(byte[] currentBytes, SourceText snapshotText)
+    {
+        using var reader = new StreamReader(
+            new MemoryStream(currentBytes), Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        var diskText = reader.ReadToEnd();
+        return string.Equals(
+            NormalizeNewlines(diskText),
+            NormalizeNewlines(snapshotText.ToString()),
+            StringComparison.Ordinal);
+    }
+
+    private static string NormalizeNewlines(string text)
+        => text.Replace("\r\n", "\n", StringComparison.Ordinal)
+               .Replace("\r", "\n", StringComparison.Ordinal);
+
+    private static async Task<byte[]?> TryReadAllBytesAsync(string path, CancellationToken ct)
+    {
+        try
+        {
+            return await File.ReadAllBytesAsync(path, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Missing (FileNotFound/DirectoryNotFound) or unreadable: freshness cannot be
+            // verified, so the file counts as stale and the batch aborts untouched.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Atomic-ish batch write: each text is written to a temp file in the target's directory,
+    /// then moved over the target (a same-volume rename, so a crash cannot leave a half-written
+    /// target). On any mid-batch failure — including cancellation between files — every
+    /// already-replaced target is restored from its precheck-captured bytes and the temp file is
+    /// deleted, so the batch either fully applies or leaves the tree as it was. Cancellation
+    /// DURING a temp-file write is harmless for that file: its target hasn't been touched yet.
+    /// </summary>
+    private static void WriteAllWithRollback(List<WritePlan> plans, CancellationToken ct)
+    {
+        var replaced = new List<WritePlan>();
+        string? tempPath = null;
+        string? failedFile = null;
+        try
+        {
+            foreach (var plan in plans)
+            {
+                ct.ThrowIfCancellationRequested();
+                failedFile = plan.FilePath;
+
+                var dir = Path.GetDirectoryName(plan.FilePath);
+                if (!string.IsNullOrEmpty(dir))
+                    Directory.CreateDirectory(dir);
+
+                tempPath = plan.FilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+                using (var writer = new StreamWriter(tempPath, append: false, plan.Encoding))
+                    plan.NewText.Write(writer, ct);
+
+                File.Move(tempPath, plan.FilePath, overwrite: true);
+                tempPath = null;
+                replaced.Add(plan);
+            }
+        }
+        catch (Exception ex)
+        {
+            var rollbackFailures = RollBack(replaced, tempPath);
+            var rollbackNote = rollbackFailures.Count == 0
+                ? $"All {replaced.Count} previously written file(s) were rolled back; no changes remain on disk."
+                : $"ROLLBACK INCOMPLETE — these files could not be restored: {string.Join(", ", rollbackFailures)}.";
+
+            if (ex is OperationCanceledException)
+            {
+                throw new OperationCanceledException(
+                    $"Write batch cancelled at '{failedFile}'. {rollbackNote}", ex, ct);
+            }
+
+            throw new IOException(
+                $"Failed writing '{failedFile}': {ex.Message} {rollbackNote}", ex);
+        }
+    }
+
+    /// <summary>Best-effort restore of already-replaced targets (and removal of a leftover temp
+    /// file). Returns the paths that could not be restored; never throws.</summary>
+    private static List<string> RollBack(List<WritePlan> replaced, string? tempPath)
+    {
+        var failures = new List<string>();
+
+        if (tempPath != null)
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch (IOException) { failures.Add(tempPath); }
+            catch (UnauthorizedAccessException) { failures.Add(tempPath); }
+        }
+
+        foreach (var plan in replaced)
+        {
+            try
+            {
+                if (plan.OriginalBytes != null)
+                    File.WriteAllBytes(plan.FilePath, plan.OriginalBytes);
+                else
+                    File.Delete(plan.FilePath);   // added document — nothing existed before
+            }
+            catch (IOException) { failures.Add(plan.FilePath); }
+            catch (UnauthorizedAccessException) { failures.Add(plan.FilePath); }
+        }
+
+        return failures;
     }
 }

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -280,6 +280,71 @@ public sealed class SolutionManager : IDisposable
                 solution = solution.WithDocumentText(docId, text);
         }
 
+        await RecompileAndSwapAsync(solution, staleIds).ConfigureAwait(false);
+
+        await Console.Error.WriteLineAsync("[roslyn-codelens] Rebuild complete (incremental).").ConfigureAwait(false);
+        return true;
+    }
+
+    /// <summary>
+    /// Commits already-written document texts to the in-memory snapshot immediately, so queries
+    /// issued right after a tool wrote files (rename_symbol apply) see the new text instead of
+    /// waiting out the file watcher's debounce window. Serialized with the watcher auto-rebuild
+    /// and ForceReloadAsync via <see cref="_rebuildGate"/> (waits, like ForceReloadAsync does),
+    /// then reuses the incremental-rebuild core: <c>WithDocumentText</c> per document, recompile
+    /// the changed projects plus their transitive dependents (mirroring the watcher's
+    /// transitive staleness), swap the snapshot, and re-map the tracker. Document ids that no
+    /// longer exist (a full reload swapped in fresh ids mid-flight) are skipped — that reload
+    /// already read the committed text from disk.
+    /// </summary>
+    public async Task CommitDocumentTextsAsync(
+        IReadOnlyList<(DocumentId Id, Microsoft.CodeAnalysis.Text.SourceText Text)> documents,
+        CancellationToken ct = default)
+    {
+        if (documents.Count == 0)
+            return;
+
+        await _rebuildGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var solution = _loaded.Solution;
+            var changedProjects = new HashSet<ProjectId>();
+            foreach (var (docId, text) in documents)
+            {
+                if (solution.GetDocument(docId) == null)
+                    continue;
+                solution = solution.WithDocumentText(docId, text);
+                changedProjects.Add(docId.ProjectId);
+            }
+
+            if (changedProjects.Count == 0)
+                return;
+
+            var staleIds = new HashSet<ProjectId>(changedProjects);
+            var graph = solution.GetProjectDependencyGraph();
+            foreach (var projectId in changedProjects)
+                staleIds.UnionWith(graph.GetProjectsThatTransitivelyDependOnThisProject(projectId));
+
+            await RecompileAndSwapAsync(solution, staleIds).ConfigureAwait(false);
+            await Console.Error.WriteLineAsync(
+                $"[roslyn-codelens] Committed {documents.Count} written document(s) to the in-memory snapshot.")
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            _rebuildGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Shared tail of the in-place update paths (#282 pattern): recompiles the stale projects of
+    /// an already-updated solution fork (unchanged projects keep their carried-over compilations,
+    /// preserving symbol identity), swaps in the new LoadedSolution + resolvers under
+    /// <see cref="_lock"/>, and re-maps the tracker so future edits resolve against the new
+    /// authoritative snapshot. Callers must hold <see cref="_rebuildGate"/>.
+    /// </summary>
+    private async Task RecompileAndSwapAsync(Solution solution, IReadOnlySet<ProjectId> staleIds)
+    {
         var compilations = new ConcurrentDictionary<ProjectId, Compilation>(_loaded.Compilations);
         var staleProjects = solution.Projects.Where(p => staleIds.Contains(p.Id)).ToList();
         var tasks = staleProjects.Select(async project =>
@@ -310,10 +375,7 @@ public sealed class SolutionManager : IDisposable
 
         // Re-map file->project/document lookups against the new snapshot. Ids are preserved,
         // but a fresh snapshot instance is now authoritative and future edits resolve against it.
-        _tracker!.UpdateMappings(newLoaded);
-
-        await Console.Error.WriteLineAsync("[roslyn-codelens] Rebuild complete (incremental).").ConfigureAwait(false);
-        return true;
+        _tracker?.UpdateMappings(newLoaded);
     }
 
     /// <summary>

--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -9,6 +9,7 @@ public class SymbolResolver
     private readonly List<INamedTypeSymbol> _allTypes;
     private readonly Dictionary<string, List<INamedTypeSymbol>> _typesBySimpleName;
     private readonly Dictionary<string, INamedTypeSymbol> _typesByFullName;
+    private readonly Dictionary<string, List<INamedTypeSymbol>> _typesByStrippedFullName;
     private readonly Dictionary<string, string> _fileToProjectName;
     private readonly Dictionary<ProjectId, string> _projectIdToName;
     private readonly Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> _interfaceImplementors;
@@ -20,7 +21,7 @@ public class SymbolResolver
     public SymbolResolver(LoadedSolution loaded)
     {
         _allTypes = CollectAllTypes(loaded);
-        (_typesBySimpleName, _typesByFullName) = BuildTypeLookups(_allTypes);
+        (_typesBySimpleName, _typesByFullName, _typesByStrippedFullName) = BuildTypeLookups(_allTypes);
         (_fileToProjectName, _projectIdToName) = BuildProjectLookups(loaded);
         (_interfaceImplementors, _derivedTypes) = BuildInheritanceMaps(_allTypes);
 
@@ -48,15 +49,42 @@ public class SymbolResolver
         return allTypes;
     }
 
-    private static (Dictionary<string, List<INamedTypeSymbol>>, Dictionary<string, INamedTypeSymbol>)
+    /// <summary>
+    /// Fully qualified name without generic type parameters: renders
+    /// "Data.Repository&lt;T&gt;" as "Data.Repository" and nested
+    /// "Ns.Outer&lt;T&gt;.Inner" as "Ns.Outer.Inner".
+    /// </summary>
+    private static readonly SymbolDisplayFormat StrippedGenericsFormat = new(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+        genericsOptions: SymbolDisplayGenericsOptions.None);
+
+    private static (Dictionary<string, List<INamedTypeSymbol>>, Dictionary<string, INamedTypeSymbol>,
+                     Dictionary<string, List<INamedTypeSymbol>>)
         BuildTypeLookups(List<INamedTypeSymbol> allTypes)
     {
         var bySimple = new Dictionary<string, List<INamedTypeSymbol>>(StringComparer.Ordinal);
         var byFull = new Dictionary<string, INamedTypeSymbol>(StringComparer.Ordinal);
+        var byStripped = new Dictionary<string, List<INamedTypeSymbol>>(StringComparer.Ordinal);
 
         foreach (ref readonly var type in CollectionsMarshal.AsSpan(allTypes))
         {
-            byFull[type.ToDisplayString()] = type;
+            var fullName = type.ToDisplayString();
+            byFull[fullName] = type;
+
+            // Generic types display with their type parameters ("Data.Repository<T>"),
+            // so the documented qualified form "Data.Repository" misses byFull. Index
+            // them under the arity-stripped name too; multiple arities share a key and
+            // surface as multiple matches for the caller's ambiguity handling.
+            var strippedName = type.ToDisplayString(StrippedGenericsFormat);
+            if (!string.Equals(strippedName, fullName, StringComparison.Ordinal))
+            {
+                if (!byStripped.TryGetValue(strippedName, out var strippedList))
+                {
+                    strippedList = new List<INamedTypeSymbol>();
+                    byStripped[strippedName] = strippedList;
+                }
+                strippedList.Add(type);
+            }
 
             if (!bySimple.TryGetValue(type.Name, out var list))
             {
@@ -66,7 +94,7 @@ public class SymbolResolver
             list.Add(type);
         }
 
-        return (bySimple, byFull);
+        return (bySimple, byFull, byStripped);
     }
 
     private static (Dictionary<string, string>, Dictionary<ProjectId, string>)
@@ -206,8 +234,13 @@ public class SymbolResolver
     {
         if (symbol.Contains('.', StringComparison.Ordinal))
         {
-            return _typesByFullName.TryGetValue(symbol, out var type)
-                ? [type]
+            if (_typesByFullName.TryGetValue(symbol, out var type))
+                return [type];
+
+            // Fall back to the arity-stripped index so the documented qualified form
+            // ("Data.Repository") reaches generic types ("Data.Repository<T>").
+            return _typesByStrippedFullName.TryGetValue(symbol, out var strippedMatches)
+                ? strippedMatches
                 : [];
         }
 

--- a/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
@@ -33,7 +33,7 @@ public static class RenameSymbolLogic
 
         var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
             renamed, loaded.Solution, ct).ConfigureAwait(false);
-        var conflicts = await ComputeConflictsAsync(loaded.Solution, renamed, ct).ConfigureAwait(false);
+        var conflicts = await ComputeConflictsAsync(loaded, renamed, ct).ConfigureAwait(false);
         var filesChanged = edits.Select(e => e.FilePath)
             .Distinct(StringComparer.OrdinalIgnoreCase).Count();
         var oldName = target.ToDisplayString();
@@ -106,27 +106,113 @@ public static class RenameSymbolLogic
     }
 
     private static async Task<IReadOnlyList<RenameConflict>> ComputeConflictsAsync(
-        Solution original, Solution renamed, CancellationToken ct)
+        LoadedSolution loaded, Solution renamed, CancellationToken ct)
     {
+        var original = loaded.Solution;
         var conflicts = new List<RenameConflict>();
-        foreach (var change in renamed.GetChanges(original).GetProjectChanges())
+        foreach (var projectId in ComputeScanSet(original, renamed))
         {
-            var before = await change.OldProject.GetCompilationAsync(ct).ConfigureAwait(false);
-            var after = await change.NewProject.GetCompilationAsync(ct).ConfigureAwait(false);
+            var afterProject = renamed.GetProject(projectId);
+            if (afterProject == null)
+                continue;
+
+            // Before side prefers the cached compilation (already built at load
+            // time); after side is the forked project. Both diagnostics passes
+            // are CPU-bound, so run them concurrently.
+            var beforeTask = Task.Run(async () =>
+            {
+                if (!loaded.Compilations.TryGetValue(projectId, out var compilation))
+                {
+                    compilation = await original.GetProject(projectId)!
+                        .GetCompilationAsync(ct).ConfigureAwait(false);
+                }
+                return compilation?.GetDiagnostics(ct);
+            }, ct);
+            var afterTask = Task.Run(async () =>
+            {
+                var compilation = await afterProject.GetCompilationAsync(ct).ConfigureAwait(false);
+                return compilation?.GetDiagnostics(ct);
+            }, ct);
+            await Task.WhenAll(beforeTask, afterTask).ConfigureAwait(false);
+
+            var before = await beforeTask.ConfigureAwait(false);
+            var after = await afterTask.ConfigureAwait(false);
             if (before == null || after == null)
                 continue;
 
-            var beforeKeys = before.GetDiagnostics(ct)
-                .Where(d => d.Severity == DiagnosticSeverity.Error)
-                .Select(DiagnosticKey)
-                .ToHashSet(StringComparer.Ordinal);
+            conflicts.AddRange(DiffNewErrors(before, after));
+        }
+        return conflicts;
+    }
 
-            foreach (var diag in after.GetDiagnostics(ct)
-                         .Where(d => d.Severity == DiagnosticSeverity.Error))
+    /// <summary>
+    /// Projects to conflict-scan: those Renamer textually changed, plus their
+    /// direct dependents — a rename can break a downstream project without
+    /// touching its text (source generators, name-based lookup changes).
+    /// </summary>
+    internal static IReadOnlyList<ProjectId> ComputeScanSet(Solution original, Solution renamed)
+    {
+        var changed = renamed.GetChanges(original).GetProjectChanges()
+            .Select(c => c.ProjectId).ToList();
+        var graph = original.GetProjectDependencyGraph();
+
+        var seen = new HashSet<ProjectId>();
+        var scanSet = new List<ProjectId>();
+        foreach (var projectId in changed)
+        {
+            if (seen.Add(projectId))
+                scanSet.Add(projectId);
+        }
+        foreach (var projectId in changed)
+        {
+            foreach (var dependent in graph.GetProjectsThatDirectlyDependOnThisProject(projectId))
             {
-                if (beforeKeys.Contains(DiagnosticKey(diag)))
-                    continue;
+                if (seen.Add(dependent))
+                    scanSet.Add(dependent);
+            }
+        }
+        return scanSet;
+    }
 
+    /// <summary>
+    /// Multiset diff of error diagnostics keyed by (Id, FilePath) — messages play
+    /// no role, so pre-existing errors whose message embeds the renamed symbol
+    /// don't become phantom conflicts, and a new error that duplicates an existing
+    /// one's message still surfaces as a count increase. Suppressed diagnostics
+    /// are skipped, matching GetDiagnosticsLogic's policy.
+    /// </summary>
+    internal static List<RenameConflict> DiffNewErrors(
+        IEnumerable<Diagnostic> before, IEnumerable<Diagnostic> after)
+    {
+        static bool IsReportableError(Diagnostic d)
+            => d.Severity == DiagnosticSeverity.Error && !d.IsSuppressed;
+        static string Key(Diagnostic d)
+            => $"{d.Id}|{d.Location.GetLineSpan().Path}";
+        static int Line(Diagnostic d)
+            => d.Location.GetLineSpan().StartLinePosition.Line + 1;
+
+        var beforeGroups = before.Where(IsReportableError)
+            .GroupBy(Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var conflicts = new List<RenameConflict>();
+        foreach (var group in after.Where(IsReportableError)
+                     .GroupBy(Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var afterDiags = group.ToList();
+            var beforeCount = beforeGroups.TryGetValue(group.Key, out var beforeDiags)
+                ? beforeDiags.Count : 0;
+            var newCount = afterDiags.Count - beforeCount;
+            if (newCount <= 0)
+                continue;
+
+            // Prefer diagnostics on lines the before side didn't have — those are
+            // most likely the genuinely new ones; fall back to arbitrary members.
+            var beforeLines = beforeDiags?.Select(Line).ToHashSet() ?? [];
+            foreach (var diag in afterDiags
+                         .OrderBy(d => beforeLines.Contains(Line(d)) ? 1 : 0)
+                         .Take(newCount))
+            {
                 var span = diag.Location.GetLineSpan();
                 conflicts.Add(new RenameConflict(
                     diag.Id, diag.GetMessage(), span.Path,
@@ -135,7 +221,4 @@ public static class RenameSymbolLogic
         }
         return conflicts;
     }
-
-    private static string DiagnosticKey(Diagnostic d)
-        => $"{d.Id}|{d.Location.GetLineSpan().Path}|{d.GetMessage()}";
 }

--- a/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
@@ -1,17 +1,28 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
 using RoslynCodeLens.Models;
 
 namespace RoslynCodeLens.Tools;
 
 public static class RenameSymbolLogic
 {
+    /// <summary>
+    /// Optional post-write hook: receives exactly the (documentId, newText) pairs that were
+    /// written to disk so the caller can commit them to the in-memory solution snapshot
+    /// (see <see cref="SolutionManager.CommitDocumentTextsAsync"/>). Null when no manager is
+    /// available (unit tests) — the file watcher then picks the change up after its debounce.
+    /// </summary>
+    public delegate Task CommitWrittenDocuments(
+        IReadOnlyList<(DocumentId Id, SourceText Text)> documents, CancellationToken ct);
+
     public static async Task<RenameSymbolResult> ExecuteAsync(
         LoadedSolution loaded, SymbolResolver resolver,
         string symbol, string newName,
         bool renameOverloads, bool renameInStrings, bool renameInComments,
-        bool preview, bool force, CancellationToken ct)
+        bool preview, bool force,
+        CommitWrittenDocuments? commitToMemory, CancellationToken ct)
     {
         if (!SyntaxFacts.IsValidIdentifier(newName))
         {
@@ -21,6 +32,18 @@ public static class RenameSymbolLogic
 
         var target = ResolveSingleTarget(resolver, symbol);
         ValidateRenameTarget(target, symbol);
+
+        // Degraded guard (finding 3): a load with dropped references can make Renamer miss
+        // references entirely, silently producing an incomplete rename. Refuse to write in
+        // that state unless the user explicitly forces it; previews warn instead (below).
+        if (!preview && loaded.Degraded && !force)
+        {
+            return new RenameSymbolResult(false, target.ToDisplayString(), newName, Applied: false,
+                [], 0, [],
+                $"Refused to apply: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load " +
+                "diagnostic(s) — projects opened with dropped references), so the rename may be incomplete " +
+                "and silently miss references. Run rebuild_solution and retry, or re-run with force=true to apply anyway.");
+        }
 
         var options = new SymbolRenameOptions(
             RenameOverloads: renameOverloads,
@@ -40,11 +63,18 @@ public static class RenameSymbolLogic
 
         if (preview)
         {
+            var previewMessage = conflicts.Count > 0
+                ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
+                : "Preview only — no files written. Re-run with preview=false to apply.";
+            if (loaded.Degraded)
+            {
+                previewMessage =
+                    $"WARNING: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load diagnostic(s) — " +
+                    "projects opened with dropped references), so this rename may be incomplete and miss references. " +
+                    previewMessage;
+            }
             return new RenameSymbolResult(true, oldName, newName, Applied: false,
-                edits, filesChanged, conflicts,
-                conflicts.Count > 0
-                    ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
-                    : "Preview only — no files written. Re-run with preview=false to apply.");
+                edits, filesChanged, conflicts, previewMessage);
         }
 
         if (conflicts.Count > 0 && !force)
@@ -55,11 +85,40 @@ public static class RenameSymbolLogic
                 "Inspect Conflicts, or re-run with force=true to apply anyway.");
         }
 
-        await SolutionChangeWriter.WriteChangesToDiskAsync(
+        var write = await SolutionChangeWriter.WriteChangesToDiskAsync(
             renamed, loaded.Solution, ct).ConfigureAwait(false);
+        if (!write.Written)
+        {
+            // Freshness refusal (finding 1): something edited these files after the solution
+            // snapshot was taken — writing snapshot-derived text would clobber those edits.
+            return new RenameSymbolResult(false, oldName, newName, Applied: false,
+                edits, filesChanged, conflicts,
+                $"Refused to apply: {write.StaleFiles.Count} file(s) changed on disk after the solution " +
+                $"snapshot was taken: {string.Join(", ", write.StaleFiles)}. No files were written. " +
+                "Run rebuild_solution and retry.");
+        }
+
+        var message = $"Renamed {oldName} to {newName} in {filesChanged} file(s).";
+        if (commitToMemory != null && write.Documents.Count > 0)
+        {
+            // Post-write commit (finding 5): make the in-memory snapshot reflect the new text
+            // immediately instead of waiting out the file watcher's debounce window. A commit
+            // failure must not fail the rename — the files ARE renamed on disk; the watcher
+            // rebuild (or an explicit rebuild_solution) will converge shortly.
+            try
+            {
+                await commitToMemory(write.Documents, ct).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                message += " Warning: files were written, but refreshing the in-memory snapshot failed " +
+                    $"({ex.Message}); queries may briefly see stale text until the file watcher catches up, " +
+                    "or run rebuild_solution.";
+            }
+        }
+
         return new RenameSymbolResult(true, oldName, newName, Applied: true,
-            edits, filesChanged, conflicts,
-            $"Renamed {oldName} to {newName} in {filesChanged} file(s).");
+            edits, filesChanged, conflicts, message);
     }
 
     internal static ISymbol ResolveSingleTarget(SymbolResolver resolver, string symbol)

--- a/src/RoslynCodeLens/Tools/RenameSymbolTool.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolTool.cs
@@ -28,6 +28,9 @@ public static class RenameSymbolTool
         var context = manager.GetAnalysisContext();
         return await RenameSymbolLogic.ExecuteAsync(
             context.Loaded, context.Resolver, symbol, newName,
-            renameOverloads, renameInStrings, renameInComments, preview, force, ct).ConfigureAwait(false);
+            renameOverloads, renameInStrings, renameInComments, preview, force,
+            // After a successful apply, push the written texts into the in-memory snapshot so
+            // follow-up queries see the new name immediately (no watcher-debounce stale window).
+            manager.CommitDocumentTextsAsync, ct).ConfigureAwait(false);
     }
 }

--- a/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
@@ -6,38 +6,56 @@ using Microsoft.CodeAnalysis.Text;
 namespace RoslynCodeLens.Tests.Fixtures;
 
 /// <summary>
-/// Builds an in-memory single-project LoadedSolution + SymbolResolver from source
-/// strings. Pass absolute paths as file names when a test needs apply-mode disk writes.
+/// Builds an in-memory LoadedSolution + SymbolResolver from source strings.
+/// Pass absolute paths as file names when a test needs apply-mode disk writes.
+/// The multi-project overload adds projects in order, each referencing all
+/// earlier ones (ProjectReference), so later projects are downstream dependents.
 /// </summary>
 internal static class RenameTestWorkspace
 {
     public static (LoadedSolution Loaded, SymbolResolver Resolver) Create(
         params (string FilePath, string Source)[] files)
+        => Create(("RenameProj", files));
+
+    public static (LoadedSolution Loaded, SymbolResolver Resolver) Create(
+        params (string ProjectName, (string FilePath, string Source)[] Files)[] projects)
     {
         var workspace = new AdhocWorkspace();
-        var projectId = ProjectId.CreateNewId();
-        var projectInfo = ProjectInfo.Create(
-                projectId, VersionStamp.Create(), "RenameProj", "RenameProj", LanguageNames.CSharp,
-                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-            .WithMetadataReferences(
-                [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+        var solution = workspace.CurrentSolution;
+        var projectIds = new List<ProjectId>();
 
-        var solution = workspace.CurrentSolution.AddProject(projectInfo);
-        foreach (var (path, source) in files)
+        foreach (var (projectName, files) in projects)
         {
-            solution = solution.AddDocument(
-                DocumentId.CreateNewId(projectId), Path.GetFileName(path),
-                SourceText.From(source), filePath: path);
+            var projectId = ProjectId.CreateNewId();
+            var projectInfo = ProjectInfo.Create(
+                    projectId, VersionStamp.Create(), projectName, projectName, LanguageNames.CSharp,
+                    compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .WithMetadataReferences(
+                    [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)])
+                .WithProjectReferences(projectIds.Select(id => new ProjectReference(id)));
+
+            solution = solution.AddProject(projectInfo);
+            foreach (var (path, source) in files)
+            {
+                solution = solution.AddDocument(
+                    DocumentId.CreateNewId(projectId), Path.GetFileName(path),
+                    SourceText.From(source), filePath: path);
+            }
+
+            projectIds.Add(projectId);
         }
 
-        var compilation = solution.GetProject(projectId)!
-            .GetCompilationAsync().GetAwaiter().GetResult()!;
+        var compilations = new ConcurrentDictionary<ProjectId, Compilation>();
+        foreach (var projectId in projectIds)
+        {
+            compilations[projectId] = solution.GetProject(projectId)!
+                .GetCompilationAsync().GetAwaiter().GetResult()!;
+        }
 
         var loaded = new LoadedSolution
         {
             Solution = solution,
-            Compilations = new ConcurrentDictionary<ProjectId, Compilation>(
-                [new KeyValuePair<ProjectId, Compilation>(projectId, compilation)]),
+            Compilations = compilations,
         };
         return (loaded, new SymbolResolver(loaded));
     }

--- a/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
@@ -10,6 +10,10 @@ namespace RoslynCodeLens.Tests.Fixtures;
 /// Pass absolute paths as file names when a test needs apply-mode disk writes.
 /// The multi-project overload adds projects in order, each referencing all
 /// earlier ones (ProjectReference), so later projects are downstream dependents.
+/// <see cref="CreateFromDisk"/> loads document text from the files themselves via
+/// SourceText.From(stream) — capturing the on-disk encoding/BOM exactly the way
+/// MSBuildWorkspace's file loader does — for tests that exercise encoding
+/// preservation on the write path.
 /// </summary>
 internal static class RenameTestWorkspace
 {
@@ -19,6 +23,28 @@ internal static class RenameTestWorkspace
 
     public static (LoadedSolution Loaded, SymbolResolver Resolver) Create(
         params (string ProjectName, (string FilePath, string Source)[] Files)[] projects)
+        => CreateCore(projects
+            .Select(p => (p.ProjectName, p.Files
+                .Select(f => (f.FilePath, SourceText.From(f.Source)))
+                .ToArray()))
+            .ToArray());
+
+    /// <summary>
+    /// Single project whose documents are read from existing files on disk, so each
+    /// document's SourceText carries the detected encoding (incl. BOM presence).
+    /// </summary>
+    public static (LoadedSolution Loaded, SymbolResolver Resolver) CreateFromDisk(
+        params string[] filePaths)
+        => CreateCore(("RenameProj", filePaths
+            .Select(path =>
+            {
+                using var stream = File.OpenRead(path);
+                return (path, SourceText.From(stream));
+            })
+            .ToArray()));
+
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) CreateCore(
+        params (string ProjectName, (string FilePath, SourceText Text)[] Files)[] projects)
     {
         var workspace = new AdhocWorkspace();
         var solution = workspace.CurrentSolution;
@@ -35,11 +61,11 @@ internal static class RenameTestWorkspace
                 .WithProjectReferences(projectIds.Select(id => new ProjectReference(id)));
 
             solution = solution.AddProject(projectInfo);
-            foreach (var (path, source) in files)
+            foreach (var (path, text) in files)
             {
                 solution = solution.AddDocument(
                     DocumentId.CreateNewId(projectId), Path.GetFileName(path),
-                    SourceText.From(source), filePath: path);
+                    text, filePath: path);
             }
 
             projectIds.Add(projectId);

--- a/tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolFixtureTests.cs
@@ -16,7 +16,7 @@ public class RenameSymbolFixtureTests
         var result = await RenameSymbolLogic.ExecuteAsync(
             _fixture.Loaded, _fixture.Resolver, "Greeter", "Salutations",
             renameOverloads: true, renameInStrings: false, renameInComments: true,
-            preview: true, force: false, CancellationToken.None);
+            preview: true, force: false, commitToMemory: null, CancellationToken.None);
 
         Assert.True(result.Success);
         Assert.False(result.Applied);

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -114,6 +114,31 @@ public class RenameSymbolLogicTests
         Assert.True(result.Success);
     }
 
+    [Fact]
+    public async Task QualifiedNameWithoutTypeParameters_RenamesGenericType()
+    {
+        // Finding 6: "Data.Repository" must resolve Repository<T>, matching the tool's
+        // documented "fully qualified (Namespace.MyClass)" contract.
+        const string source = """
+            namespace Data;
+
+            public class Repository<T>
+            {
+                public T? GetById(int id) => default;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Repository.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "Data.Repository", "Store");
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.Equal("Data.Repository<T>", result.OldName);
+        var renamed = ApplyEditsToSource(source, result.Edits, "Repository.cs");
+        Assert.Contains("class Store<T>", renamed, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repository", renamed, StringComparison.Ordinal);
+    }
+
     private static string ApplyEditsToSource(string source, IEnumerable<TextEdit> edits, string filePath)
     {
         var text = Microsoft.CodeAnalysis.Text.SourceText.From(source);

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -31,11 +31,25 @@ public class RenameSymbolLogicTests
     private static Task<RenameSymbolResult> RunAsync(
         LoadedSolution loaded, SymbolResolver resolver, string symbol, string newName,
         bool renameOverloads = true, bool renameInStrings = false, bool renameInComments = true,
-        bool preview = true, bool force = false)
+        bool preview = true, bool force = false,
+        RenameSymbolLogic.CommitWrittenDocuments? commit = null)
         => RenameSymbolLogic.ExecuteAsync(
             loaded, resolver, symbol, newName,
             renameOverloads, renameInStrings, renameInComments, preview, force,
-            CancellationToken.None);
+            commit, CancellationToken.None);
+
+    /// <summary>Rewraps a workspace as a degraded load (non-empty LoadDiagnostics).</summary>
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) Degrade(
+        (LoadedSolution Loaded, SymbolResolver Resolver) workspace)
+    {
+        var degraded = new LoadedSolution
+        {
+            Solution = workspace.Loaded.Solution,
+            Compilations = workspace.Loaded.Compilations,
+            LoadDiagnostics = ["RenameProj: metadata reference 'Missing.dll' could not be resolved"],
+        };
+        return (degraded, new SymbolResolver(degraded));
+    }
 
     [Fact]
     public async Task InvalidIdentifier_ThrowsInvalidArgument()
@@ -395,6 +409,156 @@ public class RenameSymbolLogicTests
 
         var conflict = Assert.Single(RenameSymbolLogic.DiffNewErrors(before, after));
         Assert.Equal(7, conflict.Line);
+    }
+
+    [Fact]
+    public async Task Degraded_Preview_MessageCarriesWarning()
+    {
+        var (loaded, resolver) = Degrade(RenameTestWorkspace.Create(("Widget.cs", BasicSource)));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+
+        Assert.True(result.Success);
+        Assert.False(result.Applied);
+        Assert.Contains("degraded", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1 load diagnostic", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("incomplete", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Degraded_Apply_RefusedWithoutForce()
+    {
+        var commitCalls = 0;
+        var (loaded, resolver) = Degrade(RenameTestWorkspace.Create(("Widget.cs", BasicSource)));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false,
+            commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+        Assert.False(result.Success);
+        Assert.False(result.Applied);
+        Assert.Contains("degraded", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+        Assert.Contains("force=true", result.Message, StringComparison.Ordinal);
+        Assert.Equal(0, commitCalls);
+    }
+
+    [Fact]
+    public async Task Degraded_Apply_ForceWrites()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-degraded-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = Degrade(RenameTestWorkspace.Create((path, BasicSource)));
+
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false, force: true);
+
+            Assert.True(result.Success);
+            Assert.True(result.Applied);
+            Assert.Contains("public class Sprocket", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Apply_DiskChangedSinceSnapshot_RefusedAndFileNotOverwritten()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-stale-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+            // Concurrent edit AFTER the snapshot: the apply must refuse rather than clobber it.
+            var drifted = BasicSource + "\n// concurrent edit\n";
+            await File.WriteAllTextAsync(path, drifted);
+
+            var commitCalls = 0;
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false,
+                commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+            Assert.False(result.Success);
+            Assert.False(result.Applied);
+            Assert.Contains(path, result.Message, StringComparison.Ordinal);
+            Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+            Assert.Equal(drifted, await File.ReadAllTextAsync(path));
+            Assert.Equal(0, commitCalls);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Apply_InvokesCommitHookWithExactlyTheChangedDocuments()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-commit-").FullName;
+        try
+        {
+            var widgetPath = Path.Combine(dir, "Widget.cs");
+            var otherPath = Path.Combine(dir, "Other.cs");
+            const string otherSource = "namespace RenameDemo;\npublic class Untouched { }\n";
+            await File.WriteAllTextAsync(widgetPath, BasicSource);
+            await File.WriteAllTextAsync(otherPath, otherSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create(
+                (widgetPath, BasicSource), (otherPath, otherSource));
+
+            var commits = new List<IReadOnlyList<(Microsoft.CodeAnalysis.DocumentId Id, Microsoft.CodeAnalysis.Text.SourceText Text)>>();
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false,
+                commit: (docs, _) => { commits.Add(docs); return Task.CompletedTask; });
+
+            Assert.True(result.Applied);
+            var docs = Assert.Single(commits);
+            var pair = Assert.Single(docs);   // only Widget.cs changed; Other.cs must not be committed
+            Assert.Equal(loaded.Solution.GetDocumentIdsWithFilePath(widgetPath).Single(), pair.Id);
+            Assert.Contains("public class Sprocket", pair.Text.ToString(), StringComparison.Ordinal);
+            // The committed text is exactly what landed on disk.
+            Assert.Equal(await File.ReadAllTextAsync(widgetPath), pair.Text.ToString());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Preview_DoesNotInvokeCommitHook()
+    {
+        var commitCalls = 0;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", BasicSource));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket",
+            commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+        Assert.False(result.Applied);
+        Assert.Equal(0, commitCalls);
+    }
+
+    [Fact]
+    public async Task Apply_CommitHookFailure_DoesNotFailTheRename()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-commitfail-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false,
+                commit: (_, _) => throw new InvalidOperationException("commit boom"));
+
+            Assert.True(result.Success);
+            Assert.True(result.Applied);   // the disk write DID succeed
+            Assert.Contains("commit boom", result.Message, StringComparison.Ordinal);
+            Assert.Contains("public class Sprocket", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -255,6 +255,149 @@ public class RenameSymbolLogicTests
     }
 
     [Fact]
+    public async Task PreexistingErrorMentioningSymbol_IsNotAConflict()
+    {
+        // CS0117's message embeds the type name ("'Widget' does not contain a
+        // definition for 'NoSuchMember'"). After the rename the same error is
+        // still there, just mentioning 'Sprocket' — the error COUNT for
+        // (CS0117, file) is unchanged, so it must not be reported as a conflict.
+        const string source = """
+            namespace RenameDemo;
+
+            public class Widget
+            {
+                public static int Existing = 1;
+            }
+
+            public class User
+            {
+                public object Bad = Widget.NoSuchMember;
+                public int Good = Widget.Existing;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Widget.cs", source));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Conflicts);
+    }
+
+    [Fact]
+    public async Task SameIdSameFileNewLine_IsReported()
+    {
+        // Pre-existing CS0101 on the duplicate 'Dup' (line 3). Renaming
+        // First -> Dup introduces a SECOND CS0101 in the same file with the
+        // exact same message text — only the line differs. The count-based
+        // diff must report exactly the new one, on the new line.
+        const string source = """
+            namespace RenameDemo;
+            public class Dup { }
+            public class Dup { }
+            public class First { }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Types.cs", source));
+        var result = await RunAsync(loaded, resolver, "First", "Dup");
+
+        Assert.True(result.Success);
+        Assert.NotEmpty(result.Conflicts);
+        var conflict = Assert.Single(
+            result.Conflicts, c => string.Equals(c.Id, "CS0101", StringComparison.Ordinal));
+        Assert.Equal(4, conflict.Line);   // the renamed declaration, not the pre-existing dup (line 3)
+    }
+
+    // NOTE on the dependent-project-break scenario: a rename that genuinely breaks
+    // a downstream project WITHOUT changing its text is not constructible with
+    // AdhocWorkspace. Name-capture attempts (rename LibA's Foo -> Action while LibB
+    // uses System.Action) are defused by Renamer's own conflict engine, which
+    // complexifies the captured reference in LibB to 'System.Action' — so LibB's
+    // text changes and it lands in GetProjectChanges anyway (verified empirically).
+    // The remaining real-world breaks (source generators, name-based reflection
+    // lookups) need generator/analyzer infrastructure AdhocWorkspace doesn't run.
+    // The scan-set mechanic is therefore tested directly instead: dependents ARE
+    // scanned (ComputeScanSet_IncludesDirectDependents) and scanning them applies
+    // the same count-based diff without phantom conflicts or crashes
+    // (DependentProjectWithPreexistingError_IsNotAConflict).
+    [Fact]
+    public async Task ComputeScanSet_IncludesDirectDependents()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("LibA", [("Widget.cs", "namespace Lib; public class Widget { }")]),
+            ("LibB", [("Other.cs", "namespace Dep; public class Other { }")]));
+
+        var target = RenameSymbolLogic.ResolveSingleTarget(resolver, "Widget");
+        var renamed = await Microsoft.CodeAnalysis.Rename.Renamer.RenameSymbolAsync(
+            loaded.Solution, target,
+            new Microsoft.CodeAnalysis.Rename.SymbolRenameOptions(), "Sprocket",
+            CancellationToken.None);
+
+        var scanSet = RenameSymbolLogic.ComputeScanSet(loaded.Solution, renamed);
+        var libA = loaded.Solution.Projects.Single(p => string.Equals(p.Name, "LibA", StringComparison.Ordinal)).Id;
+        var libB = loaded.Solution.Projects.Single(p => string.Equals(p.Name, "LibB", StringComparison.Ordinal)).Id;
+
+        Assert.Contains(libA, scanSet);   // textually changed by the rename
+        Assert.Contains(libB, scanSet);   // untouched, but a direct dependent of LibA
+        Assert.Equal(scanSet.Count, scanSet.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task DependentProjectWithPreexistingError_IsNotAConflict()
+    {
+        // LibB is scanned as a direct dependent; its pre-existing CS0246 must not
+        // surface as a conflict (count unchanged by the rename in LibA).
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("LibA", [("Widget.cs", "namespace Lib; public class Widget { }")]),
+            ("LibB", [("Broken.cs", "namespace Dep; public class Broken { public Unknown Field; }")]));
+        var result = await RunAsync(loaded, resolver, "Widget", "Sprocket");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Conflicts);
+    }
+
+    private static Diagnostic MakeError(string id, string path, int line, bool suppressed = false)
+    {
+        var linePosition = new Microsoft.CodeAnalysis.Text.LinePositionSpan(
+            new Microsoft.CodeAnalysis.Text.LinePosition(line - 1, 0),
+            new Microsoft.CodeAnalysis.Text.LinePosition(line - 1, 1));
+        var location = Location.Create(
+            path, new Microsoft.CodeAnalysis.Text.TextSpan(0, 0), linePosition);
+        return Diagnostic.Create(
+            id, "Test", "synthetic error",
+            DiagnosticSeverity.Error, DiagnosticSeverity.Error,
+            isEnabledByDefault: true, warningLevel: 0, isSuppressed: suppressed,
+            location: location);
+    }
+
+    [Fact]
+    public void SuppressedDiagnostics_AreIgnored()
+    {
+        // An IsSuppressed Error-severity diagnostic is not constructible through
+        // AdhocWorkspace compilation options: #pragma/SuppressMessage suppression is
+        // applied BEFORE warning-as-error elevation, so a suppressed diagnostic
+        // surfaces (under ReportSuppressedDiagnostics) at its original Warning
+        // severity, never Error. Suppressors that keep Error severity require
+        // CompilationWithAnalyzers. The filter is therefore exercised at the diff
+        // level with a synthetic suppressed diagnostic (Diagnostic.Create supports
+        // isSuppressed directly).
+        var suppressed = MakeError("CS9999", "File.cs", 3, suppressed: true);
+        Assert.Empty(RenameSymbolLogic.DiffNewErrors(before: [], after: [suppressed]));
+
+        var unsuppressed = MakeError("CS9999", "File.cs", 3);
+        var conflict = Assert.Single(RenameSymbolLogic.DiffNewErrors(before: [], after: [unsuppressed]));
+        Assert.Equal("CS9999", conflict.Id);
+        Assert.Equal(3, conflict.Line);
+    }
+
+    [Fact]
+    public void DiffNewErrors_PrefersLinesAbsentFromBefore()
+    {
+        var before = new[] { MakeError("CS0101", "Types.cs", 3) };
+        var after = new[] { MakeError("CS0101", "Types.cs", 3), MakeError("CS0101", "Types.cs", 7) };
+
+        var conflict = Assert.Single(RenameSymbolLogic.DiffNewErrors(before, after));
+        Assert.Equal(7, conflict.Line);
+    }
+
+    [Fact]
     public async Task CollidingRename_ForceTrue_WritesAnyway()
     {
         var dir = Directory.CreateTempSubdirectory("rename-force-").FullName;

--- a/tests/RoslynCodeLens.Tests/SolutionChangeWriterTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionChangeWriterTests.cs
@@ -104,7 +104,22 @@ public class SolutionChangeWriterTests : IDisposable
         Assert.Contains("class Eol2", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
     }
 
-    [Fact]
+    /// <summary>
+    /// Runs only on Windows: the injection relies on File.Move hitting a sharing violation
+    /// on a target held open with FileShare.Read — POSIX rename() ignores open handles, so
+    /// on Linux the move succeeds and no failure occurs. The platform-independent rollback
+    /// coverage lives in <see cref="WriteAllWithRollback_MidBatchFailure_RestoresReplacedFiles"/>.
+    /// </summary>
+    private sealed class WindowsOnlyFactAttribute : FactAttribute
+    {
+        public WindowsOnlyFactAttribute()
+        {
+            if (!OperatingSystem.IsWindows())
+                Skip = "File sharing-violation semantics are Windows-only (POSIX rename ignores open handles).";
+        }
+    }
+
+    [WindowsOnlyFact]
     public async Task MidBatchFailure_RollsBackReplacedFiles_AndLeavesNoTempLitter()
     {
         var pathA = PathOf("A.cs");
@@ -137,6 +152,44 @@ public class SolutionChangeWriterTests : IDisposable
         Assert.Equal(Source("Beta"), await File.ReadAllTextAsync(pathB));
         Assert.Equal(Source("Gamma"), await File.ReadAllTextAsync(pathC));
         // No temp litter: exactly the three source files remain.
+        Assert.Equal(3, Directory.GetFiles(_dir).Length);
+    }
+
+    [Fact]
+    public async Task WriteAllWithRollback_MidBatchFailure_RestoresReplacedFiles()
+    {
+        // Platform-independent rollback coverage at the mechanism level: after the freshness
+        // precheck, a mid-batch failure is only reachable via platform-dependent races at the
+        // public API (see the Windows-only test above), so the failing plan is injected
+        // directly — its target's "directory" is an existing regular file, which makes
+        // Directory.CreateDirectory throw IOException on every OS.
+        var pathA = PathOf("A.cs");
+        var pathB = PathOf("B.cs");
+        var blocker = PathOf("blocker");
+        await File.WriteAllTextAsync(pathA, Source("Alpha"));
+        await File.WriteAllTextAsync(pathB, Source("Beta"));
+        await File.WriteAllTextAsync(blocker, "not a directory");
+
+        static SolutionChangeWriter.WritePlan Plan(string path, string content, byte[]? originalBytes)
+            => new(path, DocumentId.CreateNewId(ProjectId.CreateNewId()),
+                SourceText.From(content), new UTF8Encoding(false), originalBytes);
+
+        var plans = new List<SolutionChangeWriter.WritePlan>
+        {
+            Plan(pathA, Source("Alpha2"), await File.ReadAllBytesAsync(pathA)),
+            Plan(pathB, Source("Beta2"), await File.ReadAllBytesAsync(pathB)),
+            Plan(Path.Combine(blocker, "C.cs"), Source("Gamma2"), null),
+        };
+
+        var ex = Assert.Throws<IOException>(
+            () => SolutionChangeWriter.WriteAllWithRollback(plans, CancellationToken.None));
+
+        Assert.Contains("C.cs", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("rolled back", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // A and B were replaced before the failure and must be restored byte-exact.
+        Assert.Equal(Source("Alpha"), await File.ReadAllTextAsync(pathA));
+        Assert.Equal(Source("Beta"), await File.ReadAllTextAsync(pathB));
+        // No temp litter: A.cs, B.cs, and the blocker file remain.
         Assert.Equal(3, Directory.GetFiles(_dir).Length);
     }
 

--- a/tests/RoslynCodeLens.Tests/SolutionChangeWriterTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionChangeWriterTests.cs
@@ -1,0 +1,219 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens;
+using RoslynCodeLens.Tests.Fixtures;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Disk-write path hardening (review findings 1, 4, 8): freshness precheck against the
+/// snapshot, atomic-ish batch write with rollback, and encoding/BOM preservation.
+/// </summary>
+public class SolutionChangeWriterTests : IDisposable
+{
+    private readonly string _dir;
+
+    public SolutionChangeWriterTests()
+        => _dir = Directory.CreateTempSubdirectory("solution-change-writer-").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); }
+        catch (IOException) { /* leave for the OS temp cleaner */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private string PathOf(string name) => Path.Combine(_dir, name);
+
+    private static string Source(string className)
+        => $"namespace WriterDemo;\npublic class {className}\n{{\n    public int Value;\n}}\n";
+
+    private static Solution WithReplacedText(
+        Solution solution, string filePath, string oldValue, string newValue)
+    {
+        var docId = solution.GetDocumentIdsWithFilePath(filePath).Single();
+        var text = solution.GetDocument(docId)!
+            .GetTextAsync(CancellationToken.None).GetAwaiter().GetResult().ToString();
+        return solution.WithDocumentText(
+            docId, SourceText.From(text.Replace(oldValue, newValue, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task StaleDiskFile_AbortsWholeWrite_NoFileTouched()
+    {
+        var pathA = PathOf("A.cs");
+        var pathB = PathOf("B.cs");
+        await File.WriteAllTextAsync(pathA, Source("Alpha"));
+        await File.WriteAllTextAsync(pathB, Source("Beta"));
+        var (loaded, _) = RenameTestWorkspace.Create(
+            (pathA, Source("Alpha")), (pathB, Source("Beta")));
+
+        // Concurrent edit lands on B AFTER the snapshot was taken.
+        var drifted = Source("Beta") + "// concurrent edit\n";
+        await File.WriteAllTextAsync(pathB, drifted);
+
+        var changed = WithReplacedText(loaded.Solution, pathA, "Alpha", "Alpha2");
+        changed = WithReplacedText(changed, pathB, "Beta", "Beta2");
+
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.False(result.Written);
+        Assert.Contains(pathB, result.StaleFiles);
+        Assert.Empty(result.Documents);
+        // The whole batch aborts: A (which WAS fresh) must not have been written either.
+        Assert.Equal(Source("Alpha"), await File.ReadAllTextAsync(pathA));
+        Assert.Equal(drifted, await File.ReadAllTextAsync(pathB));
+    }
+
+    [Fact]
+    public async Task MissingDiskFile_CountsAsStale()
+    {
+        var path = PathOf("Gone.cs");
+        var (loaded, _) = RenameTestWorkspace.Create((path, Source("Gone")));
+        // File was never written to disk (or was deleted since the snapshot).
+
+        var changed = WithReplacedText(loaded.Solution, path, "Gone", "Gone2");
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.False(result.Written);
+        Assert.Contains(path, result.StaleFiles);
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public async Task LineEndingOnlyDrift_IsNotStale()
+    {
+        // Snapshot holds LF; disk holds the same content with CRLF. The freshness
+        // comparison normalizes newlines, so this must NOT abort the write.
+        var path = PathOf("Eol.cs");
+        var lfSource = Source("Eol");                     // built with \n
+        Assert.DoesNotContain("\r", lfSource, StringComparison.Ordinal);
+        await File.WriteAllTextAsync(path, lfSource.Replace("\n", "\r\n", StringComparison.Ordinal));
+
+        var (loaded, _) = RenameTestWorkspace.Create((path, lfSource));
+        var changed = WithReplacedText(loaded.Solution, path, "Eol", "Eol2");
+
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.True(result.Written);
+        Assert.Empty(result.StaleFiles);
+        Assert.Contains("class Eol2", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task MidBatchFailure_RollsBackReplacedFiles_AndLeavesNoTempLitter()
+    {
+        var pathA = PathOf("A.cs");
+        var pathB = PathOf("B.cs");
+        var pathC = PathOf("C.cs");
+        await File.WriteAllTextAsync(pathA, Source("Alpha"));
+        await File.WriteAllTextAsync(pathB, Source("Beta"));
+        await File.WriteAllTextAsync(pathC, Source("Gamma"));
+        var (loaded, _) = RenameTestWorkspace.Create(
+            (pathA, Source("Alpha")), (pathB, Source("Beta")), (pathC, Source("Gamma")));
+
+        var changed = WithReplacedText(loaded.Solution, pathA, "Alpha", "Alpha2");
+        changed = WithReplacedText(changed, pathB, "Beta", "Beta2");
+        changed = WithReplacedText(changed, pathC, "Gamma", "Gamma2");
+
+        // Hold C open denying writers/deleters (readers allowed, so the freshness precheck
+        // can still verify it): File.Move onto C fails mid-batch with a sharing violation.
+        IOException ex;
+        using (new FileStream(pathC, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            ex = await Assert.ThrowsAsync<IOException>(() =>
+                SolutionChangeWriter.WriteChangesToDiskAsync(
+                    changed, loaded.Solution, CancellationToken.None));
+        }
+
+        Assert.Contains(pathC, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("rolled back", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // Every already-replaced file was restored; nothing on disk changed.
+        Assert.Equal(Source("Alpha"), await File.ReadAllTextAsync(pathA));
+        Assert.Equal(Source("Beta"), await File.ReadAllTextAsync(pathB));
+        Assert.Equal(Source("Gamma"), await File.ReadAllTextAsync(pathC));
+        // No temp litter: exactly the three source files remain.
+        Assert.Equal(3, Directory.GetFiles(_dir).Length);
+    }
+
+    [Fact]
+    public async Task PreCancelledToken_WritesNothing_AndLeavesNoTempLitter()
+    {
+        var path = PathOf("Cancel.cs");
+        await File.WriteAllTextAsync(path, Source("Cancel"));
+        var (loaded, _) = RenameTestWorkspace.Create((path, Source("Cancel")));
+        var changed = WithReplacedText(loaded.Solution, path, "Cancel", "Cancel2");
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            SolutionChangeWriter.WriteChangesToDiskAsync(changed, loaded.Solution, cts.Token));
+
+        Assert.Equal(Source("Cancel"), await File.ReadAllTextAsync(path));
+        Assert.Single(Directory.GetFiles(_dir));
+    }
+
+    [Fact]
+    public async Task Utf8BomFile_KeepsBomAfterWrite()
+    {
+        var path = PathOf("Bom.cs");
+        await File.WriteAllTextAsync(path, Source("Bom"), new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+        // Load from disk so the document's SourceText captures the BOM'd encoding,
+        // mirroring MSBuildWorkspace's file loader.
+        var (loaded, _) = RenameTestWorkspace.CreateFromDisk(path);
+
+        var changed = WithReplacedText(loaded.Solution, path, "Bom", "Bom2");
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.True(result.Written);
+        var bytes = await File.ReadAllBytesAsync(path);
+        Assert.True(bytes.Length > 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+            "UTF-8 BOM must be preserved on rewrite");
+        Assert.Contains("class Bom2", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Utf8NoBomFile_StaysBomLessAfterWrite()
+    {
+        var path = PathOf("NoBom.cs");
+        await File.WriteAllTextAsync(path, Source("NoBom"), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        var (loaded, _) = RenameTestWorkspace.CreateFromDisk(path);
+
+        var changed = WithReplacedText(loaded.Solution, path, "NoBom", "NoBom2");
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.True(result.Written);
+        var bytes = await File.ReadAllBytesAsync(path);
+        Assert.False(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+            "a BOM must not be introduced on a file that had none");
+        Assert.Contains("class NoBom2", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SuccessfulWrite_ReturnsChangedDocumentPairs()
+    {
+        var pathA = PathOf("A.cs");
+        var pathB = PathOf("B.cs");
+        await File.WriteAllTextAsync(pathA, Source("Alpha"));
+        await File.WriteAllTextAsync(pathB, Source("Beta"));
+        var (loaded, _) = RenameTestWorkspace.Create(
+            (pathA, Source("Alpha")), (pathB, Source("Beta")));
+
+        // Only A changes; B stays untouched and must not appear in Documents.
+        var changed = WithReplacedText(loaded.Solution, pathA, "Alpha", "Alpha2");
+        var result = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, CancellationToken.None);
+
+        Assert.True(result.Written);
+        var doc = Assert.Single(result.Documents);
+        Assert.Equal(loaded.Solution.GetDocumentIdsWithFilePath(pathA).Single(), doc.Id);
+        Assert.Contains("class Alpha2", doc.Text.ToString(), StringComparison.Ordinal);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/SolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionManagerTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Text;
+
 namespace RoslynCodeLens.Tests;
 
 public class SolutionManagerTests : IAsyncLifetime
@@ -54,6 +56,69 @@ public class SolutionManagerTests : IAsyncLifetime
 
         Assert.True(resolver.AllTypes.Count > 0);
         manager.Dispose();
+    }
+
+    [Fact]
+    public async Task CommitDocumentTexts_ImmediateQueriesSeeNewText_WithoutAnyWatcherEvent()
+    {
+        // Finding 5: after rename_symbol writes files, the manager's in-memory snapshot must
+        // reflect the new text immediately — no disk write happens here at all, so the file
+        // watcher can never deliver this change; only CommitDocumentTextsAsync can.
+        var manager = await SolutionManager.CreateAsync(_solutionPath);
+        try
+        {
+            await manager.WaitForWarmupAsync();
+            var before = manager.GetAnalysisContext();
+            Assert.Empty(before.Resolver.FindSymbols("CommittedProbe"));
+
+            var doc = before.Loaded.Solution.Projects
+                .First(p => string.Equals(p.Name, "TestLib", StringComparison.Ordinal))
+                .Documents.First(d => d.FilePath != null);
+            var text = await doc.GetTextAsync();
+            var newText = SourceText.From(
+                text + "\n\npublic class CommittedProbe { }\n", text.Encoding);
+
+            await manager.CommitDocumentTextsAsync([(doc.Id, newText)]);
+
+            var after = manager.GetAnalysisContext();
+            // Resolver rebuilt from the committed snapshot sees the new type immediately.
+            Assert.NotEmpty(after.Resolver.FindSymbols("CommittedProbe"));
+            // The solution text and the cached compilation were both refreshed.
+            var committedText = await after.Loaded.Solution.GetDocument(doc.Id)!.GetTextAsync();
+            Assert.Contains("CommittedProbe", committedText.ToString(), StringComparison.Ordinal);
+            Assert.Contains(
+                after.Loaded.Compilations[doc.Project.Id].SyntaxTrees,
+                t => t.ToString().Contains("CommittedProbe", StringComparison.Ordinal));
+        }
+        finally
+        {
+            manager.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task CommitDocumentTexts_UnknownDocumentId_IsANoOp()
+    {
+        // After a full reload mints fresh DocumentIds, a commit computed against the old
+        // snapshot must be skipped gracefully (disk already holds the text; the reload read it).
+        var manager = await SolutionManager.CreateAsync(_solutionPath);
+        try
+        {
+            await manager.WaitForWarmupAsync();
+            var before = manager.GetAnalysisContext();
+
+            var foreignId = Microsoft.CodeAnalysis.DocumentId.CreateNewId(
+                Microsoft.CodeAnalysis.ProjectId.CreateNewId());
+            await manager.CommitDocumentTextsAsync(
+                [(foreignId, SourceText.From("public class Ghost { }"))]);
+
+            var after = manager.GetAnalysisContext();
+            Assert.Same(before.Loaded, after.Loaded);   // nothing applied — no snapshot swap
+        }
+        finally
+        {
+            manager.Dispose();
+        }
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/SymbolResolverTests.cs
+++ b/tests/RoslynCodeLens.Tests/SymbolResolverTests.cs
@@ -1,4 +1,5 @@
 using RoslynCodeLens;
+using RoslynCodeLens.Tests.Fixtures;
 
 namespace RoslynCodeLens.Tests;
 
@@ -41,6 +42,109 @@ public class SymbolResolverTests : IAsyncLifetime
         var results = resolver.FindMethods("Greeter.Greet");
 
         Assert.NotEmpty(results);
+    }
+
+    private const string GenericRepositorySource = """
+        namespace Data;
+
+        public class Repository<T>
+        {
+            public T? GetById(int id) => default;
+        }
+        """;
+
+    [Fact]
+    public void FindSymbols_QualifiedNameWithoutTypeParameters_FindsGenericType()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(("Repository.cs", GenericRepositorySource));
+
+        var results = resolver.FindSymbols("Data.Repository");
+
+        var symbol = Assert.Single(results);
+        Assert.Equal("Data.Repository<T>", symbol.ToDisplayString());
+    }
+
+    [Fact]
+    public void FindNamedTypes_StrippedName_ReturnsAllArities()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(
+            ("Repository1.cs", GenericRepositorySource),
+            ("Repository2.cs", """
+                namespace Data;
+
+                public class Repository<T1, T2>
+                {
+                    public T1? GetById(T2 key) => default;
+                }
+                """));
+
+        var results = resolver.FindNamedTypes("Data.Repository");
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, t => t.ToDisplayString() == "Data.Repository<T>");
+        Assert.Contains(results, t => t.ToDisplayString() == "Data.Repository<T1, T2>");
+    }
+
+    [Fact]
+    public void FindSymbols_MemberOfGenericType_ResolvesViaStrippedTypeName()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(("Repository.cs", GenericRepositorySource));
+
+        var results = resolver.FindSymbols("Data.Repository.GetById");
+
+        var symbol = Assert.Single(results);
+        Assert.Equal("GetById", symbol.Name);
+        Assert.Equal("Data.Repository<T>", symbol.ContainingType.ToDisplayString());
+    }
+
+    [Fact]
+    public void FindNamedTypes_ExactGenericDisplayName_StillWorks()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(("Repository.cs", GenericRepositorySource));
+
+        var results = resolver.FindNamedTypes("Data.Repository<T>");
+
+        var type = Assert.Single(results);
+        Assert.Equal("Data.Repository<T>", type.ToDisplayString());
+    }
+
+    [Fact]
+    public void FindNamedTypes_StrippedName_FindsNestedTypeInGenericOuter()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(("Outer.cs", """
+            namespace Ns;
+
+            public class Outer<T>
+            {
+                public class Inner
+                {
+                    public int Value;
+                }
+            }
+            """));
+
+        var results = resolver.FindNamedTypes("Ns.Outer.Inner");
+
+        var type = Assert.Single(results);
+        Assert.Equal("Ns.Outer<T>.Inner", type.ToDisplayString());
+    }
+
+    [Fact]
+    public void FindNamedTypes_NonGenericDottedLookup_Unchanged()
+    {
+        var (_, resolver) = RenameTestWorkspace.Create(("Plain.cs", """
+            namespace Data;
+
+            public class PlainRepository
+            {
+                public int GetById(int id) => id;
+            }
+            """));
+
+        var results = resolver.FindNamedTypes("Data.PlainRepository");
+
+        var type = Assert.Single(results);
+        Assert.Equal("Data.PlainRepository", type.ToDisplayString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Fixes all 10 findings from the post-merge high-effort review of #298 (plan: `docs/plans/2026-07-19-rename-review-fixes.md`).

- **Conflict gate** (findings 2, 7, 9): count-based multiset diff keyed `(Id, FilePath)` — no phantom conflicts from renamed-symbol message drift, no masked same-message errors; scans direct dependents of changed projects; uses cached before-compilations; concurrent before/after passes; skips suppressed diagnostics (matches `get_diagnostics` policy)
- **Write path** (findings 1, 4, 8): on-disk freshness precheck refuses the whole batch untouched if any target changed since the snapshot (EOL-only drift tolerated); temp-file + `File.Move` writes with full rollback from captured bytes on mid-batch failure or cancellation; original `SourceText.Encoding` preserved (BOM-safe). `apply_code_action` inherits freshness + atomicity via the shared writer
- **Degraded guard** (finding 3): apply refuses on a degraded load unless `force=true`; previews warn
- **Snapshot commit** (finding 5): after a successful apply, written texts are committed to the in-memory snapshot via new `SolutionManager.CommitDocumentTextsAsync` (serialized with the watcher rebuild via `_rebuildGate`, reusing the extracted incremental-rebuild tail `RecompileAndSwapAsync`) — no more stale-read window inside the watcher debounce
- **Resolver** (finding 6): qualified names now reach generic types via an arity-stripped index (`Data.Repository` finds `Repository<T>`; members of generic types resolve; multiple arities surface as ambiguity)
- **Docs** (finding 10): CLAUDE.md 57→58 tools; BACKLOG moves rename_symbol to Recently shipped; SKILL.md documents the new refusal semantics

## Test Plan
- [x] 30 new tests (red-first where the defect was constructible; constructibility limits for dependent-break and suppressed-error cases documented in test comments)
- [x] Full suite: 669/669 pass
- [x] rename/apply/writer/manager/rebuild/tracker regression filters green after each package
- [x] Fixture-pristine check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)