### PR TITLE
fix: harden resolve_stack_trace for real-world trace shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **find_reflection_usage** — Detect dynamic/reflection-based usage
 - **find_references** — Find all references to any symbol (types, methods, properties, fields, events)
 - **go_to_definition** — Find the source file and line where a symbol is defined
+- **resolve_stack_trace** — Map a pasted .NET stack trace to file/line/symbol, undoing compiler name mangling (async/iterator state machines, lambdas, local functions, generic arity); handles inner-exception chains, log-prefixed lines, and Demystifier traces
 - **get_diagnostics** — List compiler errors, warnings, and Roslyn analyzer diagnostics
 - **get_code_fixes** — Get available code fixes with structured text edits for any diagnostic
 - **search_symbols** — Fuzzy workspace symbol search by name
@@ -60,6 +61,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **peek_il** — Decompile any method to ilasm-style IL bytecode from closed-source or generated assemblies
 - **get_code_actions** — Discover available refactorings and fixes at any position (extract method, rename, inline variable, and more)
 - **apply_code_action** — Execute any Roslyn refactoring by title, with preview mode (returns a diff before writing to disk)
+- **rename_symbol** — Solution-wide safe rename of a type or member via Roslyn's Renamer, with preview mode, conflict reporting, and a freshness check against on-disk edits
 - **list_solutions** — List all loaded solutions and which one is currently active
 - **set_active_solution** — Switch the active solution by partial name (all subsequent tools operate on it)
 - **load_solution** — Load an additional .sln/.slnx at runtime and make it the active solution

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -39,7 +39,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 ### High value
 
 - ✅ **`rename_symbol`** — *shipped* (PR #298; review-findings hardening in [docs/plans/2026-07-19-rename-review-fixes.md](plans/2026-07-19-rename-review-fixes.md)). Design: [docs/plans/2026-07-19-rename-symbol-design.md](plans/2026-07-19-rename-symbol-design.md).
-- ✅ **`resolve_stack_trace`** — *shipped* (branch `feature/resolve-stack-trace`). Map a pasted runtime stack trace to file/line/symbol, undoing name mangling (async state machines, lambdas, local functions, generics). Design: [docs/plans/2026-07-19-resolve-stack-trace-design.md](plans/2026-07-19-resolve-stack-trace-design.md).
+- ✅ **`resolve_stack_trace`** — *shipped* (PR #301). Map a pasted runtime stack trace to file/line/symbol, undoing name mangling (async state machines, lambdas, local functions, generics). Design: [docs/plans/2026-07-19-resolve-stack-trace-design.md](plans/2026-07-19-resolve-stack-trace-design.md).
 - **`get_method_source` / `get_method_source_batch`** — return a method's source body by name. `analyze_method` gives signature + callers but not the body, so agents still `Read` whole files. Batch variant is very token-efficient.
 - **Reference kind classification on `find_references`** — tag each reference as read/write/invocation/cast/typeof/nameof/attribute, with an optional `kind` filter. Enhancement to the existing tool, not a new one; also subsumes a would-be `find_pattern_usages` (is/as/pattern-match sites).
 - **Exception-flow trio: `get_exception_flow`, `find_throw_sites`, `find_catch_blocks`** — "which exceptions can escape this method, and where are they caught," with derived-type awareness. We have zero exception analysis today.
@@ -69,6 +69,7 @@ Items previously in this backlog, now merged. Listed for orientation; do not re-
 
 | Tool | Theme | PR |
 |---|---|---|
+| `resolve_stack_trace` | Navigation | #301 |
 | `rename_symbol` | Refactoring | #298 |
 | `find_tests_for_symbol` | Test-aware | #116 |
 | `find_uncovered_symbols` | Test-aware | #124 |

--- a/docs/plans/2026-07-19-stack-trace-hardening.md
+++ b/docs/plans/2026-07-19-stack-trace-hardening.md
@@ -1,0 +1,46 @@
+# resolve_stack_trace Hardening (#303 + post-merge review findings)
+
+Fixes issue #303 plus the 10 findings from the post-merge high-effort review of PR #301. Branch `fix/303-stack-trace-hardening`.
+
+**Empirical ground truth** (verified on net10 with real `Exception.ToString()` output — these are the authoritative test fixtures):
+
+```
+at Program.<>c.<<Case1_AsyncLambda>b__8_0>d.MoveNext()                                  ← awaited async lambda: DOT nesting, '>d' suffix
+at Program.<Case2_CapturingLocalFunction>g__Boom|9_0(<>c__DisplayClass9_0&)             ← capturing local fn: hosted on the type, display STRUCT byref param
+at Program.<>c__DisplayClass10_0.<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1()   ← local fn sharing captures with a lambda: DOT-nested display CLASS, single-index |1
+System.InvalidOperationException: outer
+ ---> System.ArgumentNullException: Value cannot be null. (Parameter 'inner')           ← modern .NET: '--->' on OWN line (handled today)
+at ThrowingStatics..cctor()                                                             ← static ctor frame
+at Program.GenericThrow[T](T x) in ...:line 71                                          ← modern runtime AUTO-demangles ordinary/generic async methods
+```
+
+Key insight: modern .NET prints nested types with `.` (never `+`) and auto-demangles ordinary async frames, so the mangled forms that actually reach the tool from modern traces are async lambdas (`<<M>b__N>d`), async local functions (`<<M>g__Name|N>d`), and dot-nested display classes. `+`-nested `d__N` forms come from .NET Framework traces, `Environment.StackTrace`, and old logs — still in scope, no longer the main case.
+
+## W1 — Parser + demangler
+
+1. **Dot-nesting (review #1)**: stop assuming `+`. Normalize the type portion once (shared helper): strip generic-instantiation blocks (`[[...]]` and `[...]` suffixes), strip backtick arity, convert `+`→`.`; then treat mangled containers as trailing dotted segments. Keep the ORIGINAL parsed type text on `DemangledTarget` (new field `RuntimeTypeName`, instantiation blocks removed but `+`/backticks preserved) for W2's metadata fallback.
+2. **New state-machine forms (review #2)**: with method `MoveNext`, the last segment may be `<M>d__N` (classic → StateMachine), `<<M>b__N_M>d(__N)?` (async lambda → Lambda, enclosing M), or `<<M>g__Name|N(_M)?>d(__N)?` (async local function → LocalFunction, enclosing M, name Name). After stripping the mangled segment, also strip a now-trailing `<>c` / `<>c__DisplayClassN(_M)?` container segment. Non-async lambda (`<M>b__N`) and local-function (`<M>g__Name|N`, single- or double-index suffix per Case2b) methods likewise strip trailing container segments.
+3. **Demystifier grammar (review #3)**: replace the last-space heuristic + single-parens regex with a parser that (a) finds the parameter list as the LAST balanced `(...)` group on the line, tolerating nested parens (ValueTuple) and a trailing ` + 0xNN` offset; (b) takes the method path as the identifier chain immediately before that group, so return types with spaces/generics/tuples don't truncate it; (c) recognizes Demystifier's `+LocalFunc(...)` / `+(...) => { }` suffixes — map to localFunction/lambda with the enclosing method, rather than dropping the line.
+4. **AOT offset (#303)**: runtime grammar tolerates ` + 0x[0-9a-f]+` after the parameter list (frame still resolves; offset discarded).
+5. **skippedFrameLike (#303)**: `Parse` returns `StackTraceParseResult(IReadOnlyList<ParsedTraceLine> Lines, IReadOnlyList<string> FrameLikeUnparsed)` — lines containing the `at ` anchor that fail all grammars are collected instead of silently dropped. The logic emits them as items (`Kind="unknown"`, `Origin="unresolved"`, `Symbol`=trimmed line) so trace structure stays complete, and the tool summary gains `skippedFrameLike` = their count.
+6. **Same-line inner headers (review #8)**: a header line containing ` ---> ` splits into one header entry per exception (Framework format `Outer: msg ---> Inner: msg`).
+7. **Generic exception headers (review #6)**: header type charclass admits `[`/`]` instantiation blocks; the emitted TypeFullName has instantiation blocks + arity stripped via the shared normalizer.
+8. **Bare-input fallback**: if zero lines are recognized AND the input is a single line, retry it as a frame body (optional `at `, appending `()` if no parameter list) before throwing InvalidArgument — makes the SKILL's "What method is `<M>d__12.MoveNext`?" routing actually work.
+
+## W2 — Resolution logic, DocGen, tests
+
+9. **Top-level comma counting (review #4)**: parameter count counts commas only at bracket depth 0 (tracking `<>`, `[]`, `()`), not `Split(',')`.
+10. **`.cctor` (review #5)**: constructor resolution uses `InstanceConstructors` for `.ctor` and `StaticConstructors` for `.cctor`; the member-form metadata fallback is skipped for constructor frames (the `T..ctor` name can never match).
+11. **Metadata name form (review #7)**: for the metadata fallback, try `RuntimeTypeName` (original `+`/backtick form) first — that's what `GetTypeByMetadataName` speaks — then the display-normalized form; member form then type-only, unchanged order otherwise.
+12. **Unused parameter**: `ResolveStackTraceLogic.Execute` drops the never-read `LoadedSolution` parameter (3 call sites).
+13. **DocGen hardening (review #10)**: if `EscapeMdx` ends with `inCode == true` (unbalanced backticks), fall back to escaping the whole string ignoring code spans — an unpaired backtick can no longer disable escaping. Plus a new test in RoslynCodeLens.Tests that reflects over every `[McpServerTool]` method's `[Description]` (tool + parameters) asserting balanced backticks and no bare `<`/`{` outside code spans — the authoring-time gate that keeps docs CI green.
+
+## Docs (review #9)
+
+- SKILL.md: metadata claim becomes "external frames resolve with `origin=\"metadata\"` when the assembly is referenced by the solution; frames outside that closure come back `origin=\"unresolved\"`"; note the new `skippedFrameLike` summary field and unknown-frame items.
+- BACKLOG.md: shipped bullet cites PR #301 (not the deleted branch); `resolve_stack_trace | Navigation | #301` row added to Recently shipped.
+- README.md: tool list gains rename_symbol and resolve_stack_trace (verify the list's format first).
+
+## Testing
+
+All existing 700 tests stay green (parser/demangler behavior for previously-passing forms unchanged). New tests pin every item above, with the empirical trace lines quoted verbatim as fixtures — especially Case1/Case2b dot-nested forms resolving to source. `StackTraceParseResult` migration updates existing parser tests mechanically.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -29,6 +29,7 @@ Tools that include a `summary` aggregate:
 - `find_unused_symbols` — `{ byKind: {...}, filteredOut: { testMethod, testContainer, mcpTool, generated, composition, interop } }`
 - `find_naming_violations` — `{ byRule: {...} }`
 - `get_complexity_metrics` — `{ max, avg, overThreshold }`
+- `resolve_stack_trace` — `{ byOrigin: { source, metadata, unresolved }, exceptions, skippedFrameLike }` — `skippedFrameLike` counts frame-like-but-unparseable lines (also present in items as `Kind="unknown"`)
 
 Single-object tools (`get_type_overview`, `get_symbol_context`, `apply_code_action`, etc.) are unchanged — they return their bespoke shape directly.
 
@@ -202,7 +203,7 @@ Solutions passed on the CLI at server startup are auto-trusted in session scope 
 - `get_code_actions` — all refactorings/fixes at a position (with optional range).
 - `apply_code_action` — execute a refactoring by title. Preview mode by default.
 - `rename_symbol` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via `apply_code_action`). Preview by default; new-compiler-error conflicts reported; apply refuses unless `force=true` on: conflicts, a degraded solution load, or files changed on disk since the snapshot (freshness refusal — run `rebuild_solution` and retry; `force` does not bypass freshness). After apply the in-memory snapshot updates immediately — follow-up queries see the new name without waiting for a rebuild. Generic types accept the arity-free qualified form (`Data.Repository` finds `Repository<T>`).
-- `resolve_stack_trace` — map a pasted .NET stack trace to file/line/symbol; demangles async/iterator state machines, lambdas, and local functions; handles log-prefixed lines, inner-exception chains, and Demystifier-style traces. Source frames get the declaration site (exact location when the trace carries `in file:line`); external frames come back `origin="metadata"`. Items stay in trace order.
+- `resolve_stack_trace` — map a pasted .NET stack trace to file/line/symbol; demangles async/iterator state machines, lambdas, and local functions; handles log-prefixed lines, inner-exception chains, and Demystifier-style traces. Source frames get the declaration site (exact location when the trace carries `in file:line`); external frames resolve with `origin="metadata"` when the assembly is referenced by the solution — frames outside that closure come back `origin="unresolved"`. Frame-like lines that fail all grammars aren't dropped: they surface as `Kind="unknown"` items at their original position, and `summary.skippedFrameLike` counts them. Items stay in trace order.
 - `analyze_data_flow` — variable lifecycle over a statement range (declared/read/written/captured/flows-in/out).
 - `analyze_control_flow` — reachability, returns, unreachable paths.
 
@@ -392,7 +393,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_code_actions` | No — source only | | |
 | `apply_code_action` | No — source only | | |
 | `rename_symbol` | No — source only | Locals/parameters and file renames unsupported | |
-| `resolve_stack_trace` | Yes — frames resolve to source or metadata symbols | Metadata frames carry no file/line | `peek_il` to inspect external method bodies |
+| `resolve_stack_trace` | Yes — external frames resolve when the assembly is referenced by the solution | Metadata frames carry no file/line; frames outside the solution's reference closure come back `origin="unresolved"` | `peek_il` to inspect external method bodies |
 | `analyze_data_flow` | No — source only | | |
 | `analyze_control_flow` | No — source only | | |
 | `analyze_change_impact` | No — source only | | |

--- a/src/RoslynCodeLens/StackTrace/StackFrameDemangler.cs
+++ b/src/RoslynCodeLens/StackTrace/StackFrameDemangler.cs
@@ -15,62 +15,91 @@ public sealed record DemangledTarget(
 
 public static partial class StackFrameDemangler
 {
+    // Classic async/iterator state machine: <M>d__N (method MoveNext)
     [GeneratedRegex(@"^<(?<m>[^>]+)>d__\d+$")] private static partial Regex StateMachineSegment();
+    // Awaited async lambda: <<M>b__N_M>d, optionally with a further __N suffix (method MoveNext)
+    [GeneratedRegex(@"^<<(?<m>[^>]+)>b__[\d_]+>d(?:__\d+)?$")] private static partial Regex AsyncLambdaSegment();
+    // Async local function: <<M>g__Name|N(_M)?>d(__N)? (method MoveNext)
+    [GeneratedRegex(@"^<<(?<m>[^>]+)>g__(?<name>[^|>]+)\|[\d_]+>d(?:__\d+)?$")] private static partial Regex AsyncLocalFunctionSegment();
+    // Lambda/local-function host containers: <>c and <>c__DisplayClassN(_M)?
     [GeneratedRegex(@"^<>c(__DisplayClass[\d_]+)?$")] private static partial Regex LambdaContainer();
+    // Non-async lambda method: <M>b__N(_M)?
     [GeneratedRegex(@"^<(?<m>[^>]+)>b__[\d_]+$")] private static partial Regex LambdaMethod();
+    // Local function method: <M>g__Name|N(_M)? (single- or double-index suffix)
     [GeneratedRegex(@"^<(?<m>[^>]+)>g__(?<name>[^|]+)\|[\d_]+$")] private static partial Regex LocalFunctionMethod();
-    [GeneratedRegex(@"`\d+")] private static partial Regex Arity();
 
     public static DemangledTarget Demangle(string typeFullName, string methodName)
     {
-        var runtime = typeFullName;
-        var segments = typeFullName.Split('+');
+        var runtime = TypeNameNormalizer.StripInstantiations(typeFullName);
+        // Modern .NET prints nested types with '.'; Framework/Environment.StackTrace use '+'.
+        // Normalize once, then treat mangled containers as trailing dotted segments.
+        var segments = TypeNameNormalizer.StripArity(runtime).Replace('+', '.').Split('.');
         var last = segments[^1];
 
-        // async/iterator state machine: Ns.T+<M>d__N.MoveNext
-        var sm = StateMachineSegment().Match(last);
-        if (sm.Success && methodName is "MoveNext")
+        if (methodName is "MoveNext")
         {
-            return new DemangledTarget(
-                Normalize(segments[..^1]), sm.Groups["m"].Value,
-                DemangledKind.StateMachine, null, null, runtime);
-        }
-
-        // lambda containers: Ns.T+<>c.<M>b__N / Ns.T+<>c__DisplayClassN_M.<M>b__K
-        if (LambdaContainer().IsMatch(last))
-        {
-            var lm = LambdaMethod().Match(methodName);
-            if (lm.Success)
+            // classic state machine: Ns.T.<M>d__N.MoveNext
+            var sm = StateMachineSegment().Match(last);
+            if (sm.Success)
             {
-                var m = lm.Groups["m"].Value;
                 return new DemangledTarget(
-                    Normalize(segments[..^1]), m, DemangledKind.Lambda, m, null, runtime);
+                    Join(StripContainers(segments[..^1])), sm.Groups["m"].Value,
+                    DemangledKind.StateMachine, null, null, runtime);
+            }
+
+            // awaited async lambda: Ns.T.<>c.<<M>b__N_M>d.MoveNext
+            var al = AsyncLambdaSegment().Match(last);
+            if (al.Success)
+            {
+                var m = al.Groups["m"].Value;
+                return new DemangledTarget(
+                    Join(StripContainers(segments[..^1])), m,
+                    DemangledKind.Lambda, m, null, runtime);
+            }
+
+            // async local function: Ns.T.<<M>g__Name|N_M>d.MoveNext
+            var alf = AsyncLocalFunctionSegment().Match(last);
+            if (alf.Success)
+            {
+                var m = alf.Groups["m"].Value;
+                return new DemangledTarget(
+                    Join(StripContainers(segments[..^1])), m,
+                    DemangledKind.LocalFunction, m, alf.Groups["name"].Value, runtime);
             }
         }
 
-        // lambda emitted directly on the user type (static lambdas without captures)
-        var direct = LambdaMethod().Match(methodName);
-        if (direct.Success)
+        // non-async lambda: Ns.T[.<>c|<>c__DisplayClassN_M].<M>b__K
+        var lm = LambdaMethod().Match(methodName);
+        if (lm.Success)
         {
-            var m = direct.Groups["m"].Value;
-            return new DemangledTarget(Normalize(segments), m, DemangledKind.Lambda, m, null, runtime);
+            var m = lm.Groups["m"].Value;
+            return new DemangledTarget(
+                Join(StripContainers(segments)), m, DemangledKind.Lambda, m, null, runtime);
         }
 
-        // local function: Ns.T.<M>g__Name|N_M
+        // local function: Ns.T[.<>c__DisplayClassN_M].<M>g__Name|K
         var lf = LocalFunctionMethod().Match(methodName);
         if (lf.Success)
         {
+            var m = lf.Groups["m"].Value;
             return new DemangledTarget(
-                Normalize(segments), lf.Groups["m"].Value,
-                DemangledKind.LocalFunction, lf.Groups["m"].Value, lf.Groups["name"].Value, runtime);
+                Join(StripContainers(segments)), m,
+                DemangledKind.LocalFunction, m, lf.Groups["name"].Value, runtime);
         }
 
         if (methodName is ".ctor" or ".cctor")
-            return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Constructor, null, null, runtime);
+            return new DemangledTarget(Join(segments), methodName, DemangledKind.Constructor, null, null, runtime);
 
-        return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Plain, null, null, runtime);
+        return new DemangledTarget(Join(segments), methodName, DemangledKind.Plain, null, null, runtime);
     }
 
-    private static string Normalize(string[] segments)
-        => Arity().Replace(string.Join('.', segments), "");
+    /// <summary>Strips trailing lambda-host container segments (&lt;&gt;c / &lt;&gt;c__DisplayClassN_M).</summary>
+    private static string[] StripContainers(string[] segments)
+    {
+        var end = segments.Length;
+        while (end > 0 && LambdaContainer().IsMatch(segments[end - 1])) end--;
+        return segments[..end];
+    }
+
+    private static string Join(string[] segments) => string.Join('.', segments);
 }

--- a/src/RoslynCodeLens/StackTrace/StackFrameDemangler.cs
+++ b/src/RoslynCodeLens/StackTrace/StackFrameDemangler.cs
@@ -6,10 +6,12 @@ public enum DemangledKind { Plain, StateMachine, Lambda, LocalFunction, Construc
 
 /// <summary>Logical target of a (possibly compiler-mangled) stack frame. TypeName is
 /// normalized to display form: '+' nesting becomes '.', backtick arity is stripped
-/// (the resolver's arity-stripped index matches it).</summary>
+/// (the resolver's arity-stripped index matches it). RuntimeTypeName keeps the original
+/// runtime form ('+' nesting and backtick arity preserved, generic-instantiation blocks
+/// removed) for metadata lookups that speak GetTypeByMetadataName.</summary>
 public sealed record DemangledTarget(
     string TypeName, string MethodName, DemangledKind Kind,
-    string? EnclosingMethod, string? LocalFunctionName);
+    string? EnclosingMethod, string? LocalFunctionName, string RuntimeTypeName);
 
 public static partial class StackFrameDemangler
 {
@@ -21,6 +23,7 @@ public static partial class StackFrameDemangler
 
     public static DemangledTarget Demangle(string typeFullName, string methodName)
     {
+        var runtime = typeFullName;
         var segments = typeFullName.Split('+');
         var last = segments[^1];
 
@@ -30,7 +33,7 @@ public static partial class StackFrameDemangler
         {
             return new DemangledTarget(
                 Normalize(segments[..^1]), sm.Groups["m"].Value,
-                DemangledKind.StateMachine, null, null);
+                DemangledKind.StateMachine, null, null, runtime);
         }
 
         // lambda containers: Ns.T+<>c.<M>b__N / Ns.T+<>c__DisplayClassN_M.<M>b__K
@@ -41,7 +44,7 @@ public static partial class StackFrameDemangler
             {
                 var m = lm.Groups["m"].Value;
                 return new DemangledTarget(
-                    Normalize(segments[..^1]), m, DemangledKind.Lambda, m, null);
+                    Normalize(segments[..^1]), m, DemangledKind.Lambda, m, null, runtime);
             }
         }
 
@@ -50,7 +53,7 @@ public static partial class StackFrameDemangler
         if (direct.Success)
         {
             var m = direct.Groups["m"].Value;
-            return new DemangledTarget(Normalize(segments), m, DemangledKind.Lambda, m, null);
+            return new DemangledTarget(Normalize(segments), m, DemangledKind.Lambda, m, null, runtime);
         }
 
         // local function: Ns.T.<M>g__Name|N_M
@@ -59,13 +62,13 @@ public static partial class StackFrameDemangler
         {
             return new DemangledTarget(
                 Normalize(segments), lf.Groups["m"].Value,
-                DemangledKind.LocalFunction, lf.Groups["m"].Value, lf.Groups["name"].Value);
+                DemangledKind.LocalFunction, lf.Groups["m"].Value, lf.Groups["name"].Value, runtime);
         }
 
         if (methodName is ".ctor" or ".cctor")
-            return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Constructor, null, null);
+            return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Constructor, null, null, runtime);
 
-        return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Plain, null, null);
+        return new DemangledTarget(Normalize(segments), methodName, DemangledKind.Plain, null, null, runtime);
     }
 
     private static string Normalize(string[] segments)

--- a/src/RoslynCodeLens/StackTrace/StackTraceParser.cs
+++ b/src/RoslynCodeLens/StackTrace/StackTraceParser.cs
@@ -7,7 +7,7 @@ namespace RoslynCodeLens.StackTrace;
 public sealed record ParsedTraceLine(
     string Raw,
     bool IsExceptionHeader,
-    string TypeFullName,      // exception type for headers; declaring type (runtime-mangled form) for frames
+    string TypeFullName,      // exception type (normalized) for headers; declaring type (runtime-mangled form) for frames
     string MethodName,        // empty for headers; mangled method segment for frames; [T] args stripped
     string? Parameters,       // raw parameter list text, null for headers
     string? File,
@@ -37,22 +37,35 @@ public static partial class StackTraceParser
     [GeneratedRegex(@"(?:^|\s)at\s+(?<rest>.+)$")]
     private static partial Regex AtAnchor();
 
-    // Runtime frame body: Method-part(params)[ in file:line N]
-    [GeneratedRegex(@"^(?<method>[^\s(][^(]*)\((?<params>[^)]*)\)(?:\s+in\s+(?<file>.+?):line\s+(?<line>\d+))?\s*$")]
-    private static partial Regex RuntimeFrame();
-
-    // Exception header: [---> ]Fully.Qualified.TypeName: message   (type must contain a dot,
-    // no spaces — keeps "ERROR: something" log lines out).
-    [GeneratedRegex(@"^(?:--->\s+)?(?<type>[A-Za-z_][A-Za-z0-9_.+`]*\.[A-Za-z0-9_.+`]+)\s*:\s+.+$")]
+    // Exception header: [---> ]Fully.Qualified.TypeName[`N[...]]: message   (type must contain
+    // a dot, no spaces — keeps "ERROR: something" log lines out; [ ] admit generic instantiation).
+    [GeneratedRegex(@"^(?:--->\s+)?(?<type>[A-Za-z_][A-Za-z0-9_.+`\[\]]*\.[A-Za-z0-9_.+`\[\]]+)\s*:\s+.+$")]
     private static partial Regex ExceptionHeader();
+
+    // " in <file>:line N" suffix of a runtime frame.
+    [GeneratedRegex(@"\s+in\s+(?<file>.+?):line\s+(?<line>\d+)\s*$")]
+    private static partial Regex FileLineSuffix();
+
+    // Native-AOT offset suffix: " + 0x39" after the parameter list (#303).
+    [GeneratedRegex(@"\s*\+\s*0x[0-9a-fA-F]+\s*$")]
+    private static partial Regex OffsetSuffix();
+
+    // Demystifier lambda suffix tail: "(...) => { }".
+    [GeneratedRegex(@"=>\s*\{\s*\}\s*$")]
+    private static partial Regex LambdaArrowSuffix();
 
     public static StackTraceParseResult Parse(string text)
     {
         var results = new List<ParsedTraceLine>();
+        var recognized = 0;
+        var nonEmptyLines = 0;
+        var lastNonEmpty = "";
         foreach (var rawLine in text.Split('\n'))
         {
             var line = rawLine.TrimEnd('\r').Trim();
             if (line.Length == 0) continue;
+            nonEmptyLines++;
+            lastNonEmpty = line;
             if (line.StartsWith("---", StringComparison.Ordinal) &&
                 line.Contains("stack trace", StringComparison.OrdinalIgnoreCase))
                 continue; // "--- End of ... stack trace ---" separators
@@ -61,62 +74,233 @@ public static partial class StackTraceParser
             if (at.Success && TryParseFrame(line, at.Groups["rest"].Value, out var frame))
             {
                 results.Add(frame);
+                recognized++;
                 continue;
             }
 
-            var header = ExceptionHeader().Match(line);
-            if (header.Success && !line.Contains("):", StringComparison.Ordinal))
+            if (TryParseHeaders(line, results))
+            {
+                recognized++;
+                continue;
+            }
+
+            // Frame-like but unparsed: keep it (in order) instead of silently dropping (#303).
+            if (line.StartsWith("at ", StringComparison.Ordinal))
             {
                 results.Add(new ParsedTraceLine(
-                    line, IsExceptionHeader: true, header.Groups["type"].Value,
-                    MethodName: "", Parameters: null, File: null, Line: null,
-                    IsDemystified: false, DemystifiedAsync: false));
+                    line, IsExceptionHeader: false, TypeFullName: "", MethodName: "",
+                    Parameters: null, File: null, Line: null,
+                    IsDemystified: false, DemystifiedAsync: false, IsFrameLikeUnparsed: true));
             }
             // else: noise — dropped
         }
+
+        // Bare-input fallback: a single line like "Demo.Svc.<Run>d__3.MoveNext" pasted without
+        // the 'at ' prefix (and possibly without parens) is retried as a frame body.
+        if (recognized == 0 && nonEmptyLines == 1)
+        {
+            var body = lastNonEmpty.StartsWith("at ", StringComparison.Ordinal)
+                ? lastNonEmpty[3..].TrimStart()
+                : lastNonEmpty;
+            if (!body.Contains('(')) body += "()";
+            if (TryParseFrame(lastNonEmpty, body, out var bare))
+                return new StackTraceParseResult([bare]);
+        }
+
         return new StackTraceParseResult(results);
+    }
+
+    private static bool TryParseHeaders(string line, List<ParsedTraceLine> results)
+    {
+        // Framework prints inner chains on the SAME line: "Outer: msg ---> Inner: msg";
+        // modern .NET puts " ---> Inner: msg" on its own line (single part, regex strips the arrow).
+        var added = false;
+        foreach (var part in line.Split(" ---> ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var m = ExceptionHeader().Match(part);
+            if (!m.Success || part.Contains("):", StringComparison.Ordinal)) continue;
+            results.Add(new ParsedTraceLine(
+                part, IsExceptionHeader: true,
+                TypeNameNormalizer.Normalize(m.Groups["type"].Value),
+                MethodName: "", Parameters: null, File: null, Line: null,
+                IsDemystified: false, DemystifiedAsync: false));
+            added = true;
+        }
+        return added;
     }
 
     private static bool TryParseFrame(string raw, string body, out ParsedTraceLine frame)
     {
         frame = null!;
-        var m = RuntimeFrame().Match(body);
-        if (!m.Success) return false;
+        var s = body.Trim();
 
-        var methodPart = m.Groups["method"].Value.Trim();
-        var isDemystified = false;
-        var demystifiedAsync = false;
-
-        // Demystifier form: "[async ][static ]ReturnType Ns.Type.Method" — the part before
-        // '(' contains spaces separating modifiers/return type from the method path.
-        var lastSpace = methodPart.LastIndexOf(' ');
-        if (lastSpace >= 0)
+        string? file = null;
+        int? lineNo = null;
+        var fm = FileLineSuffix().Match(s);
+        if (fm.Success)
         {
-            isDemystified = true;
-            demystifiedAsync = methodPart.Contains("async ", StringComparison.Ordinal);
-            methodPart = methodPart[(lastSpace + 1)..];
+            file = fm.Groups["file"].Value;
+            lineNo = int.Parse(fm.Groups["line"].Value, CultureInfo.InvariantCulture);
+            s = s[..fm.Index];
         }
 
-        // Strip method generic args: GetById[TKey] -> GetById
-        var bracket = methodPart.IndexOf('[');
-        if (bracket > 0 && methodPart.EndsWith("]", StringComparison.Ordinal))
-            methodPart = methodPart[..bracket];
+        // Native-AOT frames append an offset: "at MyApp.Foo.Bar() + 0x39".
+        var om = OffsetSuffix().Match(s);
+        if (om.Success) s = s[..om.Index];
+        s = s.TrimEnd();
 
-        // Split type / method on the last '.' — but ".ctor"/".cctor" keep their leading dot.
-        var splitAt = methodPart.EndsWith("..ctor", StringComparison.Ordinal) ? methodPart.Length - 5 - 1
-            : methodPart.EndsWith("..cctor", StringComparison.Ordinal) ? methodPart.Length - 6 - 1
-            : methodPart.LastIndexOf('.');
-        if (splitAt <= 0 || splitAt == methodPart.Length - 1) return false;
+        // Demystifier lambda suffix: "Method(params)+(lambdaParams) => { }".
+        var lambdaSuffix = false;
+        string? localFunction = null;
+        var am = LambdaArrowSuffix().Match(s);
+        if (am.Success)
+        {
+            var head = s[..am.Index].TrimEnd();
+            if (!TryFindLastParenGroup(head, out var lambdaOpen, out _)) return false;
+            var beforeGroup = head[..lambdaOpen].TrimEnd();
+            if (!beforeGroup.EndsWith("+", StringComparison.Ordinal)) return false;
+            lambdaSuffix = true;
+            s = beforeGroup[..^1].TrimEnd();
+        }
+
+        // The parameter list is the LAST balanced (...) group (tolerates nested parens
+        // from ValueTuple parameters and tuple return types).
+        if (!TryFindLastParenGroup(s, out var open, out var close)) return false;
+
+        // Demystifier local-function suffix: "Method(params)+LocalFunc(lfParams)".
+        if (!lambdaSuffix)
+        {
+            var j = open - 1;
+            while (j >= 0 && (char.IsLetterOrDigit(s[j]) || s[j] == '_')) j--;
+            if (j >= 1 && j < open - 1 && s[j] == '+' && s[j - 1] == ')')
+            {
+                localFunction = s[(j + 1)..open];
+                s = s[..j];
+                if (!TryFindLastParenGroup(s, out open, out close)) return false;
+            }
+        }
+
+        var parameters = s[(open + 1)..close];
+
+        // Method path: the identifier chain immediately before '(' — balanced <...> / [...]
+        // groups are skipped so generic annotations and instantiation blocks don't truncate it.
+        var start = ScanMethodPathStart(s, open);
+        var methodPart = s[start..open];
+        if (methodPart.Length == 0) return false;
+
+        // Anything before the method path is Demystifier decoration (modifiers + return type).
+        var prefix = s[..start].Trim();
+        var isDemystified = prefix.Length > 0 || lambdaSuffix || localFunction != null;
+        var demystifiedAsync = prefix.Length > 0 &&
+            $" {prefix} ".Contains(" async ", StringComparison.Ordinal);
+
+        // Split type / method on the last top-level '.' — ".ctor"/".cctor" keep their leading dot.
+        var splitAt = methodPart.EndsWith("..ctor", StringComparison.Ordinal) ? methodPart.Length - 6
+            : methodPart.EndsWith("..cctor", StringComparison.Ordinal) ? methodPart.Length - 7
+            : FindSplitDot(methodPart);
+        if (splitAt <= 0 || splitAt >= methodPart.Length - 1) return false;
 
         var type = methodPart[..splitAt];
         var method = methodPart[(splitAt + 1)..];
 
+        // Strip method generic args: GetById[TKey] -> GetById
+        var bracket = method.IndexOf('[');
+        if (bracket > 0 && method.EndsWith("]", StringComparison.Ordinal))
+            method = method[..bracket];
+
         frame = new ParsedTraceLine(
-            raw, IsExceptionHeader: false, type, method,
-            m.Groups["params"].Value,
-            m.Groups["file"].Success ? m.Groups["file"].Value : null,
-            m.Groups["line"].Success ? int.Parse(m.Groups["line"].Value, CultureInfo.InvariantCulture) : null,
-            isDemystified, demystifiedAsync);
+            raw, IsExceptionHeader: false, type, method, parameters,
+            file, lineNo, isDemystified, demystifiedAsync,
+            DemystifiedLambda: lambdaSuffix, DemystifiedLocalFunction: localFunction);
         return true;
+    }
+
+    /// <summary>Finds the trailing balanced (...) group of <paramref name="s"/>.</summary>
+    private static bool TryFindLastParenGroup(string s, out int open, out int close)
+    {
+        open = -1;
+        close = -1;
+        if (s.Length == 0 || s[^1] != ')') return false;
+        var depth = 0;
+        for (var i = s.Length - 1; i >= 0; i--)
+        {
+            if (s[i] == ')') depth++;
+            else if (s[i] == '(')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    open = i;
+                    close = s.Length - 1;
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static int ScanMethodPathStart(string s, int openParen)
+    {
+        var i = openParen - 1;
+        while (i >= 0)
+        {
+            var c = s[i];
+            if (c is '>' or ']')
+            {
+                var match = FindMatchingOpen(s, i, c == '>' ? '<' : '[');
+                if (match < 0) break;
+                i = match - 1;
+            }
+            else if (char.IsLetterOrDigit(c) || c is '_' or '.' or '+' or '`' or '|')
+            {
+                i--;
+            }
+            else
+            {
+                break;
+            }
+        }
+        return i + 1;
+    }
+
+    private static int FindMatchingOpen(string s, int closeIdx, char openChar)
+    {
+        var closeChar = s[closeIdx];
+        var depth = 0;
+        for (var i = closeIdx; i >= 0; i--)
+        {
+            if (s[i] == closeChar) depth++;
+            else if (s[i] == openChar)
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    /// <summary>Last '.' outside balanced &lt;...&gt; / [...] groups, or -1.</summary>
+    private static int FindSplitDot(string s)
+    {
+        var i = s.Length - 1;
+        while (i >= 0)
+        {
+            var c = s[i];
+            if (c is '>' or ']')
+            {
+                var match = FindMatchingOpen(s, i, c == '>' ? '<' : '[');
+                if (match < 0) return -1;
+                i = match - 1;
+            }
+            else if (c == '.')
+            {
+                return i;
+            }
+            else
+            {
+                i--;
+            }
+        }
+        return -1;
     }
 }

--- a/src/RoslynCodeLens/StackTrace/StackTraceParser.cs
+++ b/src/RoslynCodeLens/StackTrace/StackTraceParser.cs
@@ -13,7 +13,23 @@ public sealed record ParsedTraceLine(
     string? File,
     int? Line,
     bool IsDemystified,
-    bool DemystifiedAsync);
+    bool DemystifiedAsync,
+    bool IsFrameLikeUnparsed = false,          // 'at '-anchored line no grammar recognized; only Raw is meaningful
+    bool DemystifiedLambda = false,            // Demystifier '+(...) => { }' suffix
+    string? DemystifiedLocalFunction = null);  // Demystifier '+Name(...)' suffix
+
+/// <summary>
+/// Result of parsing a pasted stack trace. <see cref="Lines"/> is ONE ordered list covering
+/// every recognized or frame-like line in original order — frame-like-but-unparsed lines are
+/// discriminated via <see cref="ParsedTraceLine.IsFrameLikeUnparsed"/> so downstream consumers
+/// preserve trace positions trivially. <see cref="FrameLikeUnparsed"/> is a convenience view.
+/// </summary>
+public sealed record StackTraceParseResult(IReadOnlyList<ParsedTraceLine> Lines)
+{
+    /// <summary>Frame-like lines that failed all grammars (also present in Lines, in order).</summary>
+    public IReadOnlyList<string> FrameLikeUnparsed
+        => Lines.Where(l => l.IsFrameLikeUnparsed).Select(l => l.Raw).ToList();
+}
 
 public static partial class StackTraceParser
 {
@@ -30,7 +46,7 @@ public static partial class StackTraceParser
     [GeneratedRegex(@"^(?:--->\s+)?(?<type>[A-Za-z_][A-Za-z0-9_.+`]*\.[A-Za-z0-9_.+`]+)\s*:\s+.+$")]
     private static partial Regex ExceptionHeader();
 
-    public static IReadOnlyList<ParsedTraceLine> Parse(string text)
+    public static StackTraceParseResult Parse(string text)
     {
         var results = new List<ParsedTraceLine>();
         foreach (var rawLine in text.Split('\n'))
@@ -58,7 +74,7 @@ public static partial class StackTraceParser
             }
             // else: noise — dropped
         }
-        return results;
+        return new StackTraceParseResult(results);
     }
 
     private static bool TryParseFrame(string raw, string body, out ParsedTraceLine frame)

--- a/src/RoslynCodeLens/StackTrace/TypeNameNormalizer.cs
+++ b/src/RoslynCodeLens/StackTrace/TypeNameNormalizer.cs
@@ -38,4 +38,23 @@ public static partial class TypeNameNormalizer
 
     /// <summary>Strips backtick arity markers (`N) only.</summary>
     public static string StripArity(string typeName) => Arity().Replace(typeName, "");
+
+    /// <summary>
+    /// Removes balanced angle-bracket blocks ("&lt;TKey, TValue&gt;"). Demystified traces
+    /// print generic types in display form with type-argument blocks the arity-stripped
+    /// source index does not carry.
+    /// </summary>
+    public static string StripAngleGenerics(string typeName)
+    {
+        if (!typeName.Contains('<')) return typeName;
+        var sb = new StringBuilder(typeName.Length);
+        var depth = 0;
+        foreach (var c in typeName)
+        {
+            if (c == '<') depth++;
+            else if (c == '>') { if (depth > 0) depth--; }
+            else if (depth == 0) sb.Append(c);
+        }
+        return sb.ToString();
+    }
 }

--- a/src/RoslynCodeLens/StackTrace/TypeNameNormalizer.cs
+++ b/src/RoslynCodeLens/StackTrace/TypeNameNormalizer.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace RoslynCodeLens.StackTrace;
+
+/// <summary>
+/// Shared normalizer for runtime type names appearing in stack traces
+/// (frame declaring types and exception header types).
+/// </summary>
+public static partial class TypeNameNormalizer
+{
+    [GeneratedRegex(@"`\d+")] private static partial Regex Arity();
+
+    /// <summary>
+    /// Display form: generic-instantiation blocks and backtick arity stripped,
+    /// '+' nesting converted to '.'. Matches the resolver's arity-stripped index.
+    /// </summary>
+    public static string Normalize(string typeName)
+        => StripArity(StripInstantiations(typeName)).Replace('+', '.');
+
+    /// <summary>
+    /// Removes generic-instantiation blocks ("[...]"/"[[...]]" suffixes) but keeps
+    /// '+' nesting and backtick arity — the form GetTypeByMetadataName speaks.
+    /// </summary>
+    public static string StripInstantiations(string typeName)
+    {
+        if (!typeName.Contains('[')) return typeName;
+        var sb = new StringBuilder(typeName.Length);
+        var depth = 0;
+        foreach (var c in typeName)
+        {
+            if (c == '[') depth++;
+            else if (c == ']') { if (depth > 0) depth--; }
+            else if (depth == 0) sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Strips backtick arity markers (`N) only.</summary>
+    public static string StripArity(string typeName) => Arity().Replace(typeName, "");
+}

--- a/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
+++ b/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
@@ -44,7 +44,7 @@ public static class ResolveStackTraceLogic
     private static StackFrameInfo ResolveException(
         SymbolResolver resolver, MetadataSymbolResolver metadata, ParsedTraceLine line, int index)
     {
-        var typeName = line.TypeFullName.Replace('+', '.');
+        var typeName = line.TypeFullName; // parser emits headers already display-normalized
         var type = resolver.FindSymbols(typeName).FirstOrDefault() ?? metadata.Resolve(typeName)?.Symbol;
         var (origin, file, srcLine, project) = Locate(resolver, type);
         return new StackFrameInfo(index, line.Raw, "exception", typeName,
@@ -55,9 +55,7 @@ public static class ResolveStackTraceLogic
         SymbolResolver resolver, MetadataSymbolResolver metadata, ParsedTraceLine line, int index)
     {
         var target = line.IsDemystified
-            ? new DemangledTarget(line.TypeFullName.Replace('+', '.'), line.MethodName,
-                line.DemystifiedAsync ? DemangledKind.StateMachine : DemangledKind.Plain, null, null,
-                line.TypeFullName)
+            ? DemystifiedTarget(line)
             : StackFrameDemangler.Demangle(line.TypeFullName, line.MethodName);
 
         var method = ResolveMethod(resolver, metadata, target, line.Parameters);
@@ -76,6 +74,27 @@ public static class ResolveStackTraceLogic
         return new StackFrameInfo(index, line.Raw, kind, symbol,
             target.Kind is DemangledKind.Lambda or DemangledKind.LocalFunction ? target.EnclosingMethod : null,
             file, srcLine, origin, project);
+    }
+
+    /// <summary>Demystifier lines carry display-form names plus optional
+    /// '+LocalFunc(...)' / '+(...) =&gt; { }' suffixes mapped here.</summary>
+    private static DemangledTarget DemystifiedTarget(ParsedTraceLine line)
+    {
+        var runtime = TypeNameNormalizer.StripInstantiations(line.TypeFullName);
+        var typeName = TypeNameNormalizer.Normalize(line.TypeFullName);
+        if (line.DemystifiedLambda)
+        {
+            return new DemangledTarget(typeName, line.MethodName,
+                DemangledKind.Lambda, line.MethodName, null, runtime);
+        }
+        if (line.DemystifiedLocalFunction is { } localFunction)
+        {
+            return new DemangledTarget(typeName, line.MethodName,
+                DemangledKind.LocalFunction, line.MethodName, localFunction, runtime);
+        }
+        return new DemangledTarget(typeName, line.MethodName,
+            line.DemystifiedAsync ? DemangledKind.StateMachine : DemangledKind.Plain,
+            null, null, runtime);
     }
 
     private static ISymbol? ResolveMethod(

--- a/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
+++ b/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
@@ -5,26 +5,40 @@ using RoslynCodeLens.Symbols;
 
 namespace RoslynCodeLens.Tools;
 
+/// <summary>Resolved trace plus the count of frame-like lines that failed all grammars
+/// (those are also present in Frames as Kind="unknown"/Origin="unresolved" items, in order).</summary>
+public sealed record StackTraceResolution(IReadOnlyList<StackFrameInfo> Frames, int SkippedFrameLike);
+
 public static class ResolveStackTraceLogic
 {
-    public static IReadOnlyList<StackFrameInfo> Execute(
+    public static StackTraceResolution Execute(
         LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string stackTrace)
     {
         var parsed = StackTraceParser.Parse(stackTrace);
-        if (parsed.Count == 0)
+        if (parsed.Lines.Count == 0)
         {
             throw new McpToolException(ToolErrorCode.InvalidArgument,
                 "No stack frames recognized in input.", new { });
         }
 
-        var frames = new List<StackFrameInfo>(parsed.Count);
-        foreach (var line in parsed)
+        var frames = new List<StackFrameInfo>(parsed.Lines.Count);
+        var skippedFrameLike = 0;
+        foreach (var line in parsed.Lines)
         {
+            if (line.IsFrameLikeUnparsed)
+            {
+                // Keep trace structure complete: emit the unrecognized frame-like line
+                // as an unknown item at its original position.
+                skippedFrameLike++;
+                frames.Add(new StackFrameInfo(frames.Count, line.Raw, "unknown", line.Raw,
+                    null, null, null, "unresolved", null));
+                continue;
+            }
             frames.Add(line.IsExceptionHeader
                 ? ResolveException(resolver, metadata, line, frames.Count)
                 : ResolveFrame(resolver, metadata, line, frames.Count));
         }
-        return frames;
+        return new StackTraceResolution(frames, skippedFrameLike);
     }
 
     private static StackFrameInfo ResolveException(
@@ -42,7 +56,8 @@ public static class ResolveStackTraceLogic
     {
         var target = line.IsDemystified
             ? new DemangledTarget(line.TypeFullName.Replace('+', '.'), line.MethodName,
-                line.DemystifiedAsync ? DemangledKind.StateMachine : DemangledKind.Plain, null, null)
+                line.DemystifiedAsync ? DemangledKind.StateMachine : DemangledKind.Plain, null, null,
+                line.TypeFullName)
             : StackFrameDemangler.Demangle(line.TypeFullName, line.MethodName);
 
         var method = ResolveMethod(resolver, metadata, target, line.Parameters);

--- a/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
+++ b/src/RoslynCodeLens/Tools/ResolveStackTraceLogic.cs
@@ -12,7 +12,7 @@ public sealed record StackTraceResolution(IReadOnlyList<StackFrameInfo> Frames, 
 public static class ResolveStackTraceLogic
 {
     public static StackTraceResolution Execute(
-        LoadedSolution loaded, SymbolResolver resolver, MetadataSymbolResolver metadata, string stackTrace)
+        SymbolResolver resolver, MetadataSymbolResolver metadata, string stackTrace)
     {
         var parsed = StackTraceParser.Parse(stackTrace);
         if (parsed.Lines.Count == 0)
@@ -77,11 +77,13 @@ public static class ResolveStackTraceLogic
     }
 
     /// <summary>Demystifier lines carry display-form names plus optional
-    /// '+LocalFunc(...)' / '+(...) =&gt; { }' suffixes mapped here.</summary>
+    /// '+LocalFunc(...)' / '+(...) =&gt; { }' suffixes mapped here. Generic types keep
+    /// their '&lt;TKey, TValue&gt;' blocks in the parsed text; the lookup name strips them
+    /// so the arity-stripped source index matches (RuntimeTypeName keeps the original).</summary>
     private static DemangledTarget DemystifiedTarget(ParsedTraceLine line)
     {
         var runtime = TypeNameNormalizer.StripInstantiations(line.TypeFullName);
-        var typeName = TypeNameNormalizer.Normalize(line.TypeFullName);
+        var typeName = TypeNameNormalizer.StripAngleGenerics(TypeNameNormalizer.Normalize(line.TypeFullName));
         if (line.DemystifiedLambda)
         {
             return new DemangledTarget(typeName, line.MethodName,
@@ -100,12 +102,18 @@ public static class ResolveStackTraceLogic
     private static ISymbol? ResolveMethod(
         SymbolResolver resolver, MetadataSymbolResolver metadata, DemangledTarget target, string? parameters)
     {
+        var isConstructor = target.Kind == DemangledKind.Constructor;
         IReadOnlyList<ISymbol> candidates;
-        if (target.Kind == DemangledKind.Constructor)
+        if (isConstructor)
         {
-            // Constructor: resolve the type, pick a ctor by param count.
+            // Constructor: resolve the type, pick a ctor by param count. '.cctor' is the
+            // static (type) constructor — a distinct symbol set from InstanceConstructors.
             var type = resolver.FindSymbols(target.TypeName).OfType<INamedTypeSymbol>().FirstOrDefault();
-            candidates = type?.InstanceConstructors.Cast<ISymbol>().ToList() ?? [];
+            candidates = type == null
+                ? []
+                : string.Equals(target.MethodName, ".cctor", StringComparison.Ordinal)
+                    ? type.StaticConstructors.Cast<ISymbol>().ToList()
+                    : type.InstanceConstructors.Cast<ISymbol>().ToList();
         }
         else
         {
@@ -113,19 +121,60 @@ public static class ResolveStackTraceLogic
         }
 
         if (candidates.Count == 0)
-        {
-            return metadata.Resolve($"{target.TypeName}.{target.MethodName}")?.Symbol
-                ?? metadata.Resolve(target.TypeName)?.Symbol;
-        }
+            return ResolveViaMetadata(metadata, target, isConstructor);
 
         if (candidates.Count == 1)
             return candidates[0];
 
         // Overloads: prefer matching parameter count from the parsed parameter list.
-        var paramCount = string.IsNullOrWhiteSpace(parameters)
-            ? 0 : parameters.Split(',').Length;
+        var paramCount = CountParameters(parameters);
         return candidates.OfType<IMethodSymbol>().FirstOrDefault(m => m.Parameters.Length == paramCount)
             ?? candidates[0];
+    }
+
+    /// <summary>
+    /// Metadata fallback. GetTypeByMetadataName speaks the runtime name form ('+' nesting,
+    /// backtick arity), so RuntimeTypeName goes first, the display-normalized name second;
+    /// member form before type-only. Constructor frames skip the member form entirely —
+    /// a 'T..ctor' member name can never match a metadata member lookup.
+    /// </summary>
+    private static ISymbol? ResolveViaMetadata(
+        MetadataSymbolResolver metadata, DemangledTarget target, bool isConstructor)
+    {
+        var sameName = string.Equals(target.RuntimeTypeName, target.TypeName, StringComparison.Ordinal);
+        if (!isConstructor)
+        {
+            var member = metadata.Resolve($"{target.RuntimeTypeName}.{target.MethodName}")
+                ?? (sameName ? null : metadata.Resolve($"{target.TypeName}.{target.MethodName}"));
+            if (member != null)
+                return member.Symbol;
+        }
+        var type = metadata.Resolve(target.RuntimeTypeName)
+            ?? (sameName ? null : metadata.Resolve(target.TypeName));
+        return type?.Symbol;
+    }
+
+    /// <summary>
+    /// Parameter count from the parsed parameter text: commas count only at bracket
+    /// depth 0 — generic ('&lt;&gt;'), instantiation/array ('[]'), and tuple ('()') commas
+    /// belong to a single parameter's type.
+    /// </summary>
+    private static int CountParameters(string? parameters)
+    {
+        if (string.IsNullOrWhiteSpace(parameters))
+            return 0;
+        var count = 1;
+        var depth = 0;
+        foreach (var c in parameters)
+        {
+            switch (c)
+            {
+                case '<' or '[' or '(': depth++; break;
+                case '>' or ']' or ')': if (depth > 0) depth--; break;
+                case ',' when depth == 0: count++; break;
+            }
+        }
+        return count;
     }
 
     private static string KindOf(DemangledTarget target, ISymbol? method) => target.Kind switch

--- a/src/RoslynCodeLens/Tools/ResolveStackTraceTool.cs
+++ b/src/RoslynCodeLens/Tools/ResolveStackTraceTool.cs
@@ -25,7 +25,7 @@ public static class ResolveStackTraceTool
         manager.EnsureLoaded();
         var context = manager.GetAnalysisContext();
         var result = ResolveStackTraceLogic.Execute(
-            context.Loaded, context.Resolver, context.Metadata, stackTrace);
+            context.Resolver, context.Metadata, stackTrace);
         var frames = result.Frames;
 
         var summary = new

--- a/src/RoslynCodeLens/Tools/ResolveStackTraceTool.cs
+++ b/src/RoslynCodeLens/Tools/ResolveStackTraceTool.cs
@@ -24,8 +24,9 @@ public static class ResolveStackTraceTool
     {
         manager.EnsureLoaded();
         var context = manager.GetAnalysisContext();
-        var frames = ResolveStackTraceLogic.Execute(
+        var result = ResolveStackTraceLogic.Execute(
             context.Loaded, context.Resolver, context.Metadata, stackTrace);
+        var frames = result.Frames;
 
         var summary = new
         {
@@ -36,6 +37,7 @@ public static class ResolveStackTraceTool
                 unresolved = frames.Count(f => string.Equals(f.Origin, "unresolved", StringComparison.Ordinal)),
             },
             exceptions = frames.Count(f => string.Equals(f.Kind, "exception", StringComparison.Ordinal)),
+            skippedFrameLike = result.SkippedFrameLike,
         };
         return ToolListResult.Create(frames, limit ?? DefaultLimit, summary);
     }

--- a/tests/RoslynCodeLens.Tests/ResolveStackTraceFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/ResolveStackTraceFixtureTests.cs
@@ -13,7 +13,7 @@ public class ResolveStackTraceFixtureTests
     public void RealisticTrace_ResolvesSourceAndMetadataFrames_InOrder()
     {
         var frames = ResolveStackTraceLogic.Execute(
-            _fixture.Loaded, _fixture.Resolver, _fixture.Metadata, """
+            _fixture.Resolver, _fixture.Metadata, """
             System.InvalidOperationException: boom
                at System.String.Concat(String str0, String str1)
                at TestLib.Greeter.Greet(String name)

--- a/tests/RoslynCodeLens.Tests/ResolveStackTraceFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/ResolveStackTraceFixtureTests.cs
@@ -19,7 +19,7 @@ public class ResolveStackTraceFixtureTests
                at TestLib.Greeter.Greet(String name)
                --- End of stack trace from previous location ---
             random log noise
-            """);
+            """).Frames;
 
         Assert.Equal(3, frames.Count);   // header + 2 frames; separator + noise dropped
         Assert.Equal("exception", frames[0].Kind);

--- a/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
@@ -58,15 +58,41 @@ public class ResolveStackTraceLogicTests
         }
         """;
 
+    // Line numbers in this file are asserted below — keep declarations on their lines.
+    private const string OverloadSource = """
+        namespace Demo;
+        public class Dispatcher
+        {
+            public void Handle(System.Collections.Generic.Dictionary<string, int> map) { }
+            public void Handle(string a, int b) { }
+            public void Save(System.Collections.Generic.Dictionary<string, int> map) { }
+            public void Save(string a, int b) { }
+        }
+        public class Config
+        {
+            public Config() { }
+            static Config() { }
+        }
+        public class Repository<TKey, TValue>
+        {
+            public TValue? GetById(TKey key) => default!;
+        }
+        """;
+
+    private const int HandleDictionaryLine = 4;
+    private const int SaveDictionaryLine = 6;
+    private const int InstanceCtorLine = 11;
+    private const int StaticCtorLine = 12;
+
     private static IReadOnlyList<StackFrameInfo> Resolve(string trace)
         => ResolveFull(trace).Frames;
 
     private static StackTraceResolution ResolveFull(string trace)
     {
         var (loaded, resolver) = RenameTestWorkspace.Create(
-            ("Demo.cs", SourceText), ("Program.cs", ProgramSource));
+            ("Demo.cs", SourceText), ("Program.cs", ProgramSource), ("Overloads.cs", OverloadSource));
         var metadata = new MetadataSymbolResolver(loaded, resolver);
-        return ResolveStackTraceLogic.Execute(loaded, resolver, metadata, trace);
+        return ResolveStackTraceLogic.Execute(resolver, metadata, trace);
     }
 
     [Fact]
@@ -236,5 +262,71 @@ public class ResolveStackTraceLogicTests
         var aot = result.Frames[2];
         Assert.Equal(2, aot.Index);
         Assert.Contains("MyApp.Foo", aot.Symbol, StringComparison.Ordinal);
+    }
+
+    // ---- item 9: overload pick counts only top-level commas ----
+
+    [Fact]
+    public void OverloadPick_RuntimeGenericInstantiationCommas_DoNotCountAsParameters()
+    {
+        var f = Assert.Single(Resolve(
+            "at Demo.Dispatcher.Handle(System.Collections.Generic.Dictionary`2[System.String,System.Int32] map)"));
+        Assert.Equal("source", f.Origin);
+        Assert.Equal(HandleDictionaryLine, f.Line); // 1-arg Dictionary overload, not Handle(string, int)
+    }
+
+    [Fact]
+    public void OverloadPick_DemystifiedGenericAngleCommas_DoNotCountAsParameters()
+    {
+        var f = Assert.Single(Resolve("at void Demo.Dispatcher.Save(Dictionary<string, int> map)"));
+        Assert.Equal("source", f.Origin);
+        Assert.Equal(SaveDictionaryLine, f.Line); // 1-arg Dictionary overload, not Save(string, int)
+    }
+
+    // ---- item 10: '.cctor' resolves to the static constructor ----
+
+    [Fact]
+    public void StaticConstructorFrame_ResolvesToStaticCtorDeclaration()
+    {
+        var f = Assert.Single(Resolve("at Demo.Config..cctor()"));
+        Assert.Equal("constructor", f.Kind);
+        Assert.Equal("source", f.Origin);
+        Assert.Equal(StaticCtorLine, f.Line);
+    }
+
+    [Fact]
+    public void InstanceConstructorFrame_StillResolvesToInstanceCtorDeclaration()
+    {
+        var f = Assert.Single(Resolve("at Demo.Config..ctor()"));
+        Assert.Equal("constructor", f.Kind);
+        Assert.Equal("source", f.Origin);
+        Assert.Equal(InstanceCtorLine, f.Line);
+    }
+
+    // ---- item 11: metadata/source name forms for generic types ----
+
+    [Fact]
+    public void DemystifiedGenericTypeFrame_WithSpacedTypeArgs_ResolvesToSource()
+    {
+        var f = Assert.Single(Resolve("at TValue Demo.Repository<TKey, TValue>.GetById(TKey key)"));
+        Assert.Equal("source", f.Origin);
+        Assert.Contains("GetById", f.Symbol, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DemystifiedGenericTypeFrame_WithoutSpaces_ResolvesViaAngleStrippedLookup()
+    {
+        var f = Assert.Single(Resolve("at TValue Demo.Repository<TKey,TValue>.GetById(TKey key)"));
+        Assert.Equal("source", f.Origin);
+        Assert.Contains("GetById", f.Symbol, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RuntimeGenericMetadataFrame_BacktickForm_ResolvesToMetadata()
+    {
+        var f = Assert.Single(Resolve("at System.Collections.Generic.List`1.Add(T item)"));
+        Assert.Equal("metadata", f.Origin);
+        Assert.Contains("Add", f.Symbol, StringComparison.Ordinal);
+        Assert.Null(f.File);
     }
 }

--- a/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
@@ -36,6 +36,9 @@ public class ResolveStackTraceLogicTests
         """;
 
     private static IReadOnlyList<StackFrameInfo> Resolve(string trace)
+        => ResolveFull(trace).Frames;
+
+    private static StackTraceResolution ResolveFull(string trace)
     {
         var (loaded, resolver) = RenameTestWorkspace.Create(("Demo.cs", SourceText));
         var metadata = new MetadataSymbolResolver(loaded, resolver);

--- a/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ResolveStackTraceLogicTests.cs
@@ -35,12 +35,36 @@ public class ResolveStackTraceLogicTests
         }
         """;
 
+    // Global-namespace Program matching the empirical modern .NET trace fixtures.
+    private const string ProgramSource = """
+        public class Program
+        {
+            public static async System.Threading.Tasks.Task Case1_AsyncLambda()
+            {
+                var f = new System.Func<System.Threading.Tasks.Task>(async () =>
+                {
+                    await System.Threading.Tasks.Task.Yield();
+                });
+                await f();
+            }
+            public static void Case2b_CapturingLocalFunctionWithLambda()
+            {
+                var captured = 0;
+                void Boom() => captured++;
+                var f = new System.Func<int>(() => captured);
+                Boom();
+                f();
+            }
+        }
+        """;
+
     private static IReadOnlyList<StackFrameInfo> Resolve(string trace)
         => ResolveFull(trace).Frames;
 
     private static StackTraceResolution ResolveFull(string trace)
     {
-        var (loaded, resolver) = RenameTestWorkspace.Create(("Demo.cs", SourceText));
+        var (loaded, resolver) = RenameTestWorkspace.Create(
+            ("Demo.cs", SourceText), ("Program.cs", ProgramSource));
         var metadata = new MetadataSymbolResolver(loaded, resolver);
         return ResolveStackTraceLogic.Execute(loaded, resolver, metadata, trace);
     }
@@ -153,5 +177,64 @@ public class ResolveStackTraceLogicTests
     {
         var ex = Assert.Throws<McpToolException>(() => Resolve("no frames here at all"));
         Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    // ---- item 8: multi-line noise still throws (fallback is single-line only) ----
+
+    [Fact]
+    public void MultiLineNoiseOnlyInput_ThrowsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Resolve("noise line one\nnoise line two"));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    // ---- items 1/2: empirical dot-nested modern .NET frames resolve to source ----
+
+    [Fact]
+    public void Empirical_AsyncLambdaFrame_DotNested_ResolvesToSource()
+    {
+        var f = Assert.Single(Resolve("at Program.<>c.<<Case1_AsyncLambda>b__8_0>d.MoveNext()"));
+        Assert.Equal("lambda", f.Kind);
+        Assert.Equal("Case1_AsyncLambda", f.EnclosingMethod);
+        Assert.Equal("source", f.Origin);
+        Assert.Equal("Program.cs", f.File);
+    }
+
+    [Fact]
+    public void Empirical_LocalFunctionFrame_DotNestedDisplayClass_ResolvesToSource()
+    {
+        var f = Assert.Single(Resolve(
+            "at Program.<>c__DisplayClass10_0.<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1()"));
+        Assert.Equal("localFunction", f.Kind);
+        Assert.Equal("Case2b_CapturingLocalFunctionWithLambda", f.EnclosingMethod);
+        Assert.Equal("source", f.Origin);
+        Assert.Equal("Program.cs", f.File);
+    }
+
+    // ---- items 4/5: AOT offset frames parse; garbage frame-like lines interleave ----
+
+    [Fact]
+    public void FrameLikeGarbage_EmitsUnknownItem_InOrder_AndIsCounted()
+    {
+        var result = ResolveFull("""
+            System.InvalidOperationException: boom
+               at ???bogus
+               at MyApp.Foo.Bar() + 0x39
+            """);
+        Assert.Equal(3, result.Frames.Count);
+        Assert.Equal(1, result.SkippedFrameLike);
+
+        var unknown = result.Frames[1];
+        Assert.Equal(1, unknown.Index);
+        Assert.Equal("unknown", unknown.Kind);
+        Assert.Equal("unresolved", unknown.Origin);
+        Assert.Equal("at ???bogus", unknown.Symbol);
+        Assert.Null(unknown.File);
+        Assert.Null(unknown.Line);
+
+        // The AOT frame now parses (offset tolerated) instead of being dropped.
+        var aot = result.Frames[2];
+        Assert.Equal(2, aot.Index);
+        Assert.Contains("MyApp.Foo", aot.Symbol, StringComparison.Ordinal);
     }
 }

--- a/tests/RoslynCodeLens.Tests/StackFrameDemanglerTests.cs
+++ b/tests/RoslynCodeLens.Tests/StackFrameDemanglerTests.cs
@@ -69,4 +69,87 @@ public class StackFrameDemanglerTests
         Assert.Equal(DemangledKind.Plain, d.Kind);
         Assert.Equal("Process", d.MethodName);
     }
+
+    // ---- item 2: modern dot-nested state-machine forms (empirical fixtures) ----
+
+    [Fact]
+    public void AsyncLambdaStateMachine_DotNested_MapsToLambdaInEnclosingMethod()
+    {
+        // at Program.<>c.<<Case1_AsyncLambda>b__8_0>d.MoveNext()
+        var d = D("Program.<>c.<<Case1_AsyncLambda>b__8_0>d", "MoveNext");
+        Assert.Equal("Program", d.TypeName);
+        Assert.Equal(DemangledKind.Lambda, d.Kind);
+        Assert.Equal("Case1_AsyncLambda", d.EnclosingMethod);
+        Assert.Equal("Case1_AsyncLambda", d.MethodName);
+        Assert.Equal("Program.<>c.<<Case1_AsyncLambda>b__8_0>d", d.RuntimeTypeName);
+    }
+
+    [Fact]
+    public void LocalFunction_InDotNestedDisplayClass_SingleIndexSuffix_Maps()
+    {
+        // at Program.<>c__DisplayClass10_0.<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1()
+        var d = D("Program.<>c__DisplayClass10_0", "<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1");
+        Assert.Equal("Program", d.TypeName);
+        Assert.Equal(DemangledKind.LocalFunction, d.Kind);
+        Assert.Equal("Case2b_CapturingLocalFunctionWithLambda", d.EnclosingMethod);
+        Assert.Equal("Boom", d.LocalFunctionName);
+    }
+
+    [Fact]
+    public void LocalFunction_HostedOnType_DisplayStructByRefParam_Maps()
+    {
+        // at Program.<Case2_CapturingLocalFunction>g__Boom|9_0(<>c__DisplayClass9_0&)
+        var d = D("Program", "<Case2_CapturingLocalFunction>g__Boom|9_0");
+        Assert.Equal("Program", d.TypeName);
+        Assert.Equal(DemangledKind.LocalFunction, d.Kind);
+        Assert.Equal("Case2_CapturingLocalFunction", d.EnclosingMethod);
+        Assert.Equal("Boom", d.LocalFunctionName);
+    }
+
+    [Fact]
+    public void AsyncLocalFunctionStateMachine_MapsToLocalFunction()
+    {
+        var d = D("Demo.Svc.<<Run>g__Boom|0_0>d", "MoveNext");
+        Assert.Equal("Demo.Svc", d.TypeName);
+        Assert.Equal(DemangledKind.LocalFunction, d.Kind);
+        Assert.Equal("Run", d.EnclosingMethod);
+        Assert.Equal("Boom", d.LocalFunctionName);
+    }
+
+    [Fact]
+    public void ClassicStateMachine_DotNested_Maps()
+    {
+        var d = D("Demo.Svc.<Run>d__3", "MoveNext");
+        Assert.Equal("Demo.Svc", d.TypeName);
+        Assert.Equal(DemangledKind.StateMachine, d.Kind);
+        Assert.Equal("Run", d.MethodName);
+    }
+
+    [Fact]
+    public void LambdaContainer_DotNested_MapsToEnclosingMethod()
+    {
+        var d = D("Demo.OrderService.<>c", "<Process>b__5_0");
+        Assert.Equal("Demo.OrderService", d.TypeName);
+        Assert.Equal(DemangledKind.Lambda, d.Kind);
+        Assert.Equal("Process", d.EnclosingMethod);
+    }
+
+    // ---- item 1: instantiation blocks + RuntimeTypeName plumbing ----
+
+    [Fact]
+    public void GenericInstantiation_IsStripped_RuntimeTypeNameKeepsArity()
+    {
+        var d = D("Demo.Repository`1[[System.Int32, System.Private.CoreLib]]", "GetById");
+        Assert.Equal("Demo.Repository", d.TypeName);
+        Assert.Equal("Demo.Repository`1", d.RuntimeTypeName);
+        Assert.Equal(DemangledKind.Plain, d.Kind);
+    }
+
+    [Fact]
+    public void RuntimeTypeName_PreservesPlusNestingAndArity()
+    {
+        var d = D("Demo.Repository`1+Enumerator", "MoveNext");
+        Assert.Equal("Demo.Repository.Enumerator", d.TypeName);
+        Assert.Equal("Demo.Repository`1+Enumerator", d.RuntimeTypeName);
+    }
 }

--- a/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
+++ b/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
@@ -287,4 +287,17 @@ public class StackTraceParserTests
         Assert.Equal("A.B`2+C",
             TypeNameNormalizer.StripInstantiations("A.B`2[[X, asm],[Y, asm]]+C"));
     }
+
+    // ---- item 11: demystified generic types carry <...> blocks the source index lacks ----
+
+    [Fact]
+    public void Normalizer_StripAngleGenerics_RemovesBalancedAngleBlocks()
+    {
+        Assert.Equal("Demo.Repository",
+            TypeNameNormalizer.StripAngleGenerics("Demo.Repository<TKey, TValue>"));
+        Assert.Equal("Ns.Outer.Inner",
+            TypeNameNormalizer.StripAngleGenerics("Ns.Outer<T>.Inner<U, V>"));
+        Assert.Equal("Demo.Plain",
+            TypeNameNormalizer.StripAngleGenerics("Demo.Plain"));
+    }
 }

--- a/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
+++ b/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
@@ -116,4 +116,175 @@ public class StackTraceParserTests
         Assert.Equal("Demo.OrderService", f.TypeFullName);
         Assert.Equal(".ctor", f.MethodName);
     }
+
+    // ---- item 1/2: empirical modern .NET trace lines (verbatim fixtures) ----
+
+    [Fact]
+    public void Empirical_ModernRuntimeLines_ParseWithDotNesting()
+    {
+        var lines = StackTraceParser.Parse("""
+               at Program.<>c.<<Case1_AsyncLambda>b__8_0>d.MoveNext()
+               at Program.<Case2_CapturingLocalFunction>g__Boom|9_0(<>c__DisplayClass9_0&)
+               at Program.<>c__DisplayClass10_0.<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1()
+               at ThrowingStatics..cctor()
+               at Program.GenericThrow[T](T x) in C:\app\Program.cs:line 71
+            """).Lines;
+        Assert.Equal(5, lines.Count);
+
+        Assert.Equal("Program.<>c.<<Case1_AsyncLambda>b__8_0>d", lines[0].TypeFullName);
+        Assert.Equal("MoveNext", lines[0].MethodName);
+
+        Assert.Equal("Program", lines[1].TypeFullName);
+        Assert.Equal("<Case2_CapturingLocalFunction>g__Boom|9_0", lines[1].MethodName);
+        Assert.Equal("<>c__DisplayClass9_0&", lines[1].Parameters);
+
+        Assert.Equal("Program.<>c__DisplayClass10_0", lines[2].TypeFullName);
+        Assert.Equal("<Case2b_CapturingLocalFunctionWithLambda>g__Boom|1", lines[2].MethodName);
+
+        Assert.Equal("ThrowingStatics", lines[3].TypeFullName);
+        Assert.Equal(".cctor", lines[3].MethodName);
+
+        Assert.Equal("Program", lines[4].TypeFullName);
+        Assert.Equal("GenericThrow", lines[4].MethodName);
+        Assert.Equal(71, lines[4].Line);
+        Assert.False(lines[4].IsDemystified);
+    }
+
+    // ---- item 3: Demystifier grammar ----
+
+    [Fact]
+    public void Demystified_GenericReturnAndGenericType_KeepsFullMethodPath()
+    {
+        var f = Assert.Single(StackTraceParser.Parse(
+            "at TValue Demo.Repository<TKey, TValue>.GetById(TKey key)").Lines);
+        Assert.True(f.IsDemystified);
+        Assert.Equal("Demo.Repository<TKey, TValue>", f.TypeFullName);
+        Assert.Equal("GetById", f.MethodName);
+        Assert.Equal("TKey key", f.Parameters);
+    }
+
+    [Fact]
+    public void Demystified_TupleReturnType_DoesNotTruncateMethodPath()
+    {
+        var f = Assert.Single(StackTraceParser.Parse(
+            "at (bool ok, int v) Demo.Svc.TryGet(int id)").Lines);
+        Assert.True(f.IsDemystified);
+        Assert.Equal("Demo.Svc", f.TypeFullName);
+        Assert.Equal("TryGet", f.MethodName);
+        Assert.Equal("int id", f.Parameters);
+    }
+
+    [Fact]
+    public void Demystified_LocalFunctionSuffix_MapsToEnclosingMethod()
+    {
+        var f = Assert.Single(StackTraceParser.Parse(
+            "at void Demo.Svc.M(String[] a)+LocalFunc(int x)").Lines);
+        Assert.True(f.IsDemystified);
+        Assert.Equal("Demo.Svc", f.TypeFullName);
+        Assert.Equal("M", f.MethodName);
+        Assert.Equal("LocalFunc", f.DemystifiedLocalFunction);
+        Assert.Equal("String[] a", f.Parameters);
+    }
+
+    [Fact]
+    public void Demystified_LambdaSuffix_IsMarked()
+    {
+        var f = Assert.Single(StackTraceParser.Parse(
+            "at void Demo.Svc.M(String[] a)+(String s) => { }").Lines);
+        Assert.True(f.IsDemystified);
+        Assert.Equal("Demo.Svc", f.TypeFullName);
+        Assert.Equal("M", f.MethodName);
+        Assert.True(f.DemystifiedLambda);
+    }
+
+    // ---- item 4 (#303): AOT native offsets ----
+
+    [Fact]
+    public void AotFrame_WithHexOffset_Parses()
+    {
+        var f = Assert.Single(StackTraceParser.Parse("at MyApp.Foo.Bar() + 0x39").Lines);
+        Assert.False(f.IsFrameLikeUnparsed);
+        Assert.Equal("MyApp.Foo", f.TypeFullName);
+        Assert.Equal("Bar", f.MethodName);
+        Assert.Equal("", f.Parameters);
+    }
+
+    // ---- item 5 (#303): frame-like-but-unparsed lines surface in order ----
+
+    [Fact]
+    public void FrameLikeGarbage_SurfacesAsUnparsed_AtItsOriginalPosition()
+    {
+        var result = StackTraceParser.Parse("""
+            System.InvalidOperationException: boom
+               at ???bogus
+               at Demo.Program.Main()
+            """);
+        Assert.Equal(3, result.Lines.Count);
+        Assert.True(result.Lines[0].IsExceptionHeader);
+        Assert.True(result.Lines[1].IsFrameLikeUnparsed);
+        Assert.Equal("at ???bogus", result.Lines[1].Raw);
+        Assert.False(result.Lines[2].IsFrameLikeUnparsed);
+        Assert.Equal("Main", result.Lines[2].MethodName);
+        Assert.Equal("at ???bogus", Assert.Single(result.FrameLikeUnparsed));
+    }
+
+    // ---- item 6: Framework same-line inner exception chain ----
+
+    [Fact]
+    public void SameLineInnerException_SplitsIntoTwoHeaders_InOrder()
+    {
+        var lines = StackTraceParser.Parse(
+            "System.InvalidOperationException: outer ---> System.ArgumentNullException: nope").Lines;
+        Assert.Equal(2, lines.Count);
+        Assert.True(lines[0].IsExceptionHeader);
+        Assert.Equal("System.InvalidOperationException", lines[0].TypeFullName);
+        Assert.True(lines[1].IsExceptionHeader);
+        Assert.Equal("System.ArgumentNullException", lines[1].TypeFullName);
+    }
+
+    // ---- item 7: generic exception headers ----
+
+    [Fact]
+    public void GenericExceptionHeader_NormalizesTypeName()
+    {
+        var f = Assert.Single(StackTraceParser.Parse(
+            "Demo.ValidationException`1[Demo.Order]: order invalid").Lines);
+        Assert.True(f.IsExceptionHeader);
+        Assert.Equal("Demo.ValidationException", f.TypeFullName);
+    }
+
+    // ---- item 8: bare single-line fallback ----
+
+    [Fact]
+    public void BareSingleLine_StateMachineFrame_ParsesViaFallback()
+    {
+        var f = Assert.Single(StackTraceParser.Parse("Demo.Svc.<Run>d__3.MoveNext()").Lines);
+        Assert.Equal("Demo.Svc.<Run>d__3", f.TypeFullName);
+        Assert.Equal("MoveNext", f.MethodName);
+    }
+
+    [Fact]
+    public void BareSingleLine_WithoutParens_ParsesViaFallback()
+    {
+        var f = Assert.Single(StackTraceParser.Parse("Demo.Svc.<Run>d__3.MoveNext").Lines);
+        Assert.Equal("Demo.Svc.<Run>d__3", f.TypeFullName);
+        Assert.Equal("MoveNext", f.MethodName);
+    }
+
+    [Fact]
+    public void MultiLineNoiseOnly_ReturnsNoLines()
+        => Assert.Empty(StackTraceParser.Parse("noise line one\nnoise line two").Lines);
+
+    // ---- shared normalizer (item 1) ----
+
+    [Fact]
+    public void Normalizer_StripsInstantiationsAndArity_ConvertsPlusNesting()
+    {
+        Assert.Equal("Demo.ValidationException",
+            TypeNameNormalizer.Normalize("Demo.ValidationException`1[Demo.Order]"));
+        Assert.Equal("A.B.C",
+            TypeNameNormalizer.Normalize("A.B`2[[X, asm],[Y, asm]]+C"));
+        Assert.Equal("A.B`2+C",
+            TypeNameNormalizer.StripInstantiations("A.B`2[[X, asm],[Y, asm]]+C"));
+    }
 }

--- a/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
+++ b/tests/RoslynCodeLens.Tests/StackTraceParserTests.cs
@@ -8,7 +8,7 @@ public class StackTraceParserTests
     public void RuntimeFrame_WithFileAndLine_ParsesAllParts()
     {
         var lines = StackTraceParser.Parse(
-            @"at Demo.OrderService.Process(Int32 id) in C:\src\OrderService.cs:line 42");
+            @"at Demo.OrderService.Process(Int32 id) in C:\src\OrderService.cs:line 42").Lines;
         var f = Assert.Single(lines);
         Assert.False(f.IsExceptionHeader);
         Assert.Equal("Demo.OrderService", f.TypeFullName);
@@ -21,7 +21,7 @@ public class StackTraceParserTests
     [Fact]
     public void RuntimeFrame_WithoutFileInfo_ParsesTypeAndMethod()
     {
-        var f = Assert.Single(StackTraceParser.Parse("   at Demo.OrderService.Process(Int32 id)"));
+        var f = Assert.Single(StackTraceParser.Parse("   at Demo.OrderService.Process(Int32 id)").Lines);
         Assert.Equal("Demo.OrderService", f.TypeFullName);
         Assert.Null(f.File);
         Assert.Null(f.Line);
@@ -31,7 +31,7 @@ public class StackTraceParserTests
     public void LogPrefixedFrame_AnchorsOnAt()
     {
         var f = Assert.Single(StackTraceParser.Parse(
-            "2026-07-19 06:12:01.123 +02:00 [ERR]    at Demo.OrderService.Process(Int32 id)"));
+            "2026-07-19 06:12:01.123 +02:00 [ERR]    at Demo.OrderService.Process(Int32 id)").Lines);
         Assert.Equal("Demo.OrderService", f.TypeFullName);
         Assert.Equal("Process", f.MethodName);
     }
@@ -45,7 +45,7 @@ public class StackTraceParserTests
                at Demo.OrderService.Process(Int32 id)
                --- End of inner exception stack trace ---
                at Demo.Program.Main()
-            """);
+            """).Lines;
         Assert.Equal(4, lines.Count);          // separator line dropped
         Assert.True(lines[0].IsExceptionHeader);
         Assert.Equal("System.InvalidOperationException", lines[0].TypeFullName);
@@ -58,17 +58,17 @@ public class StackTraceParserTests
     public void MangledFrames_SplitOnLastDot_TypeKeepsMangledSegment()
     {
         var sm = Assert.Single(StackTraceParser.Parse(
-            "at Demo.OrderService+<ProcessAsync>d__12.MoveNext()"));
+            "at Demo.OrderService+<ProcessAsync>d__12.MoveNext()").Lines);
         Assert.Equal("Demo.OrderService+<ProcessAsync>d__12", sm.TypeFullName);
         Assert.Equal("MoveNext", sm.MethodName);
 
         var lambda = Assert.Single(StackTraceParser.Parse(
-            "at Demo.OrderService+<>c.<Process>b__5_0(Int32 x)"));
+            "at Demo.OrderService+<>c.<Process>b__5_0(Int32 x)").Lines);
         Assert.Equal("Demo.OrderService+<>c", lambda.TypeFullName);
         Assert.Equal("<Process>b__5_0", lambda.MethodName);
 
         var local = Assert.Single(StackTraceParser.Parse(
-            "at Demo.OrderService.<Process>g__Validate|5_0(Int32 x)"));
+            "at Demo.OrderService.<Process>g__Validate|5_0(Int32 x)").Lines);
         Assert.Equal("Demo.OrderService", local.TypeFullName);
         Assert.Equal("<Process>g__Validate|5_0", local.MethodName);
     }
@@ -77,7 +77,7 @@ public class StackTraceParserTests
     public void GenericTypeAndMethod_ParsesWithArityMarkers()
     {
         var f = Assert.Single(StackTraceParser.Parse(
-            "at Demo.Repository`1.GetById[TKey](TKey key)"));
+            "at Demo.Repository`1.GetById[TKey](TKey key)").Lines);
         Assert.Equal("Demo.Repository`1", f.TypeFullName);
         Assert.Equal("GetById", f.MethodName);      // [TKey] stripped from the name
     }
@@ -86,7 +86,7 @@ public class StackTraceParserTests
     public void DemystifiedFrame_IsRecognized_AndMarkedAsync()
     {
         var f = Assert.Single(StackTraceParser.Parse(
-            "at async Task<int> Demo.OrderService.ProcessAsync(int id)"));
+            "at async Task<int> Demo.OrderService.ProcessAsync(int id)").Lines);
         Assert.True(f.IsDemystified);
         Assert.True(f.DemystifiedAsync);
         Assert.Equal("Demo.OrderService", f.TypeFullName);
@@ -100,19 +100,19 @@ public class StackTraceParserTests
             some log chatter without a frame
             --- End of stack trace from previous location ---
             at Demo.Program.Main()
-            """);
+            """).Lines;
         var f = Assert.Single(lines);
         Assert.Equal("Main", f.MethodName);
     }
 
     [Fact]
     public void EmptyInput_ReturnsEmpty()
-        => Assert.Empty(StackTraceParser.Parse("   \n\n  "));
+        => Assert.Empty(StackTraceParser.Parse("   \n\n  ").Lines);
 
     [Fact]
     public void Constructor_Frame_Parses()
     {
-        var f = Assert.Single(StackTraceParser.Parse("at Demo.OrderService..ctor(String name)"));
+        var f = Assert.Single(StackTraceParser.Parse("at Demo.OrderService..ctor(String name)").Lines);
         Assert.Equal("Demo.OrderService", f.TypeFullName);
         Assert.Equal(".ctor", f.MethodName);
     }

--- a/tests/RoslynCodeLens.Tests/ToolDescriptionMdxSafetyTests.cs
+++ b/tests/RoslynCodeLens.Tests/ToolDescriptionMdxSafetyTests.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Reflection;
+using ModelContextProtocol.Server;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Authoring-time gate for DocGen's MDX pipeline: every tool description and parameter
+/// description must keep backticks balanced and put every '&lt;' / '{' inside a backtick
+/// code span. DocGen escapes bare ones defensively, but a stray backtick used to disable
+/// escaping for the rest of the string — keep the source descriptions clean instead.
+/// </summary>
+public class ToolDescriptionMdxSafetyTests
+{
+    private static IEnumerable<(string Label, string Description)> AllDescriptions()
+    {
+        var assembly = typeof(RoslynCodeLens.Tools.ResolveStackTraceTool).Assembly;
+        foreach (var type in assembly.GetTypes()
+                     .Where(t => t.GetCustomAttribute<McpServerToolTypeAttribute>() is not null))
+        {
+            var methods = type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null);
+
+            foreach (var method in methods)
+            {
+                var toolName = method.GetCustomAttribute<McpServerToolAttribute>()!.Name ?? method.Name;
+                var toolDesc = method.GetCustomAttribute<DescriptionAttribute>()?.Description;
+                if (toolDesc is not null)
+                    yield return (toolName, toolDesc);
+
+                foreach (var parameter in method.GetParameters())
+                {
+                    var paramDesc = parameter.GetCustomAttribute<DescriptionAttribute>()?.Description;
+                    if (paramDesc is not null)
+                        yield return ($"{toolName}({parameter.Name})", paramDesc);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void ReflectionReachesTheToolSurface()
+    {
+        // Guard against the gate silently going inert (e.g. attribute type mismatch).
+        var toolCount = AllDescriptions()
+            .Select(d => d.Label.Split('(')[0])
+            .Distinct(StringComparer.Ordinal)
+            .Count();
+        Assert.True(toolCount >= 59, $"Expected at least 59 tools with descriptions, found {toolCount}.");
+    }
+
+    [Fact]
+    public void AllToolAndParameterDescriptions_AreMdxSafe()
+    {
+        var violations = new List<string>();
+        foreach (var (label, description) in AllDescriptions())
+        {
+            if (description.Count(c => c == '`') % 2 != 0)
+            {
+                violations.Add($"{label}: unbalanced backticks");
+                continue; // code-span tracking below would be meaningless
+            }
+
+            var inCode = false;
+            foreach (var ch in description)
+            {
+                if (ch == '`') { inCode = !inCode; continue; }
+                if (!inCode && ch is '<' or '{')
+                {
+                    violations.Add($"{label}: bare '{ch}' outside a backtick code span");
+                    break;
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            "MDX-unsafe tool descriptions (wrap mangled-name tokens in backticks):\n  "
+            + string.Join("\n  ", violations));
+    }
+}

--- a/tools/DocGen/Program.cs
+++ b/tools/DocGen/Program.cs
@@ -186,6 +186,9 @@ static string EscapeYaml(string s) =>
 // MDX parses '<' and '{' outside inline code spans as JSX, so tool descriptions containing
 // compiler-mangled names (<M>d__N.MoveNext, <>c) break the docs build. Backslash-escape them
 // everywhere except inside backtick code spans, where MDX already treats them literally.
+// If the backticks turn out unbalanced, the toggle would leave escaping disabled from the
+// stray backtick onward — fall back to escaping ALL '<'/'{' regardless of code spans.
+// (ToolDescriptionMdxSafetyTests is the authoring-time gate that keeps this path cold.)
 static string EscapeMdx(string s)
 {
     var sb = new StringBuilder(s.Length + 8);
@@ -194,6 +197,14 @@ static string EscapeMdx(string s)
     {
         if (ch == '`') { inCode = !inCode; sb.Append(ch); continue; }
         if (!inCode && ch is '<' or '{') sb.Append('\\');
+        sb.Append(ch);
+    }
+    if (!inCode) return sb.ToString();
+
+    sb.Clear();
+    foreach (var ch in s)
+    {
+        if (ch is '<' or '{') sb.Append('\\');
         sb.Append(ch);
     }
     return sb.ToString();


### PR DESCRIPTION
Fixes #303. Also addresses the 10 findings from the post-merge review of #301, grounded in empirical net10 `Exception.ToString()` output (real traces print nested types with `.`, auto-demangle ordinary async frames, and emit `<<M>b__N>d` async-lambda machines — different shapes than the original tests assumed).

## Summary
- **Parser/demangler** (empirical fixtures as tests): dot-nested mangled containers (modern .NET) alongside `+` (Framework); async-lambda (`<<M>b__N>d`) and async-local-function state machines; display-class stripping for capturing local functions; rewritten Demystifier grammar (balanced-parens parameter scan — generic type params with spaces, ValueTuple parens, `+LocalFunc(...)` suffixes); generic exception headers (`` Ex`1[...] ``); Framework same-line ` ---> ` inner headers; shared `TypeNameNormalizer`
- **#303 items**: AOT ` + 0xNN` frames now parse; frame-like-but-unparseable lines surface as `Kind="unknown"` items in position plus a `skippedFrameLike` summary count — trimmed traces are no longer silently incomplete; single-line bare mangled input works via a fallback parse
- **Resolution**: overload pick counts top-level commas only (bracket-depth aware); `.cctor` resolves via `StaticConstructors` (member-form metadata fallback skipped for ctors); metadata fallback tries the original runtime name form (`+`/backticks) first so `GetTypeByMetadataName` can actually match; unused `LoadedSolution` parameter dropped
- **DocGen**: unbalanced backticks can no longer disable MDX escaping; new authoring-time test asserts every tool/parameter description is MDX-safe (balanced backticks, no bare `<`/`{` outside code spans)
- **Docs**: SKILL.md metadata claim corrected + `skippedFrameLike` documented; BACKLOG shipped bullet cites #301 + Recently-shipped row added; README tool list gains rename_symbol and resolve_stack_trace

## Test Plan
- [x] 35 new tests (19 W1 + 16 W2), red-first; empirical trace lines quoted verbatim as fixtures
- [x] Full suite: 735/735 pass
- [x] No existing assertion weakened (migrations were mechanical accessor renames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)