### PR TITLE
feat: change_signature — add, remove, and reorder parameters across the solution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 63 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 64 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **get_code_actions** — Discover available refactorings and fixes at any position (extract method, rename, inline variable, and more)
 - **apply_code_action** — Execute any Roslyn refactoring by title, with preview mode (returns a diff before writing to disk)
 - **rename_symbol** — Solution-wide safe rename of a type or member via Roslyn's Renamer, with preview mode, conflict reporting, and a freshness check against on-disk edits
+- **change_signature** — Add, remove, and reorder a method's parameters and rewrite every call site; handles named/optional arguments, `params` and extension methods, and reports the overrides and interface implementations it cascaded to
 - **list_solutions** — List all loaded solutions and which one is currently active
 - **set_active_solution** — Switch the active solution by partial name (all subsequent tools operate on it)
 - **load_solution** — Load an additional .sln/.slnx at runtime and make it the active solution

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -46,7 +46,7 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 ### Medium value
 
-- **`change_signature`** — add/remove/reorder parameters with all call sites updated. Like rename, not reachable via code actions.
+- ✅ **`change_signature`** — *shipped* (PR #312). Add/remove/reorder parameters with all call sites updated, via a reflection bridge over Roslyn's internal change-signature engine (no public API exists, unlike `Renamer`). Design: [docs/plans/2026-07-20-change-signature-design.md](plans/2026-07-20-change-signature-design.md).
 - **`get_extension_methods`** — which extension methods (including C# 14 extension blocks) apply to a given type. Not answerable with current tools.
 - **`get_instantiation_options`** — "how do I construct this type": accessible constructors, factory methods, DI registration. Pairs well with `generate_test_skeleton`.
 - **Cognitive complexity + nesting depth in `get_complexity_metrics`** — we only report cyclomatic; cognitive complexity is a better refactoring-priority signal. Enhancement to the existing tool.
@@ -69,6 +69,7 @@ Items previously in this backlog, now merged. Listed for orientation; do not re-
 
 | Tool | Theme | PR |
 |---|---|---|
+| `change_signature` | Refactoring | #312 |
 | `get_exception_flow` | Analysis | #309 |
 | `find_throw_sites` | Analysis | #309 |
 | `find_catch_blocks` | Analysis | #309 |

--- a/docs/plans/2026-07-20-change-signature-design.md
+++ b/docs/plans/2026-07-20-change-signature-design.md
@@ -82,3 +82,27 @@ Matrix on `RenameTestWorkspace`: each operation alone and combined; named argume
 ## Docs
 
 SKILL.md: Red Flags row ("add/remove/reorder a parameter" / "let me edit N call sites"), tool bullet next to `rename_symbol`, Quick Reference row, metadata-support row (source only). CLAUDE.md 63 → **64**. `tools/DocGen/Program.cs` categoryMap → `diagnostics` (alongside `rename_symbol`). README bullet. BACKLOG: mark shipped + Recently-shipped row.
+
+## Corrections found during pre-merge review
+
+Three assumptions in the sections above were verified against the running Roslyn build and did
+not hold. The implementation now guards each one:
+
+- **`ParameterConfiguration.Create` does not "preserve" the `this` and `params` slots — it
+  re-derives them by POSITION.** Index 0 of the updated list becomes the extension-method
+  receiver, and only the final element can be `params`. A reorder or remove is therefore capable
+  of rebinding `this` to a different parameter, or of stranding a `params` array mid-list (CS0231).
+  Both are refused before the bridge is reached.
+- **An unresolved added-parameter type is not written literally.**
+  `CSharpChangeSignatureService.CreateNewParameterSyntax` calls
+  `addedParameter.Type.GenerateTypeSyntax()` unconditionally; the `typeBinds` flag does not gate
+  that path, so a null `ITypeSymbol` NullReferenceExceptions inside Roslyn. An unresolvable — or
+  ambiguous — `type` is now an `InvalidArgument` refusal.
+- **`CascadedTo` must be computed from the ROOT of the hierarchy, not from the target.** Roslyn
+  cascades across the whole override/implementation set, so a target that is itself a derived
+  override or an interface implementation under-reported its blast radius when the walk only went
+  downward.
+
+`InvalidArgument` accordingly also covers: an added name that is not a valid C# identifier or
+collides with an existing parameter, a `type` that does not resolve or is ambiguous, displacing or
+removing an extension receiver, and leaving a surviving `params` array anywhere but last.

--- a/docs/plans/2026-07-20-change-signature-design.md
+++ b/docs/plans/2026-07-20-change-signature-design.md
@@ -1,0 +1,77 @@
+# `change_signature` — Design
+
+Date: 2026-07-20
+Status: Approved
+Origin: SharpLensMcp gap analysis (docs/BACKLOG.md §5, medium tier). Add, remove, and reorder a method's parameters with every call site updated. Like `rename_symbol`, it is not reachable through `apply_code_action`. Tool count 63 → 64.
+
+## Empirical findings (verified, not assumed)
+
+A probe against Microsoft.CodeAnalysis 5.6 established the constraints that shape this design:
+
+- **Every `ChangeSignature` type in Roslyn is internal** — `Microsoft.CodeAnalysis.Features` exports **zero** public `ChangeSignature` types, in direct contrast to `Renamer`, which is public in `Workspaces`. There is no supported public API.
+- **`AbstractChangeSignatureService.ChangeSignature(SemanticDocument, ISymbol, SyntaxNode, SyntaxNode, SignatureChange, LineFormattingOptions, CancellationToken)` is a *public method on an internal type*** — reachable by reflection, and it takes a `SignatureChange` directly.
+- **That entry point bypasses the UI.** `IChangeSignatureOptionsService` exists but is only consumed by the interactive `ChangeSignatureWithContextAsync` path (the IDE dialog). Driving `ChangeSignature(...)` needs no options service.
+- **`ParameterConfiguration(ExistingParameter thisParameter, ImmutableArray<…> parametersWithoutDefaultValues, ImmutableArray<…> remainingEditableParameters, ExistingParameter paramsParameter, int selectedIndex)`** models the extension-method `this` parameter, the `params` array, and the default-value split as first-class slots.
+- `SignatureChange(ParameterConfiguration original, ParameterConfiguration updated)`.
+
+## Decisions (brainstorming outcomes)
+
+| Question | Decision |
+|---|---|
+| Engine | **Reflection into Roslyn's internal service.** It already handles cascading to overrides and interface implementations, named and optional arguments, `params` arrays, extension-method `this`, and XML `<param>` docs. Hand-rolling that matrix is where a write tool ships silent corruption — every review this session found 2–4 real bugs in far simpler read-only analysis. |
+| Operations | **remove + reorder + add.** |
+| Added-parameter values | **Caller supplies `callSiteValue`, required.** No inference: the tool never guesses semantics at a call site. An optional `defaultValue` makes the parameter optional, letting existing call sites omit it — the genuinely safe form. |
+| Safety | `rename_symbol`'s model — preview default, diagnostics-delta conflicts with `force`, degraded-load refusal, shared write path — **plus a `cascadedTo` report** naming every override/implementation Roslyn also rewrote, so the blast radius is visible before applying. |
+
+## Tool contract
+
+```
+change_signature(
+  method: string,
+  operations: [
+    { kind: "remove",  parameter: "logger" },
+    { kind: "reorder", order: ["id", "name", "token"] },
+    { kind: "add", name: "token", type: "System.Threading.CancellationToken",
+      callSiteValue: "CancellationToken.None", defaultValue: "default" }
+  ],
+  preview: bool = true,
+  force: bool = false)
+```
+
+Operations apply in order against the original parameter list. `reorder` takes a full permutation of the parameters surviving at that point (partial orders are rejected rather than guessed at). `add` appends unless the following `reorder` places it.
+
+## Result — `ChangeSignatureResult`
+
+`{ Success, Method (resolved display), OldSignature, NewSignature, Applied, Edits[], FilesChanged, CascadedTo[] (display strings of overrides/implementations also rewritten), Conflicts[] (RenameConflict shape), Message }`.
+
+## Architecture
+
+`Analysis/ChangeSignatureBridge.cs` isolates **every** reflection call behind one typed surface: resolve the internal types and members once (cached in a `Lazy`), build the original and updated `ParameterConfiguration` preserving Roslyn's `this`/`params`/default-value slots, construct `SignatureChange`, invoke `ChangeSignature(...)`, and return a plain `Solution`. No reflection leaks into the logic or tool layers.
+
+**Failure mode is loud, never silent.** If any probe fails — a Roslyn upgrade renaming a type or changing a signature — the bridge throws `McpToolException(Internal, …)` naming the missing member *before anything is written*. A tool that rewrites call sites must never degrade gracefully into partial work.
+
+`ChangeSignatureLogic` resolves the method (`SymbolResolver` → overload group ⇒ `AmbiguousMatch`), validates the operation list against the actual parameters, calls the bridge, computes conflicts and the cascade set, and returns edits. `ChangeSignatureTool` is the thin MCP wrapper passing `manager.CommitDocumentTextsAsync`.
+
+## Safety pipeline (reusing shipped infrastructure)
+
+1. Degraded load → refuse apply unless `force`; warn in preview.
+2. Bridge probe → `Internal` error if the API moved.
+3. Diagnostics delta (compiler errors, count-based per `(Id, FilePath)` as established in #300) → `Conflicts`; apply refuses unless `force`.
+4. `SolutionChangeWriter.WriteChangesToDiskAsync` → freshness refusal, atomic writes with rollback, encoding preservation.
+5. `SolutionChangeWriter.CommitAsync` → immediate snapshot update; no outcome may fail the operation.
+
+## Errors
+
+`SymbolNotFound` (method or parameter), `AmbiguousMatch` (overloads — the caller must qualify), `InvalidArgument` (empty operations, unknown `kind`, `reorder` that isn't a permutation, `add` without `callSiteValue`, removing a parameter that doesn't exist), `Internal` (bridge probe failure).
+
+## Known limits
+
+Static rewriting only: reflection-based and `dynamic` call sites are not updated, and neither are call sites in projects that failed to load. Partial methods and cross-project overrides follow Roslyn's own cascade rules. Delegates whose shape no longer matches are surfaced through the conflict check rather than rewritten.
+
+## Testing
+
+Matrix on `RenameTestWorkspace`: each operation alone and combined; named arguments at call sites; optional parameters; `params` arrays; extension-method `this`; the override and interface-implementation cascade (asserting `CascadedTo`); XML `<param>` doc updates; `add` with and without `defaultValue` (call sites updated vs left omitting); conflict detection when a removed parameter is still referenced in the body; every error case above; preview leaves disk untouched; apply writes and commits. Plus a **bridge-probe test** that fails loudly if the internal API moves — the early-warning system for a Roslyn upgrade. Fixture integration on TestSolution (preview only, so fixture files stay pristine).
+
+## Docs
+
+SKILL.md: Red Flags row ("add/remove/reorder a parameter" / "let me edit N call sites"), tool bullet next to `rename_symbol`, Quick Reference row, metadata-support row (source only). CLAUDE.md 63 → **64**. `tools/DocGen/Program.cs` categoryMap → `diagnostics` (alongside `rename_symbol`). README bullet. BACKLOG: mark shipped + Recently-shipped row.

--- a/docs/plans/2026-07-20-change-signature-design.md
+++ b/docs/plans/2026-07-20-change-signature-design.md
@@ -9,10 +9,16 @@ Origin: SharpLensMcp gap analysis (docs/BACKLOG.md §5, medium tier). Add, remov
 A probe against Microsoft.CodeAnalysis 5.6 established the constraints that shape this design:
 
 - **Every `ChangeSignature` type in Roslyn is internal** — `Microsoft.CodeAnalysis.Features` exports **zero** public `ChangeSignature` types, in direct contrast to `Renamer`, which is public in `Workspaces`. There is no supported public API.
-- **`AbstractChangeSignatureService.ChangeSignature(SemanticDocument, ISymbol, SyntaxNode, SyntaxNode, SignatureChange, LineFormattingOptions, CancellationToken)` is a *public method on an internal type*** — reachable by reflection, and it takes a `SignatureChange` directly.
-- **That entry point bypasses the UI.** `IChangeSignatureOptionsService` exists but is only consumed by the interactive `ChangeSignatureWithContextAsync` path (the IDE dialog). Driving `ChangeSignature(...)` needs no options service.
+- **The public-looking `AbstractChangeSignatureService.ChangeSignature(…)` returns a `SyntaxNode`, not a `Solution`** — it rewrites only the *declaration*. Driving it would change the signature and leave every call site broken. **This is the trap in this design, and the probe is the only reason it isn't in the implementation.**
+- **The solution-wide entry point is `ChangeSignatureWithContextAsync(ChangeSignatureAnalyzedContext, ChangeSignatureOptionsResult, CancellationToken)` → `Task<ChangeSignatureResult>`** (internal, reflectable). `ChangeSignatureResult` exposes `Succeeded`, `UpdatedSolution`, `ChangeSignatureFailureKind`, and `ConfirmationMessage` — Roslyn reports its own refusals, so we surface those rather than inventing our own.
+- **The context can be constructed directly**: `ChangeSignatureAnalysisSucceededContext(SemanticDocument document, int positionForTypeBinding, ISymbol symbol, ParameterConfiguration parameterConfiguration)`. Building it from our already-resolved symbol avoids `GetChangeSignatureContextAsync`'s cursor-position lookup entirely — much more robust for a name-addressed tool.
+- **No UI dependency.** `IChangeSignatureOptionsService` is consumed only by the IDE dialog flow; supplying `ChangeSignatureOptionsResult(SignatureChange updatedSignature, bool previewChanges)` ourselves bypasses it.
 - **`ParameterConfiguration(ExistingParameter thisParameter, ImmutableArray<…> parametersWithoutDefaultValues, ImmutableArray<…> remainingEditableParameters, ExistingParameter paramsParameter, int selectedIndex)`** models the extension-method `this` parameter, the `params` array, and the default-value split as first-class slots.
+- **`AddedParameter(ITypeSymbol type, string typeName, string name, CallSiteKind callSiteKind, string callSiteValue, bool isRequired, string defaultValue, bool typeBinds)`** — matches the caller-supplies-the-value decision exactly; `ExistingParameter(IParameterSymbol)` wraps survivors.
 - `SignatureChange(ParameterConfiguration original, ParameterConfiguration updated)`.
+- `CSharpChangeSignatureService` has a parameterless constructor and is `[ExportLanguageService]`/`[Shared]`, so it can be obtained from workspace language services or instantiated directly.
+
+**One unknown left for implementation:** constructing the `SemanticDocument` the context requires (internal type, expected to have a static async factory). Resolve it by probe before writing the bridge, not by guessing.
 
 ## Decisions (brainstorming outcomes)
 
@@ -46,7 +52,7 @@ Operations apply in order against the original parameter list. `reorder` takes a
 
 ## Architecture
 
-`Analysis/ChangeSignatureBridge.cs` isolates **every** reflection call behind one typed surface: resolve the internal types and members once (cached in a `Lazy`), build the original and updated `ParameterConfiguration` preserving Roslyn's `this`/`params`/default-value slots, construct `SignatureChange`, invoke `ChangeSignature(...)`, and return a plain `Solution`. No reflection leaks into the logic or tool layers.
+`Analysis/ChangeSignatureBridge.cs` isolates **every** reflection call behind one typed surface. Resolve the internal types and members once (cached in a `Lazy`), then per request: wrap survivors in `ExistingParameter` and new parameters in `AddedParameter`, build the original and updated `ParameterConfiguration` preserving Roslyn's `this`/`params`/default-value slots, construct `SignatureChange` and `ChangeSignatureOptionsResult`, build a `ChangeSignatureAnalysisSucceededContext` from the resolved symbol, invoke `ChangeSignatureWithContextAsync`, and return a typed record carrying `Succeeded`, `UpdatedSolution`, and Roslyn's own failure kind/message. No reflection leaks into the logic or tool layers.
 
 **Failure mode is loud, never silent.** If any probe fails — a Roslyn upgrade renaming a type or changing a signature — the bridge throws `McpToolException(Internal, …)` naming the missing member *before anything is written*. A tool that rewrites call sites must never degrade gracefully into partial work.
 
@@ -56,6 +62,7 @@ Operations apply in order against the original parameter list. `reorder` takes a
 
 1. Degraded load → refuse apply unless `force`; warn in preview.
 2. Bridge probe → `Internal` error if the API moved.
+2b. Roslyn's own verdict → if `ChangeSignatureResult.Succeeded` is false, surface its `ChangeSignatureFailureKind`/`ConfirmationMessage` and write nothing.
 3. Diagnostics delta (compiler errors, count-based per `(Id, FilePath)` as established in #300) → `Conflicts`; apply refuses unless `force`.
 4. `SolutionChangeWriter.WriteChangesToDiskAsync` → freshness refusal, atomic writes with rollback, encoding preservation.
 5. `SolutionChangeWriter.CommitAsync` → immediate snapshot update; no outcome may fail the operation.

--- a/docs/plans/2026-07-20-change-signature-implementation.md
+++ b/docs/plans/2026-07-20-change-signature-implementation.md
@@ -1,0 +1,263 @@
+# change_signature — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A `change_signature` MCP tool that adds, removes, and reorders a method's parameters and updates every call site, driving Roslyn's internal change-signature engine through one isolated reflection bridge.
+
+**Architecture:** `Analysis/ChangeSignatureBridge.cs` owns **every** reflection call and exposes one typed method. `ChangeSignatureLogic` resolves the method, validates operations, calls the bridge, computes conflicts + the cascade set, and returns edits. `ChangeSignatureTool` is the thin MCP wrapper. Safety reuses the shipped write path unchanged. Design doc: `docs/plans/2026-07-20-change-signature-design.md` — **read it first**, especially the verified-internals section.
+
+**Tech Stack:** Roslyn 5.6 (existing deps; internal APIs via reflection), xUnit, `RenameTestWorkspace`.
+
+**Working directory:** `.worktrees/change-signature`, branch `feature/change-signature`. All commands from its root.
+
+---
+
+## Verified Roslyn internals — use these exactly, do not re-derive
+
+All probed against Microsoft.CodeAnalysis 5.6. `AbstractChangeSignatureService` and friends live in `Microsoft.CodeAnalysis.Features`; `SemanticDocument` in `Microsoft.CodeAnalysis.Workspaces`.
+
+| Member | Signature |
+|---|---|
+| `SemanticDocument.CreateAsync` | `static Task<SemanticDocument>(Document, CancellationToken)` — **public type in Workspaces** |
+| `ParameterConfiguration.Create` | `static ParameterConfiguration(ImmutableArray<Parameter>, bool isExtensionMethod, int selectedIndex)` — derives the `this`/`params`/default split itself; **prefer this over the 5-arg ctor** |
+| `ExistingParameter` | `ctor(IParameterSymbol)` |
+| `AddedParameter` | `ctor(ITypeSymbol type, string typeName, string name, CallSiteKind, string callSiteValue, bool isRequired, string defaultValue, bool typeBinds)` |
+| `CallSiteKind` | enum: `Value, ValueWithName, Todo, Omitted, Inferred` — use `Value` for an explicit call-site value, `Omitted` when the parameter is optional and existing calls should skip it |
+| `SignatureChange` | `ctor(ParameterConfiguration originalConfiguration, ParameterConfiguration updatedConfiguration)` |
+| `ChangeSignatureOptionsResult` | `ctor(SignatureChange updatedSignature, bool previewChanges)` |
+| `ChangeSignatureAnalysisSucceededContext` | `ctor(SemanticDocument, int positionForTypeBinding, ISymbol, ParameterConfiguration)` |
+| `AbstractChangeSignatureService.ChangeSignatureWithContextAsync` | `Task<ChangeSignatureResult>(ChangeSignatureAnalyzedContext, ChangeSignatureOptionsResult, CancellationToken)` — **internal instance method; this is the solution-wide entry point** |
+| `ChangeSignatureResult` | `.Succeeded`, `.UpdatedSolution`, `.ChangeSignatureFailureKind`, `.ConfirmationMessage` |
+| `CSharpChangeSignatureService` | in `Microsoft.CodeAnalysis.CSharp.Features`; parameterless ctor, `[ExportLanguageService]` |
+
+**DO NOT use `AbstractChangeSignatureService.ChangeSignature(...)`.** It looks like the entry point and is even public, but it returns a `SyntaxNode` — it rewrites the declaration only and would leave every call site broken.
+
+`Parameter` is the abstract base of `ExistingParameter`/`AddedParameter`; build `ImmutableArray<Parameter>` reflectively (create a typed array via `Array.CreateInstance(parameterType, n)` then `ImmutableArray.Create`-equivalent, or call the generic `ImmutableArray.CreateRange<T>` via `MakeGenericMethod`).
+
+---
+
+### Task 1: Models
+
+**Files:** Create `src/RoslynCodeLens/Models/SignatureOperation.cs`, `ChangeSignatureResult.cs`.
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+/// <summary>
+/// One edit to a parameter list, applied in order against the original parameters.
+/// Kind: remove | reorder | add.
+/// remove  → Parameter names the parameter to drop.
+/// reorder → Order is a full permutation of the names surviving at that point.
+/// add     → Name/Type plus CallSiteValue (required: what every existing call site passes).
+///           DefaultValue makes the parameter optional, letting existing calls omit it instead.
+/// </summary>
+public record SignatureOperation(
+    string Kind,
+    string? Parameter = null,
+    IReadOnlyList<string>? Order = null,
+    string? Name = null,
+    string? Type = null,
+    string? CallSiteValue = null,
+    string? DefaultValue = null);
+```
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record ChangeSignatureResult(
+    bool Success,
+    string Method,
+    string OldSignature,
+    string NewSignature,
+    bool Applied,
+    IReadOnlyList<TextEdit> Edits,
+    int FilesChanged,
+    IReadOnlyList<string> CascadedTo,
+    IReadOnlyList<RenameConflict> Conflicts,
+    string Message);
+```
+
+`RenameConflict` already exists (`{ Id, Message, File, Line }`) — reuse it, do not clone.
+
+Build → commit `feat: change_signature models`.
+
+---
+
+### Task 2: ChangeSignatureBridge (TDD — probe first)
+
+**Files:** Create `tests/RoslynCodeLens.Tests/ChangeSignatureBridgeTests.cs`, `src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs`.
+
+**Step 1: the probe test comes first — it is the early-warning system for a Roslyn upgrade.**
+
+```csharp
+using RoslynCodeLens.Analysis;
+
+namespace RoslynCodeLens.Tests;
+
+public class ChangeSignatureBridgeTests
+{
+    /// <summary>
+    /// Every internal Roslyn member the bridge needs must resolve. If a Roslyn upgrade moves or
+    /// renames one, this fails loudly here rather than at a user's apply — which is the whole
+    /// reason the reflection is confined to one probeable surface.
+    /// </summary>
+    [Fact]
+    public void Probe_ResolvesEveryRequiredMember()
+    {
+        var missing = ChangeSignatureBridge.Probe();
+        Assert.Empty(missing);
+    }
+}
+```
+
+**Step 2:** run `--filter "FullyQualifiedName~ChangeSignatureBridge"` → FAIL (type missing).
+
+**Step 3: implement the bridge.** Shape (fill in against the table above):
+
+```csharp
+namespace RoslynCodeLens.Analysis;
+
+/// <summary>Outcome of Roslyn's own change-signature engine, with its verdict preserved.</summary>
+public sealed record BridgeResult(bool Succeeded, Solution? UpdatedSolution, string? FailureMessage);
+
+/// <summary>Describes one parameter of the target signature, in final order.</summary>
+public sealed record DesiredParameter(
+    IParameterSymbol? Existing,                 // null for an added parameter
+    string? Name, string? TypeName, ITypeSymbol? Type,
+    string? CallSiteValue, string? DefaultValue);
+
+/// <summary>
+/// The ONLY place that touches Roslyn's internal change-signature API. Everything reflective is
+/// resolved once and cached; <see cref="Probe"/> reports anything missing so a Roslyn upgrade
+/// fails loudly instead of degrading into partial work.
+/// </summary>
+public static class ChangeSignatureBridge
+{
+    // Lazy<Members> resolving: the two assemblies, each type in the table, each ctor/method.
+    // Probe() returns the names of anything unresolved (empty list = healthy).
+    public static IReadOnlyList<string> Probe() { /* ... */ }
+
+    public static async Task<BridgeResult> ChangeSignatureAsync(
+        Document document, IMethodSymbol method,
+        IReadOnlyList<DesiredParameter> updated, CancellationToken ct)
+    {
+        // 1. SemanticDocument.CreateAsync(document, ct)
+        // 2. original = ParameterConfiguration.Create([ExistingParameter(p) for p in method.Parameters],
+        //                                            method.IsExtensionMethod, selectedIndex: 0)
+        // 3. updatedConfig = ParameterConfiguration.Create(mapped `updated`, method.IsExtensionMethod, 0)
+        //      ExistingParameter(sym) for survivors;
+        //      AddedParameter(type, typeName, name,
+        //          DefaultValue == null ? CallSiteKind.Value : CallSiteKind.Omitted,
+        //          callSiteValue, isRequired: DefaultValue == null, defaultValue, typeBinds: type != null)
+        // 4. change = SignatureChange(original, updatedConfig)
+        // 5. context = ChangeSignatureAnalysisSucceededContext(semanticDoc, 0, method, original)
+        // 6. options = ChangeSignatureOptionsResult(change, previewChanges: false)
+        // 7. service = CSharpChangeSignatureService instance (Activator.CreateInstance, or the
+        //    workspace language service if direct construction misbehaves — try direct first)
+        // 8. result = await (Task)ChangeSignatureWithContextAsync.Invoke(service, [context, options, ct])
+        // 9. read .Succeeded / .UpdatedSolution / .ConfirmationMessage into BridgeResult
+    }
+}
+```
+
+Every reflective failure throws `McpToolException(ToolErrorCode.Internal, "...", new { member })` naming the member. Never swallow.
+
+**Step 4:** probe test green.
+
+**Step 5:** add a real end-to-end bridge test before moving on — a two-parameter method with one call site, reordered:
+
+```csharp
+[Fact]
+public async Task Reorder_RewritesDeclarationAndCallSite()
+{
+    var (loaded, resolver) = RenameTestWorkspace.Create(("Demo.cs", """
+        namespace Demo;
+        public class Svc
+        {
+            public int Add(int a, string b) => a;
+            public int Use() => Add(1, "x");
+        }
+        """));
+    var method = (IMethodSymbol)resolver.FindSymbols("Svc.Add").Single();
+    var doc = loaded.Solution.GetDocument(
+        method.DeclaringSyntaxReferences[0].SyntaxTree)!;
+
+    var reordered = new[] { method.Parameters[1], method.Parameters[0] }
+        .Select(p => new DesiredParameter(p, null, null, null, null, null)).ToList();
+
+    var result = await ChangeSignatureBridge.ChangeSignatureAsync(doc, method, reordered, default);
+
+    Assert.True(result.Succeeded, result.FailureMessage);
+    var text = (await result.UpdatedSolution!.GetDocument(doc.Id)!.GetTextAsync()).ToString();
+    Assert.Contains("Add(string b, int a)", text, StringComparison.Ordinal);
+    Assert.Contains("Add(\"x\", 1)", text, StringComparison.Ordinal);   // call site followed
+}
+```
+
+**If this test does not rewrite the call site, stop and report — the entry point is wrong and the rest of the plan is void.** That assertion is the plan's single most important check.
+
+Commit `feat: ChangeSignatureBridge over Roslyn's internal engine`.
+
+---
+
+### Task 3: ChangeSignatureLogic (TDD)
+
+**Files:** Create `tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs`, `src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs`.
+
+Signature: `ExecuteAsync(LoadedSolution loaded, SymbolResolver resolver, string method, IReadOnlyList<SignatureOperation> operations, bool preview, bool force, CommitWrittenDocuments? commitToMemory, CancellationToken ct)`.
+
+Flow: resolve method (overload group with >1 member ⇒ `AmbiguousMatch` listing signatures) → degraded-load guard (as `RenameSymbolLogic`) → apply operations to build `DesiredParameter[]` → bridge → if `!Succeeded` return failure carrying Roslyn's message → extract edits + conflicts (reuse the count-based diagnostics diff already in `RenameSymbolLogic`; extract it to a shared helper rather than copying — reviewers have flagged duplication repeatedly) → cascade set via `SymbolFinder.FindOverridesAsync` + `FindImplementationsAsync` on the original symbol → preview/apply gates → `SolutionChangeWriter.WriteChangesToDiskAsync` → `SolutionChangeWriter.CommitAsync`.
+
+**Operation application** against `method.Parameters`:
+- `remove`: drop by name; unknown name ⇒ `SymbolNotFound`.
+- `reorder`: `Order` must be exactly the multiset of surviving names ⇒ else `InvalidArgument` naming the difference.
+- `add`: `Name`, `Type`, `CallSiteValue` all required ⇒ else `InvalidArgument`; resolve `Type` via `SymbolResolver`/`MetadataSymbolResolver`, and if it doesn't resolve pass `typeBinds: false` with the literal type name (Roslyn supports that).
+
+**Tests** (fixture source with an interface, an implementor, an override, an extension method, named-argument and optional-parameter call sites):
+
+1. `Remove_DropsParameterAndUpdatesCallSites`
+2. `Reorder_RewritesCallSitesInNewOrder`
+3. `Add_InsertsCallSiteValueEverywhere` — `callSiteValue: "CancellationToken.None"` appears at each call site
+4. `Add_WithDefault_LeavesExistingCallSitesAlone` — `defaultValue` set ⇒ `CallSiteKind.Omitted`; call sites unchanged, declaration gains an optional parameter
+5. `NamedArguments_AreRewritten` — a call site using `name:` syntax survives a reorder correctly
+6. `InterfaceImplementation_IsCascaded` — changing the interface method updates the implementor, and `CascadedTo` names it
+7. `Override_IsCascaded`
+8. `ExtensionMethod_ThisParameterPreserved` — reorder of an extension method keeps `this` first
+9. `RemovedParameterStillUsed_ProducesConflict` — removing a parameter the body references ⇒ `Conflicts` non-empty, apply refused without `force`
+10. `Overloads_AreAmbiguous` → `AmbiguousMatch`
+11. `UnknownMethod` → `SymbolNotFound`; `UnknownParameter` → `SymbolNotFound`
+12. `ReorderNotAPermutation` → `InvalidArgument`; `AddWithoutCallSiteValue` → `InvalidArgument`; `EmptyOperations` → `InvalidArgument`
+13. `Preview_LeavesDiskUntouched` / `Apply_WritesAndCommits` (temp-dir workspace, mirroring the rename tests)
+14. `RoslynRefusal_IsSurfaced` — if a case exists where Roslyn returns `Succeeded: false`, assert its message reaches `Message`; if none is constructible, note it in the report rather than faking one.
+
+Commit `feat: change_signature resolution, operations, and safety gates`.
+
+---
+
+### Task 4: Tool wrapper + fixture test
+
+**Files:** Create `src/RoslynCodeLens/Tools/ChangeSignatureTool.cs`, `tests/RoslynCodeLens.Tests/ChangeSignatureFixtureTests.cs`.
+
+Wrapper mirrors `RenameSymbolTool`: `manager.EnsureLoaded()`, `GetAnalysisContext()`, passes `manager.CommitDocumentTextsAsync`. Parameters: `method`, `operations` (array of the model), `preview = true`, `force = false`. The `[Description]` must explain each operation kind and that `callSiteValue` is required for `add` — and must pass `ToolDescriptionMdxSafetyTests` (backtick every code token; no bare `<`/`{`).
+
+Fixture test: preview-only against `TestSolutionFixture` so fixture files stay pristine — reorder `Greeter.Greet`'s parameters (check its real signature first) and assert edits span the declaration and its test call sites.
+
+Commit `feat: expose change_signature MCP tool`.
+
+---
+
+### Task 5: Docs + verification
+
+- SKILL.md: Red Flags row (`| "Add/remove/reorder a parameter" / "Let me update all the call sites by hand" | change_signature |`), a bullet beside `rename_symbol` covering operations, `callSiteValue`, the cascade report and the safety gates, a Quick Reference row, and a metadata-support row (source only).
+- CLAUDE.md: 63 → **64**.
+- `tools/DocGen/Program.cs` categoryMap: `["change_signature"] = "diagnostics"`.
+- README.md: one bullet in the existing style.
+- `docs/BACKLOG.md`: medium-tier bullet → ✅ shipped (PR #n) + a Recently-shipped row.
+- Full `dotnet build` + `dotnet test` (~880 expected; the suite takes ~8-12 min — run it in the background). Fixture-pristine check.
+
+Commit `docs: document change_signature (64 tools)`.
+
+---
+
+## Deviations
+Report every Roslyn API mismatch, whether direct `Activator.CreateInstance` of the service worked or the workspace language service was needed, the Task 2 Step 5 outcome (call-site rewriting — the make-or-break check), and anything about cascade reporting that `SymbolFinder` couldn't answer.

--- a/docs/plans/2026-07-20-change-signature-implementation.md
+++ b/docs/plans/2026-07-20-change-signature-implementation.md
@@ -151,10 +151,11 @@ public static class ChangeSignatureBridge
         //          callSiteValue, isRequired: DefaultValue == null, defaultValue, typeBinds: type != null)
         // 4. change = SignatureChange(original, updatedConfig)
         // 5. context = ChangeSignatureAnalysisSucceededContext(semanticDoc, positionForTypeBinding, method, original)
-        //    positionForTypeBinding: the DECLARATION's span start, not 0. Position 0 binds added
-        //    parameter type names at file scope — before any using directives or the enclosing
-        //    namespace — so `add` with e.g. CancellationToken would fail to bind and silently
-        //    degrade to typeBinds:false. Task 3's Add test is what proves this; don't take it on faith.
+        //    positionForTypeBinding: the DECLARATION's span start, mirroring the IDE flow.
+        //    (Originally justified as necessary for added type names to bind — that was tested
+        //    during Task 3 by flipping it to 0, and every Add test still passed. What actually
+        //    makes CancellationToken render is resolving a real ITypeSymbol and passing
+        //    typeBinds:true; the Simplifier reduces it against the target document.)
         // 6. options = ChangeSignatureOptionsResult(change, previewChanges: false)
         // 7. service = CSharpChangeSignatureService instance (Activator.CreateInstance, or the
         //    workspace language service if direct construction misbehaves — try direct first)

--- a/docs/plans/2026-07-20-change-signature-implementation.md
+++ b/docs/plans/2026-07-20-change-signature-implementation.md
@@ -18,7 +18,7 @@ All probed against Microsoft.CodeAnalysis 5.6. `AbstractChangeSignatureService` 
 
 | Member | Signature |
 |---|---|
-| `SemanticDocument.CreateAsync` | `static Task<SemanticDocument>(Document, CancellationToken)` — **public type in Workspaces** |
+| `SemanticDocument.CreateAsync` | `static Task<SemanticDocument>(Document, CancellationToken)` — in Workspaces. **The type is `internal`** (an earlier note here said public; it is not), so bind with `BindingFlags.NonPublic`. |
 | `ParameterConfiguration.Create` | `static ParameterConfiguration(ImmutableArray<Parameter>, bool isExtensionMethod, int selectedIndex)` — derives the `this`/`params`/default split itself; **prefer this over the 5-arg ctor** |
 | `ExistingParameter` | `ctor(IParameterSymbol)` |
 | `AddedParameter` | `ctor(ITypeSymbol type, string typeName, string name, CallSiteKind, string callSiteValue, bool isRequired, string defaultValue, bool typeBinds)` |
@@ -150,7 +150,11 @@ public static class ChangeSignatureBridge
         //          DefaultValue == null ? CallSiteKind.Value : CallSiteKind.Omitted,
         //          callSiteValue, isRequired: DefaultValue == null, defaultValue, typeBinds: type != null)
         // 4. change = SignatureChange(original, updatedConfig)
-        // 5. context = ChangeSignatureAnalysisSucceededContext(semanticDoc, 0, method, original)
+        // 5. context = ChangeSignatureAnalysisSucceededContext(semanticDoc, positionForTypeBinding, method, original)
+        //    positionForTypeBinding: the DECLARATION's span start, not 0. Position 0 binds added
+        //    parameter type names at file scope — before any using directives or the enclosing
+        //    namespace — so `add` with e.g. CancellationToken would fail to bind and silently
+        //    degrade to typeBinds:false. Task 3's Add test is what proves this; don't take it on faith.
         // 6. options = ChangeSignatureOptionsResult(change, previewChanges: false)
         // 7. service = CSharpChangeSignatureService instance (Activator.CreateInstance, or the
         //    workspace language service if direct construction misbehaves — try direct first)

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -106,6 +106,7 @@ If any of these thoughts cross your mind, stop and switch to the MCP tool:
 | "Where is this exception thrown?" / "Who raises `TimeoutException`?" | `find_throw_sites` |
 | "Who catches this?" / "Is anything swallowing exceptions?" / "Find empty catch blocks" | `find_catch_blocks` |
 | "Rename this class/method everywhere" / "Let me edit N files to change this name" | `rename_symbol` |
+| "Add/remove/reorder a parameter" / "Let me update all the call sites by hand" | `change_signature` |
 | "Where did this exception come from?" / user pastes a stack trace / "What method is `<M>d__12.MoveNext`?" | `resolve_stack_trace` |
 | "Let me `Read` the file to see this method's body" / "Show me the source of these 5 methods" | `get_method_source` |
 | "Where is this field written / who mutates it?" / "Is this ever assigned outside the ctor?" | `find_references` with `kinds: ["write","readwrite"]` |
@@ -214,6 +215,7 @@ Solutions passed on the CLI at server startup are auto-trusted in session scope 
 - `get_code_actions` — all refactorings/fixes at a position (with optional range).
 - `apply_code_action` — execute a refactoring by title. Preview mode by default. Applying refuses to overwrite files that changed on disk since the snapshot (run `rebuild_solution` and retry), and on success the in-memory snapshot updates immediately, so follow-up queries see the new text without waiting for the file watcher. Actions that create a *new* file (extract interface, move type to file) write it, but the new file only enters the snapshot once the watcher picks it up — the result's `warning` says so when it applies.
 - `rename_symbol` — solution-wide safe rename of a type or member (Roslyn Renamer; NOT available via `apply_code_action`). Preview by default; new-compiler-error conflicts reported; apply refuses unless `force=true` on: conflicts, a degraded solution load, or files changed on disk since the snapshot (freshness refusal — run `rebuild_solution` and retry; `force` does not bypass freshness). After apply the in-memory snapshot updates immediately — follow-up queries see the new name without waiting for a rebuild. Generic types accept the arity-free qualified form (`Data.Repository` finds `Repository<T>`).
+- `change_signature` — add, remove, and reorder a method's parameters, rewriting every call site (Roslyn's change-signature engine; also NOT reachable via `apply_code_action`). `operations` apply in order: `remove` by parameter name, `reorder` with a full permutation of the surviving names, and `add` with a **required** `callSiteValue` naming exactly what each existing call site passes — the tool never guesses that. Give an added parameter a `defaultValue` instead and existing call sites are left untouched. Named arguments, optional parameters, `params` arrays and the extension-method `this` are all handled. `cascadedTo` lists the overrides and interface implementations rewritten alongside it, so check it in preview before applying. Same gates as `rename_symbol`: preview by default, conflict / degraded-load / freshness refusals, `force` to override, immediate snapshot update on apply.
 - `resolve_stack_trace` — map a pasted .NET stack trace to file/line/symbol; demangles async/iterator state machines, lambdas, and local functions; handles log-prefixed lines, inner-exception chains, and Demystifier-style traces. Source frames get the declaration site (exact location when the trace carries `in file:line`); external frames resolve with `origin="metadata"` when the assembly is referenced by the solution — frames outside that closure come back `origin="unresolved"`. Frame-like lines that fail all grammars aren't dropped: they surface as `Kind="unknown"` items at their original position, and `summary.skippedFrameLike` counts them. Items stay in trace order.
 - `analyze_data_flow` — variable lifecycle over a statement range (declared/read/written/captured/flows-in/out).
 - `analyze_control_flow` — reachability, returns, unreachable paths.
@@ -346,6 +348,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `get_code_actions` | "What refactorings are available here?" |
 | `apply_code_action` | "Apply this refactoring" / "Extract method" |
 | `rename_symbol` | "Rename this symbol everywhere" / "Change this name across the solution" |
+| `change_signature` | "Add/remove/reorder a parameter and fix all the callers" |
 | `resolve_stack_trace` | "Where did this exception come from?" / "Resolve this stack trace" |
 | `find_unused_symbols` | "Any dead code?" |
 | `get_complexity_metrics` | "Which methods are too complex?" |
@@ -416,6 +419,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `get_code_actions` | No — source only | | |
 | `apply_code_action` | No — source only | | |
 | `rename_symbol` | No — source only | Locals/parameters and file renames unsupported | |
+| `change_signature` | No — source only; a metadata-defined method is refused | Reflection / `dynamic` call sites are not rewritten | |
 | `resolve_stack_trace` | Yes — external frames resolve when the assembly is referenced by the solution | Metadata frames carry no file/line; frames outside the solution's reference closure come back `origin="unresolved"` | `peek_il` to inspect external method bodies |
 | `analyze_data_flow` | No — source only | | |
 | `analyze_control_flow` | No — source only | | |

--- a/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
+++ b/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
@@ -33,6 +33,14 @@ public static class ChangeSignatureBridge
     /// </summary>
     public static IReadOnlyList<string> Probe() => Cached.Value.Missing;
 
+    /// <summary>
+    /// Every member the probe checked, whether or not it resolved — <see cref="Probe"/> returning
+    /// empty is only meaningful against this list, since an unchecked member is indistinguishable
+    /// from a healthy one. Exposed so a test can assert the probe's coverage rather than just its
+    /// verdict.
+    /// </summary>
+    public static IReadOnlyList<string> ProbedMembers() => Cached.Value.Checked;
+
     public static async Task<BridgeResult> ChangeSignatureAsync(
         Document document,
         IMethodSymbol method,
@@ -267,6 +275,9 @@ public static class ChangeSignatureBridge
     {
         public List<string> Missing { get; } = [];
 
+        /// <summary>Every member name the probe looked for, resolved or not.</summary>
+        public List<string> Checked { get; } = [];
+
         public Type? ParameterType { get; private set; }
         public Type? CallSiteKindType { get; private set; }
         public Type? CSharpServiceType { get; private set; }
@@ -381,6 +392,8 @@ public static class ChangeSignatureBridge
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
                     [typeof(Document), typeof(CancellationToken)],
                     "SemanticDocument.CreateAsync(Document, CancellationToken)");
+                m.CheckTaskReturnType(
+                    m.SemanticDocumentCreateAsync, semanticDocument, "SemanticDocument.CreateAsync");
             }
 
             if (abstractService is not null && analyzedContext is not null && optionsResult is not null)
@@ -393,7 +406,13 @@ public static class ChangeSignatureBridge
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                     [analyzedContext, optionsResult, typeof(CancellationToken)],
                     "AbstractChangeSignatureService.ChangeSignatureWithContextAsync(ChangeSignatureAnalyzedContext, ChangeSignatureOptionsResult, CancellationToken)");
+                m.CheckTaskReturnType(
+                    m.ChangeSignatureWithContextAsync, changeSignatureResult,
+                    "AbstractChangeSignatureService.ChangeSignatureWithContextAsync");
             }
+
+            // Built via Activator, so nothing above would have caught its removal.
+            m.CheckParameterlessCtor(m.CSharpServiceType, "CSharpChangeSignatureService..ctor()");
 
             if (changeSignatureResult is not null)
             {
@@ -410,6 +429,7 @@ public static class ChangeSignatureBridge
         private static MethodInfo? ResolveImmutableArrayCreate(Members m, Type parameterType)
         {
             const string Name = "ImmutableArray.Create<Parameter>(Parameter[])";
+            m.Checked.Add(Name);
             var open = typeof(ImmutableArray).GetMethods(BindingFlags.Public | BindingFlags.Static)
                 .FirstOrDefault(candidate =>
                     string.Equals(candidate.Name, "Create", StringComparison.Ordinal)
@@ -426,8 +446,65 @@ public static class ChangeSignatureBridge
             return open.MakeGenericMethod(parameterType);
         }
 
+        /// <summary>
+        /// Records a member the probe examined and, when it did not resolve, that it is missing.
+        /// Every lookup funnels through here so Checked can never drift from Missing.
+        /// </summary>
+        private T? Record<T>(string display, T? resolved) where T : class
+        {
+            Checked.Add(display);
+            if (resolved is null)
+                Missing.Add(display);
+
+            return resolved;
+        }
+
+        /// <summary>
+        /// Asserts a resolved method returns exactly <c>Task&lt;expected&gt;</c>. Resolving the
+        /// method by name and parameter types is not enough: the bridge awaits the Task and reads
+        /// its Result, so a changed return type would fail at that cast during a user's apply
+        /// rather than at the probe.
+        /// </summary>
+        private void CheckTaskReturnType(MethodInfo? method, Type? expected, string display)
+        {
+            var name = $"{display} → Task<{expected?.Name ?? "?"}>";
+            Checked.Add(name);
+
+            if (method is null || expected is null)
+            {
+                Missing.Add(name);
+                return;
+            }
+
+            var returnType = method.ReturnType;
+            var matches = returnType.IsGenericType
+                && returnType.GetGenericTypeDefinition() == typeof(Task<>)
+                && returnType.GetGenericArguments()[0] == expected;
+
+            if (!matches)
+                Missing.Add(name);
+        }
+
+        /// <summary>
+        /// The service is built with Activator.CreateInstance(nonPublic: true), which resolves
+        /// nothing ahead of time — without this the missing constructor would only show up as a
+        /// thrown exception mid-apply.
+        /// </summary>
+        private void CheckParameterlessCtor(Type? type, string display)
+        {
+            Checked.Add(display);
+
+            if (type?.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    binder: null, Type.EmptyTypes, modifiers: null) is null)
+            {
+                Missing.Add(display);
+            }
+        }
+
         private Assembly? LoadAssembly(string name)
         {
+            Checked.Add($"assembly {name}");
             try
             {
                 return Assembly.Load(name);
@@ -440,58 +517,29 @@ public static class ChangeSignatureBridge
         }
 
         private Type? FindType(Assembly assembly, string fullName)
-        {
-            var type = assembly.GetType(fullName, throwOnError: false);
-            if (type is null)
-            {
-                Missing.Add(fullName);
-            }
-
-            return type;
-        }
+            => Record(fullName, assembly.GetType(fullName, throwOnError: false));
 
         private ConstructorInfo? FindCtor(Type type, Type[] parameterTypes, string display)
-        {
-            var ctor = type.GetConstructor(
+            => Record(display, type.GetConstructor(
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                binder: null, parameterTypes, modifiers: null);
-            if (ctor is null)
-            {
-                Missing.Add(display);
-            }
-
-            return ctor;
-        }
+                binder: null, parameterTypes, modifiers: null));
 
         private MethodInfo? FindMethod(
             Type type, string name, BindingFlags flags, Type[] parameterTypes, string display)
-        {
-            var method = type.GetMethod(name, flags, binder: null, parameterTypes, modifiers: null);
-            if (method is null)
-            {
-                Missing.Add(display);
-            }
-
-            return method;
-        }
+            => Record(display, type.GetMethod(name, flags, binder: null, parameterTypes, modifiers: null));
 
         private PropertyInfo? FindProperty(Type type, string name)
-        {
-            var property = type.GetProperty(
-                name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (property is null)
-            {
-                Missing.Add($"ChangeSignatureResult.{name}");
-            }
-
-            return property;
-        }
+            => Record($"ChangeSignatureResult.{name}", type.GetProperty(
+                name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance));
 
         private int EnumValue(Type enumType, string name)
         {
+            var display = $"CallSiteKind.{name}";
+            Checked.Add(display);
+
             if (!Enum.IsDefined(enumType, name))
             {
-                Missing.Add($"CallSiteKind.{name}");
+                Missing.Add(display);
                 return 0;
             }
 

--- a/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
+++ b/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
@@ -115,8 +115,16 @@ public static class ChangeSignatureBridge
     }
 
     /// <summary>
-    /// Where Roslyn speculatively binds the type names of added parameters. The declaration's own
-    /// position resolves `using`s and the enclosing namespace; 0 would bind at file scope.
+    /// Where Roslyn speculatively binds the type names of added parameters — the position the IDE
+    /// flow supplies, so this mirrors it.
+    /// <para>
+    /// It is NOT what makes a type like <c>CancellationToken</c> render correctly: that works
+    /// because the caller resolves a real <c>ITypeSymbol</c> and the bridge passes
+    /// <c>typeBinds: true</c>, after which Roslyn renders from the symbol and the Simplifier
+    /// reduces it against the target document. Verified by flipping this to 0 — every added-
+    /// parameter test still passed. The declaration position matters only if a type ever arrives
+    /// unresolved, which is why it is kept.
+    /// </para>
     /// </summary>
     private static int PositionForTypeBinding(Document document, IMethodSymbol method)
     {

--- a/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
+++ b/src/RoslynCodeLens/Analysis/ChangeSignatureBridge.cs
@@ -1,0 +1,493 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Analysis;
+
+/// <summary>Outcome of Roslyn's own change-signature engine, with its verdict preserved.</summary>
+public sealed record BridgeResult(bool Succeeded, Solution? UpdatedSolution, string? FailureMessage);
+
+/// <summary>Describes one parameter of the target signature, in final order.</summary>
+public sealed record DesiredParameter(
+    IParameterSymbol? Existing,                 // null for an added parameter
+    string? Name,
+    string? TypeName,
+    ITypeSymbol? Type,
+    string? CallSiteValue,
+    string? DefaultValue);
+
+/// <summary>
+/// The ONLY place that touches Roslyn's internal change-signature API. Everything reflective is
+/// resolved once and cached; <see cref="Probe"/> reports anything missing so a Roslyn upgrade
+/// fails loudly instead of degrading into partial work.
+/// </summary>
+public static class ChangeSignatureBridge
+{
+    private const string ChangeSignatureNamespace = "Microsoft.CodeAnalysis.ChangeSignature";
+
+    private static readonly Lazy<Members> Cached = new(Members.Resolve, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Names of every required internal Roslyn member that failed to resolve. Empty means healthy.
+    /// </summary>
+    public static IReadOnlyList<string> Probe() => Cached.Value.Missing;
+
+    public static async Task<BridgeResult> ChangeSignatureAsync(
+        Document document,
+        IMethodSymbol method,
+        IReadOnlyList<DesiredParameter> updated,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(updated);
+
+        var m = Cached.Value;
+        if (m.Missing.Count > 0)
+        {
+            throw new McpToolException(
+                ToolErrorCode.Internal,
+                "Roslyn's internal change-signature API is not available in this build: "
+                    + string.Join(", ", m.Missing),
+                new { missing = m.Missing });
+        }
+
+        // 1. SemanticDocument for the declaring document.
+        var semanticDocumentTask = (Task)Invoke(
+            m.SemanticDocumentCreateAsync!, null, [document, ct], "SemanticDocument.CreateAsync")!;
+        await semanticDocumentTask.ConfigureAwait(false);
+        var semanticDocument = GetTaskResult(semanticDocumentTask, "SemanticDocument.CreateAsync");
+
+        var isExtensionMethod = method.IsExtensionMethod;
+
+        // 2. The original configuration, straight from the symbol's parameters.
+        var originalConfiguration = CreateConfiguration(
+            m,
+            method.Parameters.Select(p => CreateExistingParameter(m, p)).ToArray(),
+            isExtensionMethod);
+
+        // 3. The updated configuration: survivors keep their symbol, new parameters are described.
+        var updatedConfiguration = CreateConfiguration(
+            m,
+            updated.Select(p => p.Existing is not null
+                ? CreateExistingParameter(m, p.Existing)
+                : CreateAddedParameter(m, p)).ToArray(),
+            isExtensionMethod);
+
+        // 4-6. The change, the analyzed context, and the options that bypass the IDE dialog.
+        var signatureChange = Construct(
+            m.SignatureChangeCtor!, [originalConfiguration, updatedConfiguration], "SignatureChange..ctor");
+        var context = Construct(
+            m.SucceededContextCtor!,
+            [semanticDocument, PositionForTypeBinding(document, method), method, originalConfiguration],
+            "ChangeSignatureAnalysisSucceededContext..ctor");
+        var options = Construct(
+            m.OptionsResultCtor!, [signatureChange, false], "ChangeSignatureOptionsResult..ctor");
+
+        // 7. The C# language service. Internal type, parameterless ctor.
+        var service = CreateService(m);
+
+        // 8. The solution-wide entry point. NOT ChangeSignature(...), which rewrites the
+        //    declaration only and would leave every call site broken.
+        var changeTask = (Task)Invoke(
+            m.ChangeSignatureWithContextAsync!, service, [context, options, ct],
+            "AbstractChangeSignatureService.ChangeSignatureWithContextAsync")!;
+        await changeTask.ConfigureAwait(false);
+        var result = GetTaskResult(changeTask, "AbstractChangeSignatureService.ChangeSignatureWithContextAsync");
+
+        // 9. Roslyn's own verdict, preserved rather than reinterpreted.
+        var succeeded = (bool)GetProperty(m.ResultSucceeded!, result, "ChangeSignatureResult.Succeeded")!;
+        var updatedSolution = (Solution?)GetProperty(
+            m.ResultUpdatedSolution!, result, "ChangeSignatureResult.UpdatedSolution");
+        var confirmation = (string?)GetProperty(
+            m.ResultConfirmationMessage!, result, "ChangeSignatureResult.ConfirmationMessage");
+        var failureKind = GetProperty(
+            m.ResultFailureKind!, result, "ChangeSignatureResult.ChangeSignatureFailureKind");
+
+        var failureMessage = succeeded
+            ? null
+            : confirmation ?? (failureKind is null
+                ? "Roslyn refused the signature change without reporting a reason."
+                : $"Roslyn refused the signature change: {failureKind}.");
+
+        return new BridgeResult(succeeded, succeeded ? updatedSolution : null, failureMessage);
+    }
+
+    /// <summary>
+    /// Where Roslyn speculatively binds the type names of added parameters. The declaration's own
+    /// position resolves `using`s and the enclosing namespace; 0 would bind at file scope.
+    /// </summary>
+    private static int PositionForTypeBinding(Document document, IMethodSymbol method)
+    {
+        foreach (var reference in method.DeclaringSyntaxReferences)
+        {
+            if (document.FilePath is not null
+                && string.Equals(reference.SyntaxTree.FilePath, document.FilePath, StringComparison.Ordinal))
+            {
+                return reference.Span.Start;
+            }
+        }
+
+        return 0;
+    }
+
+    private static object CreateService(Members m)
+    {
+        try
+        {
+            return Activator.CreateInstance(m.CSharpServiceType!, nonPublic: true)
+                ?? throw new McpToolException(
+                    ToolErrorCode.Internal,
+                    "Could not construct CSharpChangeSignatureService.",
+                    new { member = "CSharpChangeSignatureService..ctor" });
+        }
+        catch (Exception ex) when (ex is not McpToolException)
+        {
+            throw new McpToolException(
+                ToolErrorCode.Internal,
+                $"Could not construct CSharpChangeSignatureService: {ex.Message}",
+                new { member = "CSharpChangeSignatureService..ctor" });
+        }
+    }
+
+    private static object CreateExistingParameter(Members m, IParameterSymbol parameter)
+        => Construct(m.ExistingParameterCtor!, [parameter], "ExistingParameter..ctor");
+
+    private static object CreateAddedParameter(Members m, DesiredParameter p)
+    {
+        // No default value ⇒ every existing call site must pass something explicit.
+        // A default value ⇒ existing call sites may omit the argument entirely.
+        var hasDefault = !string.IsNullOrEmpty(p.DefaultValue);
+        var callSiteKind = Enum.ToObject(
+            m.CallSiteKindType!, hasDefault ? m.CallSiteKindOmitted : m.CallSiteKindValue);
+
+        return Construct(
+            m.AddedParameterCtor!,
+            [
+                p.Type,
+                p.TypeName ?? p.Type?.ToDisplayString() ?? string.Empty,
+                p.Name ?? string.Empty,
+                callSiteKind,
+                p.CallSiteValue ?? string.Empty,
+                !hasDefault,
+                p.DefaultValue ?? string.Empty,
+                p.Type is not null,
+            ],
+            "AddedParameter..ctor");
+    }
+
+    /// <summary>
+    /// ParameterConfiguration.Create derives the `this`/`params`/default-value split itself, so the
+    /// bridge never has to model those slots.
+    /// </summary>
+    private static object CreateConfiguration(Members m, object[] parameters, bool isExtensionMethod)
+    {
+        var typed = Array.CreateInstance(m.ParameterType!, parameters.Length);
+        Array.Copy(parameters, typed, parameters.Length);
+        var immutable = Invoke(
+            m.ImmutableArrayCreate!, null, [typed], "ImmutableArray.Create<Parameter>");
+
+        return Invoke(
+            m.ParameterConfigurationCreate!, null, [immutable, isExtensionMethod, 0],
+            "ParameterConfiguration.Create")!;
+    }
+
+    private static object Construct(ConstructorInfo ctor, object?[] args, string member)
+    {
+        try
+        {
+            return ctor.Invoke(args);
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw new McpToolException(
+                ToolErrorCode.Internal,
+                $"Roslyn's {member} rejected the arguments: {ex.InnerException?.Message ?? ex.Message}",
+                new { member });
+        }
+    }
+
+    private static object? Invoke(MethodInfo method, object? instance, object?[] args, string member)
+    {
+        try
+        {
+            return method.Invoke(instance, args);
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw new McpToolException(
+                ToolErrorCode.Internal,
+                $"Roslyn's {member} failed: {ex.InnerException?.Message ?? ex.Message}",
+                new { member });
+        }
+    }
+
+    private static object? GetProperty(PropertyInfo property, object instance, string member)
+    {
+        try
+        {
+            return property.GetValue(instance);
+        }
+        catch (TargetInvocationException ex)
+        {
+            throw new McpToolException(
+                ToolErrorCode.Internal,
+                $"Reading {member} failed: {ex.InnerException?.Message ?? ex.Message}",
+                new { member });
+        }
+    }
+
+    private static object GetTaskResult(Task task, string member)
+    {
+        var resultProperty = task.GetType().GetProperty("Result")
+            ?? throw new McpToolException(
+                ToolErrorCode.Internal,
+                $"{member} did not return a Task with a result.",
+                new { member });
+
+        return resultProperty.GetValue(task)
+            ?? throw new McpToolException(
+                ToolErrorCode.Internal, $"{member} returned null.", new { member });
+    }
+
+    /// <summary>
+    /// Every reflective handle the bridge needs, resolved once. Anything that fails to resolve is
+    /// recorded in <see cref="Missing"/> rather than throwing, so Probe can report the whole set.
+    /// </summary>
+    private sealed class Members
+    {
+        public List<string> Missing { get; } = [];
+
+        public Type? ParameterType { get; private set; }
+        public Type? CallSiteKindType { get; private set; }
+        public Type? CSharpServiceType { get; private set; }
+        public ConstructorInfo? ExistingParameterCtor { get; private set; }
+        public ConstructorInfo? AddedParameterCtor { get; private set; }
+        public ConstructorInfo? SignatureChangeCtor { get; private set; }
+        public ConstructorInfo? OptionsResultCtor { get; private set; }
+        public ConstructorInfo? SucceededContextCtor { get; private set; }
+        public MethodInfo? ParameterConfigurationCreate { get; private set; }
+        public MethodInfo? SemanticDocumentCreateAsync { get; private set; }
+        public MethodInfo? ChangeSignatureWithContextAsync { get; private set; }
+        public MethodInfo? ImmutableArrayCreate { get; private set; }
+        public PropertyInfo? ResultSucceeded { get; private set; }
+        public PropertyInfo? ResultUpdatedSolution { get; private set; }
+        public PropertyInfo? ResultConfirmationMessage { get; private set; }
+        public PropertyInfo? ResultFailureKind { get; private set; }
+        public int CallSiteKindValue { get; private set; }
+        public int CallSiteKindOmitted { get; private set; }
+
+        public static Members Resolve()
+        {
+            var m = new Members();
+
+            var features = m.LoadAssembly("Microsoft.CodeAnalysis.Features");
+            var csharpFeatures = m.LoadAssembly("Microsoft.CodeAnalysis.CSharp.Features");
+            var workspaces = typeof(Workspace).Assembly;
+            if (features is null || csharpFeatures is null)
+            {
+                return m;
+            }
+
+            var parameterType = m.FindType(features, $"{ChangeSignatureNamespace}.Parameter");
+            var existingParameter = m.FindType(features, $"{ChangeSignatureNamespace}.ExistingParameter");
+            var addedParameter = m.FindType(features, $"{ChangeSignatureNamespace}.AddedParameter");
+            var callSiteKind = m.FindType(features, $"{ChangeSignatureNamespace}.CallSiteKind");
+            var parameterConfiguration = m.FindType(features, $"{ChangeSignatureNamespace}.ParameterConfiguration");
+            var signatureChange = m.FindType(features, $"{ChangeSignatureNamespace}.SignatureChange");
+            var optionsResult = m.FindType(features, $"{ChangeSignatureNamespace}.ChangeSignatureOptionsResult");
+            var analyzedContext = m.FindType(features, $"{ChangeSignatureNamespace}.ChangeSignatureAnalyzedContext");
+            var succeededContext = m.FindType(features, $"{ChangeSignatureNamespace}.ChangeSignatureAnalysisSucceededContext");
+            var changeSignatureResult = m.FindType(features, $"{ChangeSignatureNamespace}.ChangeSignatureResult");
+            var abstractService = m.FindType(features, $"{ChangeSignatureNamespace}.AbstractChangeSignatureService");
+            var semanticDocument = m.FindType(workspaces, "Microsoft.CodeAnalysis.SemanticDocument");
+            m.CSharpServiceType = m.FindType(
+                csharpFeatures, "Microsoft.CodeAnalysis.CSharp.ChangeSignature.CSharpChangeSignatureService");
+
+            m.ParameterType = parameterType;
+            m.CallSiteKindType = callSiteKind;
+
+            if (callSiteKind is not null)
+            {
+                m.CallSiteKindValue = m.EnumValue(callSiteKind, "Value");
+                m.CallSiteKindOmitted = m.EnumValue(callSiteKind, "Omitted");
+            }
+
+            if (existingParameter is not null)
+            {
+                m.ExistingParameterCtor = m.FindCtor(
+                    existingParameter, [typeof(IParameterSymbol)], "ExistingParameter..ctor(IParameterSymbol)");
+            }
+
+            if (addedParameter is not null && callSiteKind is not null)
+            {
+                m.AddedParameterCtor = m.FindCtor(
+                    addedParameter,
+                    [
+                        typeof(ITypeSymbol), typeof(string), typeof(string), callSiteKind,
+                        typeof(string), typeof(bool), typeof(string), typeof(bool),
+                    ],
+                    "AddedParameter..ctor(ITypeSymbol, string, string, CallSiteKind, string, bool, string, bool)");
+            }
+
+            if (parameterConfiguration is not null && parameterType is not null)
+            {
+                m.ParameterConfigurationCreate = m.FindMethod(
+                    parameterConfiguration,
+                    "Create",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                    [typeof(ImmutableArray<>).MakeGenericType(parameterType), typeof(bool), typeof(int)],
+                    "ParameterConfiguration.Create(ImmutableArray<Parameter>, bool, int)");
+
+                m.ImmutableArrayCreate = ResolveImmutableArrayCreate(m, parameterType);
+            }
+
+            if (signatureChange is not null && parameterConfiguration is not null)
+            {
+                m.SignatureChangeCtor = m.FindCtor(
+                    signatureChange, [parameterConfiguration, parameterConfiguration],
+                    "SignatureChange..ctor(ParameterConfiguration, ParameterConfiguration)");
+            }
+
+            if (optionsResult is not null && signatureChange is not null)
+            {
+                m.OptionsResultCtor = m.FindCtor(
+                    optionsResult, [signatureChange, typeof(bool)],
+                    "ChangeSignatureOptionsResult..ctor(SignatureChange, bool)");
+            }
+
+            if (succeededContext is not null && semanticDocument is not null && parameterConfiguration is not null)
+            {
+                m.SucceededContextCtor = m.FindCtor(
+                    succeededContext,
+                    [semanticDocument, typeof(int), typeof(ISymbol), parameterConfiguration],
+                    "ChangeSignatureAnalysisSucceededContext..ctor(SemanticDocument, int, ISymbol, ParameterConfiguration)");
+            }
+
+            if (semanticDocument is not null)
+            {
+                m.SemanticDocumentCreateAsync = m.FindMethod(
+                    semanticDocument,
+                    "CreateAsync",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                    [typeof(Document), typeof(CancellationToken)],
+                    "SemanticDocument.CreateAsync(Document, CancellationToken)");
+            }
+
+            if (abstractService is not null && analyzedContext is not null && optionsResult is not null)
+            {
+                // The solution-wide entry point. Deliberately NOT ChangeSignature(...), which
+                // returns a SyntaxNode and rewrites the declaration only.
+                m.ChangeSignatureWithContextAsync = m.FindMethod(
+                    abstractService,
+                    "ChangeSignatureWithContextAsync",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    [analyzedContext, optionsResult, typeof(CancellationToken)],
+                    "AbstractChangeSignatureService.ChangeSignatureWithContextAsync(ChangeSignatureAnalyzedContext, ChangeSignatureOptionsResult, CancellationToken)");
+            }
+
+            if (changeSignatureResult is not null)
+            {
+                m.ResultSucceeded = m.FindProperty(changeSignatureResult, "Succeeded");
+                m.ResultUpdatedSolution = m.FindProperty(changeSignatureResult, "UpdatedSolution");
+                m.ResultConfirmationMessage = m.FindProperty(changeSignatureResult, "ConfirmationMessage");
+                m.ResultFailureKind = m.FindProperty(changeSignatureResult, "ChangeSignatureFailureKind");
+            }
+
+            return m;
+        }
+
+        /// <summary>ImmutableArray.Create&lt;T&gt;(params T[]) closed over the internal Parameter type.</summary>
+        private static MethodInfo? ResolveImmutableArrayCreate(Members m, Type parameterType)
+        {
+            const string Name = "ImmutableArray.Create<Parameter>(Parameter[])";
+            var open = typeof(ImmutableArray).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .FirstOrDefault(candidate =>
+                    string.Equals(candidate.Name, "Create", StringComparison.Ordinal)
+                    && candidate.IsGenericMethodDefinition
+                    && candidate.GetGenericArguments().Length == 1
+                    && candidate.GetParameters() is [{ ParameterType.IsArray: true }]);
+
+            if (open is null)
+            {
+                m.Missing.Add(Name);
+                return null;
+            }
+
+            return open.MakeGenericMethod(parameterType);
+        }
+
+        private Assembly? LoadAssembly(string name)
+        {
+            try
+            {
+                return Assembly.Load(name);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or BadImageFormatException or FileLoadException)
+            {
+                Missing.Add($"assembly {name}");
+                return null;
+            }
+        }
+
+        private Type? FindType(Assembly assembly, string fullName)
+        {
+            var type = assembly.GetType(fullName, throwOnError: false);
+            if (type is null)
+            {
+                Missing.Add(fullName);
+            }
+
+            return type;
+        }
+
+        private ConstructorInfo? FindCtor(Type type, Type[] parameterTypes, string display)
+        {
+            var ctor = type.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null, parameterTypes, modifiers: null);
+            if (ctor is null)
+            {
+                Missing.Add(display);
+            }
+
+            return ctor;
+        }
+
+        private MethodInfo? FindMethod(
+            Type type, string name, BindingFlags flags, Type[] parameterTypes, string display)
+        {
+            var method = type.GetMethod(name, flags, binder: null, parameterTypes, modifiers: null);
+            if (method is null)
+            {
+                Missing.Add(display);
+            }
+
+            return method;
+        }
+
+        private PropertyInfo? FindProperty(Type type, string name)
+        {
+            var property = type.GetProperty(
+                name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property is null)
+            {
+                Missing.Add($"ChangeSignatureResult.{name}");
+            }
+
+            return property;
+        }
+
+        private int EnumValue(Type enumType, string name)
+        {
+            if (!Enum.IsDefined(enumType, name))
+            {
+                Missing.Add($"CallSiteKind.{name}");
+                return 0;
+            }
+
+            return (int)Enum.Parse(enumType, name);
+        }
+    }
+}

--- a/src/RoslynCodeLens/Models/ChangeSignatureResult.cs
+++ b/src/RoslynCodeLens/Models/ChangeSignatureResult.cs
@@ -1,0 +1,13 @@
+namespace RoslynCodeLens.Models;
+
+public record ChangeSignatureResult(
+    bool Success,
+    string Method,
+    string OldSignature,
+    string NewSignature,
+    bool Applied,
+    IReadOnlyList<TextEdit> Edits,
+    int FilesChanged,
+    IReadOnlyList<string> CascadedTo,
+    IReadOnlyList<RenameConflict> Conflicts,
+    string Message);

--- a/src/RoslynCodeLens/Models/SignatureOperation.cs
+++ b/src/RoslynCodeLens/Models/SignatureOperation.cs
@@ -1,0 +1,18 @@
+namespace RoslynCodeLens.Models;
+
+/// <summary>
+/// One edit to a parameter list, applied in order against the original parameters.
+/// Kind: remove | reorder | add.
+/// remove  → Parameter names the parameter to drop.
+/// reorder → Order is a full permutation of the names surviving at that point.
+/// add     → Name/Type plus CallSiteValue (required: what every existing call site passes).
+///           DefaultValue makes the parameter optional, letting existing calls omit it instead.
+/// </summary>
+public record SignatureOperation(
+    string Kind,
+    string? Parameter = null,
+    IReadOnlyList<string>? Order = null,
+    string? Name = null,
+    string? Type = null,
+    string? CallSiteValue = null,
+    string? DefaultValue = null);

--- a/src/RoslynCodeLens/SolutionChangeSafety.cs
+++ b/src/RoslynCodeLens/SolutionChangeSafety.cs
@@ -1,0 +1,165 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Safety gates shared by every tool that rewrites the solution (rename_symbol, change_signature):
+/// the degraded-load guard and the compiler-diagnostics delta that turns "this edit would introduce
+/// new errors" into reportable <see cref="RenameConflict"/>s. Both tools must judge risk the same
+/// way, so the logic lives here once rather than being copied per tool.
+/// </summary>
+public static class SolutionChangeSafety
+{
+    /// <summary>
+    /// Apply-mode refusal message for a degraded load, or null when there is nothing to refuse.
+    /// A load with dropped references can make Roslyn miss references entirely, silently producing
+    /// an incomplete rewrite; writing in that state is refused unless the caller forces it.
+    /// <paramref name="operation"/> names the edit in prose ("rename", "signature change").
+    /// </summary>
+    public static string? DegradedApplyRefusal(LoadedSolution loaded, bool force, string operation)
+    {
+        if (!loaded.Degraded || force)
+            return null;
+
+        return $"Refused to apply: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load " +
+            "diagnostic(s) — projects opened with dropped references), so the " + operation +
+            " may be incomplete and silently miss references. Run rebuild_solution and retry, " +
+            "or re-run with force=true to apply anyway.";
+    }
+
+    /// <summary>
+    /// Prefixes a preview message with the degraded-load warning when the load was degraded;
+    /// returns <paramref name="message"/> unchanged otherwise.
+    /// </summary>
+    public static string DegradedPreviewWarning(LoadedSolution loaded, string operation, string message)
+    {
+        if (!loaded.Degraded)
+            return message;
+
+        return $"WARNING: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load diagnostic(s) — " +
+            "projects opened with dropped references), so this " + operation +
+            " may be incomplete and miss references. " + message;
+    }
+
+    /// <summary>
+    /// New compiler errors the changed solution would introduce, over the scan set
+    /// (<see cref="ComputeScanSet"/>) and using the count-based delta in <see cref="DiffNewErrors"/>.
+    /// </summary>
+    public static async Task<IReadOnlyList<RenameConflict>> ComputeConflictsAsync(
+        LoadedSolution loaded, Solution changed, CancellationToken ct)
+    {
+        var original = loaded.Solution;
+        var conflicts = new List<RenameConflict>();
+        foreach (var projectId in ComputeScanSet(original, changed))
+        {
+            var afterProject = changed.GetProject(projectId);
+            if (afterProject == null)
+                continue;
+
+            // Before side prefers the cached compilation (already built at load
+            // time); after side is the forked project. Both diagnostics passes
+            // are CPU-bound, so run them concurrently.
+            var beforeTask = Task.Run(async () =>
+            {
+                if (!loaded.Compilations.TryGetValue(projectId, out var compilation))
+                {
+                    compilation = await original.GetProject(projectId)!
+                        .GetCompilationAsync(ct).ConfigureAwait(false);
+                }
+                return compilation?.GetDiagnostics(ct);
+            }, ct);
+            var afterTask = Task.Run(async () =>
+            {
+                var compilation = await afterProject.GetCompilationAsync(ct).ConfigureAwait(false);
+                return compilation?.GetDiagnostics(ct);
+            }, ct);
+            await Task.WhenAll(beforeTask, afterTask).ConfigureAwait(false);
+
+            var before = await beforeTask.ConfigureAwait(false);
+            var after = await afterTask.ConfigureAwait(false);
+            if (before == null || after == null)
+                continue;
+
+            conflicts.AddRange(DiffNewErrors(before, after));
+        }
+        return conflicts;
+    }
+
+    /// <summary>
+    /// Projects to conflict-scan: those the edit textually changed, plus their
+    /// direct dependents — an edit can break a downstream project without
+    /// touching its text (source generators, name-based lookup changes).
+    /// </summary>
+    public static IReadOnlyList<ProjectId> ComputeScanSet(Solution original, Solution changed)
+    {
+        var changedProjects = changed.GetChanges(original).GetProjectChanges()
+            .Select(c => c.ProjectId).ToList();
+        var graph = original.GetProjectDependencyGraph();
+
+        var seen = new HashSet<ProjectId>();
+        var scanSet = new List<ProjectId>();
+        foreach (var projectId in changedProjects)
+        {
+            if (seen.Add(projectId))
+                scanSet.Add(projectId);
+        }
+        foreach (var projectId in changedProjects)
+        {
+            foreach (var dependent in graph.GetProjectsThatDirectlyDependOnThisProject(projectId))
+            {
+                if (seen.Add(dependent))
+                    scanSet.Add(dependent);
+            }
+        }
+        return scanSet;
+    }
+
+    /// <summary>
+    /// Multiset diff of error diagnostics keyed by (Id, FilePath) — messages play
+    /// no role, so pre-existing errors whose message embeds the edited symbol
+    /// don't become phantom conflicts, and a new error that duplicates an existing
+    /// one's message still surfaces as a count increase. Suppressed diagnostics
+    /// are skipped, matching GetDiagnosticsLogic's policy.
+    /// </summary>
+    public static List<RenameConflict> DiffNewErrors(
+        IEnumerable<Diagnostic> before, IEnumerable<Diagnostic> after)
+    {
+        static bool IsReportableError(Diagnostic d)
+            => d.Severity == DiagnosticSeverity.Error && !d.IsSuppressed;
+        static string Key(Diagnostic d)
+            => $"{d.Id}|{d.Location.GetLineSpan().Path}";
+        static int Line(Diagnostic d)
+            => d.Location.GetLineSpan().StartLinePosition.Line + 1;
+
+        var beforeGroups = before.Where(IsReportableError)
+            .GroupBy(Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        var conflicts = new List<RenameConflict>();
+        foreach (var group in after.Where(IsReportableError)
+                     .GroupBy(Key, StringComparer.OrdinalIgnoreCase))
+        {
+            var afterDiags = group.ToList();
+            var beforeCount = beforeGroups.TryGetValue(group.Key, out var beforeDiags)
+                ? beforeDiags.Count : 0;
+            var newCount = afterDiags.Count - beforeCount;
+            if (newCount <= 0)
+                continue;
+
+            // Prefer diagnostics on lines the before side didn't have — those are
+            // most likely the genuinely new ones; fall back to arbitrary members.
+            var beforeLines = beforeDiags?.Select(Line).ToHashSet() ?? [];
+            foreach (var diag in afterDiags
+                         .OrderBy(d => beforeLines.Contains(Line(d)) ? 1 : 0)
+                         .Take(newCount))
+            {
+                var span = diag.Location.GetLineSpan();
+                conflicts.Add(new RenameConflict(
+                    diag.Id, diag.GetMessage(), span.Path,
+                    span.StartLinePosition.Line + 1));
+            }
+        }
+        return conflicts;
+    }
+}

--- a/src/RoslynCodeLens/SolutionChangeSafety.cs
+++ b/src/RoslynCodeLens/SolutionChangeSafety.cs
@@ -43,6 +43,87 @@ public static class SolutionChangeSafety
     }
 
     /// <summary>
+    /// What <see cref="PreviewOrApplyAsync"/> decided, in the vocabulary both rewriting tools
+    /// share. Each tool maps this onto its own result record; nothing here is tool-specific.
+    /// </summary>
+    public sealed record SolutionChangeOutcome(
+        bool Success,
+        bool Applied,
+        IReadOnlyList<TextEdit> Edits,
+        int FilesChanged,
+        IReadOnlyList<RenameConflict> Conflicts,
+        string Message);
+
+    /// <summary>
+    /// The single decision procedure for whether bytes hit disk, shared by rename_symbol and
+    /// change_signature: diff the change into edits, compute conflicts, and then either report a
+    /// preview, refuse over conflicts, refuse over a stale file, or write and commit.
+    /// <para>
+    /// This lives here rather than in each tool because these are the steps that decide whether a
+    /// user's files are modified. Two copies drift, and a drift in this sequence is the difference
+    /// between refusing to clobber a concurrent edit and clobbering it. Only the success sentence
+    /// varies per tool, which is what <paramref name="describeApplied"/> supplies;
+    /// <paramref name="operation"/> names the edit in prose ("rename", "signature change") for the
+    /// degraded-load warning.
+    /// </para>
+    /// </summary>
+    public static async Task<SolutionChangeOutcome> PreviewOrApplyAsync(
+        LoadedSolution loaded, Solution changed, string operation,
+        bool preview, bool force,
+        Func<int, string> describeApplied,
+        CommitWrittenDocuments? commitToMemory, CancellationToken ct)
+    {
+        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
+            changed, loaded.Solution, ct).ConfigureAwait(false);
+        var conflicts = await ComputeConflictsAsync(loaded, changed, ct).ConfigureAwait(false);
+        var filesChanged = edits.Select(e => e.FilePath)
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        if (preview)
+        {
+            var previewMessage = conflicts.Count > 0
+                ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
+                : "Preview only — no files written. Re-run with preview=false to apply.";
+            previewMessage = DegradedPreviewWarning(loaded, operation, previewMessage);
+            return new SolutionChangeOutcome(true, false, edits, filesChanged, conflicts, previewMessage);
+        }
+
+        if (conflicts.Count > 0 && !force)
+        {
+            return new SolutionChangeOutcome(false, false, edits, filesChanged, conflicts,
+                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
+                "Inspect Conflicts, or re-run with force=true to apply anyway.");
+        }
+
+        var write = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            changed, loaded.Solution, ct).ConfigureAwait(false);
+        if (!write.Written)
+        {
+            // Freshness refusal: something edited these files after the solution snapshot was
+            // taken, so writing snapshot-derived text would clobber those edits. Deliberately NOT
+            // overridable by force — unlike conflicts, this is not a risk the caller can accept,
+            // because the text that would be written was computed from something else entirely.
+            return new SolutionChangeOutcome(false, false, edits, filesChanged, conflicts,
+                $"Refused to apply: {write.StaleFiles.Count} file(s) changed on disk after the solution " +
+                $"snapshot was taken: {string.Join(", ", write.StaleFiles)}. No files were written. " +
+                "Run rebuild_solution and retry.");
+        }
+
+        var message = describeApplied(filesChanged);
+
+        // Post-write commit: make the in-memory snapshot reflect the new text immediately instead
+        // of waiting out the file watcher's debounce window. No outcome here — cancellation
+        // included — may fail the operation: the files are already changed on disk, so reporting
+        // failure would misdescribe what happened.
+        var commitWarning = await SolutionChangeWriter.CommitAsync(
+            commitToMemory, write, ct).ConfigureAwait(false);
+        if (commitWarning != null)
+            message += " Warning: " + commitWarning;
+
+        return new SolutionChangeOutcome(true, true, edits, filesChanged, conflicts, message);
+    }
+
+    /// <summary>
     /// New compiler errors the changed solution would introduce, over the scan set
     /// (<see cref="ComputeScanSet"/>) and using the count-based delta in <see cref="DiffNewErrors"/>.
     /// </summary>

--- a/src/RoslynCodeLens/SolutionChangeSafety.cs
+++ b/src/RoslynCodeLens/SolutionChangeSafety.cs
@@ -87,9 +87,16 @@ public static class SolutionChangeSafety
     }
 
     /// <summary>
-    /// Projects to conflict-scan: those the edit textually changed, plus their
-    /// direct dependents — an edit can break a downstream project without
-    /// touching its text (source generators, name-based lookup changes).
+    /// Projects to conflict-scan: those the edit textually changed, plus every project that
+    /// depends on them TRANSITIVELY — an edit can break a downstream project without touching its
+    /// text (source generators, name-based lookup changes), and a project two hops away sees the
+    /// changed types just as directly as one hop away does. Scanning only immediate dependents
+    /// silently missed those.
+    /// <para>
+    /// Cost: each scanned project outside the cached set needs a compilation, so a change low in
+    /// a wide dependency graph can compile most of the solution. That is the price of not
+    /// under-reporting conflicts on exactly the changes most likely to break something.
+    /// </para>
     /// </summary>
     public static IReadOnlyList<ProjectId> ComputeScanSet(Solution original, Solution changed)
     {
@@ -106,7 +113,7 @@ public static class SolutionChangeSafety
         }
         foreach (var projectId in changedProjects)
         {
-            foreach (var dependent in graph.GetProjectsThatDirectlyDependOnThisProject(projectId))
+            foreach (var dependent in graph.GetProjectsThatTransitivelyDependOnThisProject(projectId))
             {
                 if (seen.Add(dependent))
                     scanSet.Add(dependent);

--- a/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
@@ -458,21 +458,78 @@ public static class ChangeSignatureLogic
     /// <summary>
     /// Overrides and interface implementations Roslyn's engine rewrites alongside the target, so
     /// the blast radius is visible before applying.
+    /// <para>
+    /// The walk goes UP before it goes down. Roslyn cascades over the entire hierarchy, so
+    /// enumerating only what the target itself is overridden/implemented by under-reports
+    /// whenever the target is not the root: changing a derived override also rewrites the base
+    /// and every sibling override, and changing one interface implementation also rewrites the
+    /// interface member and every other implementer. The roots are found first
+    /// (<see cref="FindHierarchyRoots"/>), then the downward enumeration runs from each.
+    /// </para>
     /// </summary>
     private static async Task<IReadOnlyList<string>> FindCascadeSetAsync(
         LoadedSolution loaded, IMethodSymbol target, CancellationToken ct)
     {
         var cascade = new List<ISymbol>();
-        cascade.AddRange(await SymbolFinder.FindOverridesAsync(
-            target, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
-        cascade.AddRange(await SymbolFinder.FindImplementationsAsync(
-            target, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
+        foreach (var root in FindHierarchyRoots(target))
+        {
+            // The root itself is rewritten too, unless it IS the target.
+            if (!SymbolEqualityComparer.Default.Equals(root, target))
+                cascade.Add(root);
+
+            cascade.AddRange(await SymbolFinder.FindOverridesAsync(
+                root, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
+            cascade.AddRange(await SymbolFinder.FindImplementationsAsync(
+                root, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
+        }
 
         return cascade
+            .Where(s => !SymbolEqualityComparer.Default.Equals(s, target))
             .Select(s => s.ToDisplayString())
             .Distinct(StringComparer.Ordinal)
             .OrderBy(s => s, StringComparer.Ordinal)
             .ToList();
+    }
+
+    /// <summary>
+    /// The base-most declaration(s) the target participates in: the top of its override chain,
+    /// plus every interface member it implements (explicitly or implicitly). The target itself
+    /// is the only root when it heads its own hierarchy.
+    /// </summary>
+    private static List<IMethodSymbol> FindHierarchyRoots(IMethodSymbol target)
+    {
+        var roots = new List<IMethodSymbol>();
+
+        var topOfChain = target;
+        while (topOfChain.OverriddenMethod is { } overridden)
+            topOfChain = overridden;
+        roots.Add(topOfChain);
+
+        // Explicit implementations name their interface members directly.
+        roots.AddRange(target.ExplicitInterfaceImplementations);
+
+        // Implicit ones must be matched through the containing type: an interface member whose
+        // implementation resolves to the target (or to the base it overrides) shares the cascade.
+        var containingType = target.ContainingType;
+        if (containingType != null)
+        {
+            foreach (var @interface in containingType.AllInterfaces)
+            {
+                foreach (var member in @interface.GetMembers(target.Name).OfType<IMethodSymbol>())
+                {
+                    var implementation = containingType.FindImplementationForInterfaceMember(member);
+                    if (implementation != null
+                        && (SymbolEqualityComparer.Default.Equals(implementation, target)
+                            || SymbolEqualityComparer.Default.Equals(implementation, topOfChain)))
+                    {
+                        roots.Add(member);
+                    }
+                }
+            }
+        }
+
+        var seen = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+        return roots.Where(r => seen.Add(r)).ToList();
     }
 
     // ------------------------------------------------------------------ display

--- a/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
@@ -57,59 +57,24 @@ public static class ChangeSignatureLogic
         }
 
         var updated = bridge.UpdatedSolution;
-        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
-            updated, loaded.Solution, ct).ConfigureAwait(false);
-        var conflicts = await SolutionChangeSafety.ComputeConflictsAsync(
-            loaded, updated, ct).ConfigureAwait(false);
         var cascadedTo = await FindCascadeSetAsync(loaded, target, ct).ConfigureAwait(false);
-        var filesChanged = edits.Select(e => e.FilePath)
-            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
 
-        if (preview)
-        {
-            var previewMessage = conflicts.Count > 0
-                ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
-                : "Preview only — no files written. Re-run with preview=false to apply.";
-            previewMessage = SolutionChangeSafety.DegradedPreviewWarning(
-                loaded, "signature change", previewMessage);
-            return new ChangeSignatureResult(true, resolvedName, oldSignature, newSignature,
-                Applied: false, edits, filesChanged, cascadedTo, conflicts, previewMessage);
-        }
+        // The preview/conflict-gate/write/freshness/commit sequence is shared verbatim with
+        // rename_symbol — it decides whether bytes hit disk, so it lives in one place.
+        var outcome = await SolutionChangeSafety.PreviewOrApplyAsync(
+            loaded, updated, "signature change", preview, force,
+            filesChanged =>
+            {
+                var applied = $"Changed {resolvedName} to {newSignature} in {filesChanged} file(s).";
+                return cascadedTo.Count > 0
+                    ? applied + $" Cascaded to {cascadedTo.Count} override(s)/implementation(s)."
+                    : applied;
+            },
+            commitToMemory, ct).ConfigureAwait(false);
 
-        if (conflicts.Count > 0 && !force)
-        {
-            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
-                Applied: false, edits, filesChanged, cascadedTo, conflicts,
-                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
-                "Inspect Conflicts, or re-run with force=true to apply anyway.");
-        }
-
-        var write = await SolutionChangeWriter.WriteChangesToDiskAsync(
-            updated, loaded.Solution, ct).ConfigureAwait(false);
-        if (!write.Written)
-        {
-            // Something edited these files after the snapshot was taken — writing snapshot-derived
-            // text would clobber those edits.
-            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
-                Applied: false, edits, filesChanged, cascadedTo, conflicts,
-                $"Refused to apply: {write.StaleFiles.Count} file(s) changed on disk after the solution " +
-                $"snapshot was taken: {string.Join(", ", write.StaleFiles)}. No files were written. " +
-                "Run rebuild_solution and retry.");
-        }
-
-        var message = $"Changed {resolvedName} to {newSignature} in {filesChanged} file(s).";
-        if (cascadedTo.Count > 0)
-            message += $" Cascaded to {cascadedTo.Count} override(s)/implementation(s).";
-
-        // Post-write commit: the files are already changed on disk, so no outcome here —
-        // cancellation included — may fail the operation.
-        var commitWarning = await SolutionChangeWriter.CommitAsync(
-            commitToMemory, write, ct).ConfigureAwait(false);
-        if (commitWarning != null)
-            message += " Warning: " + commitWarning;
-
-        return new ChangeSignatureResult(true, resolvedName, oldSignature, newSignature,
-            Applied: true, edits, filesChanged, cascadedTo, conflicts, message);
+        return new ChangeSignatureResult(
+            outcome.Success, resolvedName, oldSignature, newSignature, outcome.Applied,
+            outcome.Edits, outcome.FilesChanged, cascadedTo, outcome.Conflicts, outcome.Message);
     }
 
     // ------------------------------------------------------------------ resolution

--- a/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.FindSymbols;
 using RoslynCodeLens.Analysis;
 using RoslynCodeLens.Models;
@@ -19,9 +20,7 @@ public static class ChangeSignatureLogic
         bool preview, bool force,
         CommitWrittenDocuments? commitToMemory, CancellationToken ct)
     {
-        ArgumentNullException.ThrowIfNull(operations);
-
-        if (operations.Count == 0)
+        if (operations == null || operations.Count == 0)
         {
             throw new McpToolException(ToolErrorCode.InvalidArgument,
                 "No operations supplied — pass at least one remove/reorder/add operation.",
@@ -197,7 +196,7 @@ public static class ChangeSignatureLogic
                     current = Reorder(current, operation);
                     break;
                 case "add":
-                    current.Add(CreateAdded(loaded, resolver, document, operation));
+                    current.Add(CreateAdded(loaded, resolver, document, current, operation));
                     break;
                 default:
                     throw new McpToolException(ToolErrorCode.InvalidArgument,
@@ -206,7 +205,64 @@ public static class ChangeSignatureLogic
             }
         }
 
+        ValidateExtensionReceiver(target, current);
+        ValidateParamsIsLast(target, current);
         return current;
+    }
+
+    /// <summary>
+    /// An extension method's receiver is identified BY POSITION: Roslyn's
+    /// ParameterConfiguration.Create takes index 0 of the list as `this`. Moving another parameter
+    /// into that slot, or dropping the original receiver, would therefore rebind `this` to a
+    /// different parameter and silently change what every call site means.
+    /// </summary>
+    private static void ValidateExtensionReceiver(
+        IMethodSymbol target, List<DesiredParameter> current)
+    {
+        if (!target.IsExtensionMethod || target.Parameters.Length == 0)
+            return;
+
+        var receiver = target.Parameters[0];
+        if (current.Count > 0
+            && SymbolEqualityComparer.Default.Equals(current[0].Existing, receiver))
+        {
+            return;
+        }
+
+        var stillPresent = current.Any(
+            p => SymbolEqualityComparer.Default.Equals(p.Existing, receiver));
+        var problem = stillPresent
+            ? $"is no longer first (final order: {Describe(current)})"
+            : "was removed";
+
+        throw new McpToolException(ToolErrorCode.InvalidArgument,
+            $"'{target.Name}' is an extension method: its receiver '{receiver.Name}' (the `this` "
+                + $"parameter) {problem}. The receiver must stay first and cannot be removed — "
+                + "Roslyn binds `this` by position, so moving it would silently rebind every call site.",
+            new { receiver = receiver.Name, order = current.Select(p => p.Name).ToList() });
+    }
+
+    /// <summary>
+    /// C# recognises `params` only on the LAST parameter (and Roslyn's engine re-derives it from
+    /// the final slot), so a surviving params array anywhere else emits CS0231. Refused rather
+    /// than written: an `add` appends, and a reorder can move it, so both reach here.
+    /// </summary>
+    private static void ValidateParamsIsLast(IMethodSymbol target, List<DesiredParameter> current)
+    {
+        var paramsParameter = target.Parameters.LastOrDefault(p => p.IsParams);
+        if (paramsParameter == null)
+            return;
+
+        var index = current.FindIndex(
+            p => SymbolEqualityComparer.Default.Equals(p.Existing, paramsParameter));
+        if (index < 0 || index == current.Count - 1)
+            return;   // removed, or still last — both fine
+
+        throw new McpToolException(ToolErrorCode.InvalidArgument,
+            $"'{paramsParameter.Name}' is a params array and must remain the last parameter, but "
+                + $"the requested signature is ({Describe(current)}). Remove it, or place every "
+                + "other parameter before it.",
+            new { paramsParameter = paramsParameter.Name, order = current.Select(p => p.Name).ToList() });
     }
 
     private static void Remove(List<DesiredParameter> current, SignatureOperation operation)
@@ -272,12 +328,31 @@ public static class ChangeSignatureLogic
     }
 
     private static DesiredParameter CreateAdded(
-        LoadedSolution loaded, SymbolResolver resolver, Document document, SignatureOperation operation)
+        LoadedSolution loaded, SymbolResolver resolver, Document document,
+        List<DesiredParameter> current, SignatureOperation operation)
     {
         if (string.IsNullOrWhiteSpace(operation.Name))
         {
             throw new McpToolException(ToolErrorCode.InvalidArgument,
                 "An add operation requires 'name' — the new parameter's name.", new { kind = operation.Kind });
+        }
+
+        // Same guard rename_symbol uses: anything that isn't a lone valid identifier ("1st",
+        // "x, int y", a keyword) would otherwise be written verbatim into the parameter list.
+        if (!SyntaxFacts.IsValidIdentifier(operation.Name))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{operation.Name}' is not a valid C# identifier.", new { name = operation.Name });
+        }
+
+        // C# identifiers are case-sensitive, so the collision check is ordinal. Without it the
+        // duplicate name silently aliases the original in reorder's name→parameter lookup.
+        if (current.Any(p => string.Equals(p.Name, operation.Name, StringComparison.Ordinal)))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"A parameter named '{operation.Name}' already exists ({Describe(current)}) — "
+                    + "parameter names must be unique.",
+                new { name = operation.Name, existing = current.Select(p => p.Name).ToList() });
         }
 
         if (string.IsNullOrWhiteSpace(operation.Type))

--- a/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
@@ -370,8 +370,6 @@ public static class ChangeSignatureLogic
                 new { name = operation.Name });
         }
 
-        // A type that doesn't resolve is still usable: Roslyn writes the literal type name with
-        // typeBinds:false rather than refusing (the caller may be adding a type it is about to write).
         var type = ResolveType(loaded, resolver, document, operation.Type);
         return new DesiredParameter(
             Existing: null,
@@ -402,7 +400,19 @@ public static class ChangeSignatureLogic
         ["string"] = SpecialType.System_String,
     };
 
-    private static ITypeSymbol? ResolveType(
+    /// <summary>
+    /// The added parameter's type, or a refusal. Both failure modes are explicit rather than
+    /// degrading to null:
+    /// <list type="bullet">
+    /// <item>More than one match — binding to an arbitrary candidate would give the parameter a
+    /// type the caller never named.</item>
+    /// <item>No match — <c>CSharpChangeSignatureService.CreateNewParameterSyntax</c> calls
+    /// <c>addedParameter.Type.GenerateTypeSyntax()</c> unconditionally, so a null type
+    /// NullReferenceExceptions inside Roslyn (verified) instead of being written literally. The
+    /// <c>typeBinds</c> flag does not gate that path.</item>
+    /// </list>
+    /// </summary>
+    private static ITypeSymbol ResolveType(
         LoadedSolution loaded, SymbolResolver resolver, Document document, string typeName)
     {
         var compilation = document.Project.Id is { } projectId
@@ -421,7 +431,26 @@ public static class ChangeSignatureLogic
         }
 
         var matches = resolver.FindNamedTypes(typeName);
-        return matches.Count == 1 ? matches[0] : null;
+        if (matches.Count > 1)
+        {
+            var candidates = matches.Select(t => t.ToDisplayString())
+                .OrderBy(s => s, StringComparer.Ordinal).ToList();
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"Type '{typeName}' is ambiguous — it matches {candidates.Count} types: "
+                    + string.Join(", ", candidates) + ". Use the fully qualified name.",
+                new { type = typeName, candidates });
+        }
+
+        if (matches.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"Type '{typeName}' could not be resolved in this solution. Use the fully "
+                    + "qualified name, or add the type first — an unresolved type cannot be "
+                    + "written into a signature.",
+                new { type = typeName });
+        }
+
+        return matches[0];
     }
 
     // ------------------------------------------------------------------ cascade

--- a/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureLogic.cs
@@ -1,0 +1,395 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FindSymbols;
+using RoslynCodeLens.Analysis;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tools;
+
+/// <summary>
+/// Resolution, operation validation, cascade reporting and safety gates around
+/// <see cref="ChangeSignatureBridge"/>. Nothing reflective lives here: the bridge owns Roslyn's
+/// internal engine, this owns the contract the tool exposes.
+/// </summary>
+public static class ChangeSignatureLogic
+{
+    public static async Task<ChangeSignatureResult> ExecuteAsync(
+        LoadedSolution loaded, SymbolResolver resolver,
+        string method, IReadOnlyList<SignatureOperation> operations,
+        bool preview, bool force,
+        CommitWrittenDocuments? commitToMemory, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+
+        if (operations.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                "No operations supplied — pass at least one remove/reorder/add operation.",
+                new { method });
+        }
+
+        var target = ResolveMethod(resolver, method);
+        var document = GetDeclaringDocument(loaded, target, method);
+
+        var oldSignature = FormatSignature(target.Name,
+            target.Parameters.Select(p => p.ToDisplayString()));
+        var resolvedName = target.ToDisplayString();
+
+        var desired = BuildDesiredParameters(loaded, resolver, document, target, operations);
+        var newSignature = FormatSignature(target.Name, desired.Select(DescribeParameter));
+
+        var degradedRefusal = preview
+            ? null
+            : SolutionChangeSafety.DegradedApplyRefusal(loaded, force, "signature change");
+        if (degradedRefusal != null)
+        {
+            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
+                Applied: false, [], 0, [], [], degradedRefusal);
+        }
+
+        var bridge = await ChangeSignatureBridge.ChangeSignatureAsync(
+            document, target, desired, ct).ConfigureAwait(false);
+        if (!bridge.Succeeded || bridge.UpdatedSolution == null)
+        {
+            // Roslyn's own verdict, surfaced verbatim. Nothing is written.
+            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
+                Applied: false, [], 0, [], [],
+                bridge.FailureMessage ?? "Roslyn refused the signature change.");
+        }
+
+        var updated = bridge.UpdatedSolution;
+        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
+            updated, loaded.Solution, ct).ConfigureAwait(false);
+        var conflicts = await SolutionChangeSafety.ComputeConflictsAsync(
+            loaded, updated, ct).ConfigureAwait(false);
+        var cascadedTo = await FindCascadeSetAsync(loaded, target, ct).ConfigureAwait(false);
+        var filesChanged = edits.Select(e => e.FilePath)
+            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
+
+        if (preview)
+        {
+            var previewMessage = conflicts.Count > 0
+                ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
+                : "Preview only — no files written. Re-run with preview=false to apply.";
+            previewMessage = SolutionChangeSafety.DegradedPreviewWarning(
+                loaded, "signature change", previewMessage);
+            return new ChangeSignatureResult(true, resolvedName, oldSignature, newSignature,
+                Applied: false, edits, filesChanged, cascadedTo, conflicts, previewMessage);
+        }
+
+        if (conflicts.Count > 0 && !force)
+        {
+            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
+                Applied: false, edits, filesChanged, cascadedTo, conflicts,
+                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
+                "Inspect Conflicts, or re-run with force=true to apply anyway.");
+        }
+
+        var write = await SolutionChangeWriter.WriteChangesToDiskAsync(
+            updated, loaded.Solution, ct).ConfigureAwait(false);
+        if (!write.Written)
+        {
+            // Something edited these files after the snapshot was taken — writing snapshot-derived
+            // text would clobber those edits.
+            return new ChangeSignatureResult(false, resolvedName, oldSignature, newSignature,
+                Applied: false, edits, filesChanged, cascadedTo, conflicts,
+                $"Refused to apply: {write.StaleFiles.Count} file(s) changed on disk after the solution " +
+                $"snapshot was taken: {string.Join(", ", write.StaleFiles)}. No files were written. " +
+                "Run rebuild_solution and retry.");
+        }
+
+        var message = $"Changed {resolvedName} to {newSignature} in {filesChanged} file(s).";
+        if (cascadedTo.Count > 0)
+            message += $" Cascaded to {cascadedTo.Count} override(s)/implementation(s).";
+
+        // Post-write commit: the files are already changed on disk, so no outcome here —
+        // cancellation included — may fail the operation.
+        var commitWarning = await SolutionChangeWriter.CommitAsync(
+            commitToMemory, write, ct).ConfigureAwait(false);
+        if (commitWarning != null)
+            message += " Warning: " + commitWarning;
+
+        return new ChangeSignatureResult(true, resolvedName, oldSignature, newSignature,
+            Applied: true, edits, filesChanged, cascadedTo, conflicts, message);
+    }
+
+    // ------------------------------------------------------------------ resolution
+
+    internal static IMethodSymbol ResolveMethod(SymbolResolver resolver, string method)
+    {
+        var matches = resolver.FindSymbols(method);
+        if (matches.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.SymbolNotFound,
+                $"Method '{method}' not found.", new { method });
+        }
+
+        // Overloads share one logical group; unlike rename, change_signature edits exactly one
+        // of them, so a group with more than one member is an ambiguity the caller must resolve.
+        var groups = LogicalMemberGroups.GroupLogicalTargets(matches);
+        if (groups.Count > 1)
+        {
+            throw new McpToolException(ToolErrorCode.AmbiguousMatch,
+                $"'{method}' matched {groups.Count} distinct symbols: "
+                    + string.Join(", ", groups.Select(g => g.First().ToDisplayString()))
+                    + ". Use a more qualified name.",
+                new { matches = groups.Select(g => g.First().ToDisplayString()).ToList() });
+        }
+
+        var group = groups[0].ToList();
+        if (group.Count > 1)
+        {
+            var signatures = group.Select(s => s.ToDisplayString()).OrderBy(s => s, StringComparer.Ordinal).ToList();
+            throw new McpToolException(ToolErrorCode.AmbiguousMatch,
+                $"'{method}' matched {group.Count} overloads: {string.Join(", ", signatures)}. "
+                    + "change_signature edits one overload — qualify the call or rename it first.",
+                new { overloads = signatures });
+        }
+
+        if (group[0] is not IMethodSymbol target)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"'{method}' is a {group[0].Kind} — change_signature only applies to methods.",
+                new { method });
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    /// The document holding the declaration Roslyn will rewrite. A method with no source
+    /// declaration (metadata) has none, and is refused here rather than at the bridge.
+    /// </summary>
+    private static Document GetDeclaringDocument(
+        LoadedSolution loaded, IMethodSymbol target, string method)
+    {
+        foreach (var reference in target.DeclaringSyntaxReferences)
+        {
+            var document = loaded.Solution.GetDocument(reference.SyntaxTree);
+            if (document != null)
+                return document;
+        }
+
+        throw new McpToolException(ToolErrorCode.InvalidArgument,
+            $"'{method}' has no declaration in source — only methods defined in source can have "
+                + "their signature changed.",
+            new { method });
+    }
+
+    // ------------------------------------------------------------------ operations
+
+    private static List<DesiredParameter> BuildDesiredParameters(
+        LoadedSolution loaded, SymbolResolver resolver, Document document,
+        IMethodSymbol target, IReadOnlyList<SignatureOperation> operations)
+    {
+        var current = target.Parameters
+            .Select(p => new DesiredParameter(p, p.Name, null, p.Type, null, null))
+            .ToList();
+
+        foreach (var operation in operations)
+        {
+            switch (operation.Kind?.ToLowerInvariant())
+            {
+                case "remove":
+                    Remove(current, operation);
+                    break;
+                case "reorder":
+                    current = Reorder(current, operation);
+                    break;
+                case "add":
+                    current.Add(CreateAdded(loaded, resolver, document, operation));
+                    break;
+                default:
+                    throw new McpToolException(ToolErrorCode.InvalidArgument,
+                        $"Unknown operation kind '{operation.Kind}' — expected remove, reorder or add.",
+                        new { kind = operation.Kind });
+            }
+        }
+
+        return current;
+    }
+
+    private static void Remove(List<DesiredParameter> current, SignatureOperation operation)
+    {
+        if (string.IsNullOrWhiteSpace(operation.Parameter))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                "A remove operation requires 'parameter' — the name of the parameter to drop.",
+                new { kind = operation.Kind });
+        }
+
+        var index = current.FindIndex(
+            p => string.Equals(p.Name, operation.Parameter, StringComparison.Ordinal));
+        if (index < 0)
+        {
+            throw new McpToolException(ToolErrorCode.SymbolNotFound,
+                $"Parameter '{operation.Parameter}' not found. Remaining parameters: "
+                    + Describe(current) + ".",
+                new { parameter = operation.Parameter, remaining = current.Select(p => p.Name).ToList() });
+        }
+
+        current.RemoveAt(index);
+    }
+
+    private static List<DesiredParameter> Reorder(
+        List<DesiredParameter> current, SignatureOperation operation)
+    {
+        if (operation.Order == null || operation.Order.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                "A reorder operation requires 'order' — the full list of surviving parameter names.",
+                new { kind = operation.Kind });
+        }
+
+        var order = operation.Order.ToList();
+        var missing = current.Select(p => p.Name!)
+            .Where(name => !order.Contains(name, StringComparer.Ordinal)).ToList();
+        var unknown = order
+            .Where(name => !current.Any(p => string.Equals(p.Name, name, StringComparison.Ordinal)))
+            .ToList();
+        var duplicated = order.GroupBy(n => n, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+
+        if (missing.Count > 0 || unknown.Count > 0 || duplicated.Count > 0)
+        {
+            var problems = new List<string>();
+            if (missing.Count > 0)
+                problems.Add("omits " + string.Join(", ", missing));
+            if (unknown.Count > 0)
+                problems.Add("names unknown parameter(s) " + string.Join(", ", unknown));
+            if (duplicated.Count > 0)
+                problems.Add("repeats " + string.Join(", ", duplicated));
+
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"reorder must be a full permutation of the surviving parameters ({Describe(current)}) "
+                    + "but " + string.Join("; ", problems) + ".",
+                new { order, remaining = current.Select(p => p.Name).ToList() });
+        }
+
+        return order
+            .Select(name => current.First(p => string.Equals(p.Name, name, StringComparison.Ordinal)))
+            .ToList();
+    }
+
+    private static DesiredParameter CreateAdded(
+        LoadedSolution loaded, SymbolResolver resolver, Document document, SignatureOperation operation)
+    {
+        if (string.IsNullOrWhiteSpace(operation.Name))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                "An add operation requires 'name' — the new parameter's name.", new { kind = operation.Kind });
+        }
+
+        if (string.IsNullOrWhiteSpace(operation.Type))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"An add operation requires 'type' — the new parameter's type (adding '{operation.Name}').",
+                new { name = operation.Name });
+        }
+
+        if (string.IsNullOrWhiteSpace(operation.CallSiteValue))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"An add operation requires 'callSiteValue' — the expression every existing call site "
+                    + $"will pass for '{operation.Name}'. change_signature never guesses call-site semantics.",
+                new { name = operation.Name });
+        }
+
+        // A type that doesn't resolve is still usable: Roslyn writes the literal type name with
+        // typeBinds:false rather than refusing (the caller may be adding a type it is about to write).
+        var type = ResolveType(loaded, resolver, document, operation.Type);
+        return new DesiredParameter(
+            Existing: null,
+            Name: operation.Name,
+            TypeName: operation.Type,
+            Type: type,
+            CallSiteValue: operation.CallSiteValue,
+            DefaultValue: operation.DefaultValue);
+    }
+
+    /// <summary>C# keyword aliases so `int` works as well as `System.Int32`.</summary>
+    private static readonly Dictionary<string, SpecialType> KeywordAliases = new(StringComparer.Ordinal)
+    {
+        ["bool"] = SpecialType.System_Boolean,
+        ["byte"] = SpecialType.System_Byte,
+        ["sbyte"] = SpecialType.System_SByte,
+        ["char"] = SpecialType.System_Char,
+        ["decimal"] = SpecialType.System_Decimal,
+        ["double"] = SpecialType.System_Double,
+        ["float"] = SpecialType.System_Single,
+        ["int"] = SpecialType.System_Int32,
+        ["uint"] = SpecialType.System_UInt32,
+        ["long"] = SpecialType.System_Int64,
+        ["ulong"] = SpecialType.System_UInt64,
+        ["short"] = SpecialType.System_Int16,
+        ["ushort"] = SpecialType.System_UInt16,
+        ["object"] = SpecialType.System_Object,
+        ["string"] = SpecialType.System_String,
+    };
+
+    private static ITypeSymbol? ResolveType(
+        LoadedSolution loaded, SymbolResolver resolver, Document document, string typeName)
+    {
+        var compilation = document.Project.Id is { } projectId
+            && loaded.Compilations.TryGetValue(projectId, out var cached)
+                ? cached
+                : null;
+
+        if (compilation != null)
+        {
+            if (KeywordAliases.TryGetValue(typeName, out var special))
+                return compilation.GetSpecialType(special);
+
+            var byMetadataName = compilation.GetTypeByMetadataName(typeName);
+            if (byMetadataName != null)
+                return byMetadataName;
+        }
+
+        var matches = resolver.FindNamedTypes(typeName);
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    // ------------------------------------------------------------------ cascade
+
+    /// <summary>
+    /// Overrides and interface implementations Roslyn's engine rewrites alongside the target, so
+    /// the blast radius is visible before applying.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>> FindCascadeSetAsync(
+        LoadedSolution loaded, IMethodSymbol target, CancellationToken ct)
+    {
+        var cascade = new List<ISymbol>();
+        cascade.AddRange(await SymbolFinder.FindOverridesAsync(
+            target, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
+        cascade.AddRange(await SymbolFinder.FindImplementationsAsync(
+            target, loaded.Solution, cancellationToken: ct).ConfigureAwait(false));
+
+        return cascade
+            .Select(s => s.ToDisplayString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // ------------------------------------------------------------------ display
+
+    private static string Describe(IEnumerable<DesiredParameter> parameters)
+    {
+        var names = parameters.Select(p => p.Name).ToList();
+        return names.Count == 0 ? "(none)" : string.Join(", ", names);
+    }
+
+    private static string FormatSignature(string name, IEnumerable<string> parameters)
+        => $"{name}({string.Join(", ", parameters)})";
+
+    private static string DescribeParameter(DesiredParameter parameter)
+    {
+        if (parameter.Existing != null)
+            return parameter.Existing.ToDisplayString();
+
+        var text = $"{parameter.Type?.ToDisplayString() ?? parameter.TypeName} {parameter.Name}";
+        return string.IsNullOrEmpty(parameter.DefaultValue)
+            ? text
+            : $"{text} = {parameter.DefaultValue}";
+    }
+}

--- a/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
@@ -19,7 +19,8 @@ public static class ChangeSignatureTool
                  "since the tool never guesses call-site semantics — with an optional " +
                  "`defaultValue` that instead makes the parameter optional and leaves existing " +
                  "calls untouched. Rejected as unsafe: an added name that is not a valid C# "
-                 + "identifier or collides with an existing parameter; moving or removing an "
+                 + "identifier or collides with an existing parameter; a `type` that does not "
+                 + "resolve, or resolves ambiguously (qualify it); moving or removing an "
                  + "extension method's `this` parameter (it must stay first); and any signature "
                  + "that would leave a surviving `params` array anywhere but last — add the "
                  + "parameter and reorder it before the `params` array, or remove that array. "

--- a/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+[McpServerToolType]
+public static class ChangeSignatureTool
+{
+    [McpServerTool(Name = "change_signature"),
+     Description("Add, remove, or reorder a method's parameters and update every call site " +
+                 "(Roslyn's own change-signature engine). Cascades to overrides and interface " +
+                 "implementations, rewrites named and optional arguments, and preserves an " +
+                 "extension method's `this` parameter; the overrides and implementations it also " +
+                 "rewrote are listed in `CascadedTo`. Operations apply in order: " +
+                 "`remove` drops `parameter`; `reorder` takes `order`, a full permutation of the " +
+                 "parameters surviving at that point; `add` appends `name` plus `type` and " +
+                 "REQUIRES `callSiteValue` — the expression every existing call site will pass, " +
+                 "since the tool never guesses call-site semantics — with an optional " +
+                 "`defaultValue` that instead makes the parameter optional and leaves existing " +
+                 "calls untouched. Defaults to preview mode (returns edits without writing files); " +
+                 "set `preview=false` to apply. New compiler errors the change would introduce are " +
+                 "reported as Conflicts, and apply mode refuses to write them unless `force=true`. " +
+                 "Source-defined methods only; overloaded names must be disambiguated.")]
+    public static async Task<ChangeSignatureResult> Execute(
+        MultiSolutionManager manager,
+        [Description("Method to change: `MyClass.MyMethod` or fully qualified `Namespace.MyClass.MyMethod`")] string method,
+        [Description("Parameter edits applied in order. Each has `kind` (`remove`, `reorder` or `add`) plus: `parameter` for `remove`; `order` for `reorder`; `name`, `type`, `callSiteValue` and optional `defaultValue` for `add`")] SignatureOperation[] operations,
+        [Description("Preview only — return edits without writing to disk (default: true)")] bool preview = true,
+        [Description("Apply even when Conflicts are reported (default: false)")] bool force = false,
+        CancellationToken ct = default)
+    {
+        manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
+        return await ChangeSignatureLogic.ExecuteAsync(
+            context.Loaded, context.Resolver, method, operations, preview, force,
+            // After a successful apply, push the written texts into the in-memory snapshot so
+            // follow-up queries see the new signature immediately (no watcher-debounce window).
+            manager.CommitDocumentTextsAsync, ct).ConfigureAwait(false);
+    }
+}

--- a/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
+++ b/src/RoslynCodeLens/Tools/ChangeSignatureTool.cs
@@ -18,7 +18,12 @@ public static class ChangeSignatureTool
                  "REQUIRES `callSiteValue` — the expression every existing call site will pass, " +
                  "since the tool never guesses call-site semantics — with an optional " +
                  "`defaultValue` that instead makes the parameter optional and leaves existing " +
-                 "calls untouched. Defaults to preview mode (returns edits without writing files); " +
+                 "calls untouched. Rejected as unsafe: an added name that is not a valid C# "
+                 + "identifier or collides with an existing parameter; moving or removing an "
+                 + "extension method's `this` parameter (it must stay first); and any signature "
+                 + "that would leave a surviving `params` array anywhere but last — add the "
+                 + "parameter and reorder it before the `params` array, or remove that array. "
+                 + "Defaults to preview mode (returns edits without writing files); " +
                  "set `preview=false` to apply. New compiler errors the change would introduce are " +
                  "reported as Conflicts, and apply mode refuses to write them unless `force=true`. " +
                  "Source-defined methods only; overloaded names must be disambiguated.")]

--- a/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
@@ -28,13 +28,13 @@ public static class RenameSymbolLogic
         // Degraded guard (finding 3): a load with dropped references can make Renamer miss
         // references entirely, silently producing an incomplete rename. Refuse to write in
         // that state unless the user explicitly forces it; previews warn instead (below).
-        if (!preview && loaded.Degraded && !force)
+        var degradedRefusal = preview
+            ? null
+            : SolutionChangeSafety.DegradedApplyRefusal(loaded, force, "rename");
+        if (degradedRefusal != null)
         {
             return new RenameSymbolResult(false, target.ToDisplayString(), newName, Applied: false,
-                [], 0, [],
-                $"Refused to apply: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load " +
-                "diagnostic(s) — projects opened with dropped references), so the rename may be incomplete " +
-                "and silently miss references. Run rebuild_solution and retry, or re-run with force=true to apply anyway.");
+                [], 0, [], degradedRefusal);
         }
 
         var options = new SymbolRenameOptions(
@@ -48,7 +48,8 @@ public static class RenameSymbolLogic
 
         var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
             renamed, loaded.Solution, ct).ConfigureAwait(false);
-        var conflicts = await ComputeConflictsAsync(loaded, renamed, ct).ConfigureAwait(false);
+        var conflicts = await SolutionChangeSafety.ComputeConflictsAsync(
+            loaded, renamed, ct).ConfigureAwait(false);
         var filesChanged = edits.Select(e => e.FilePath)
             .Distinct(StringComparer.OrdinalIgnoreCase).Count();
         var oldName = target.ToDisplayString();
@@ -58,13 +59,7 @@ public static class RenameSymbolLogic
             var previewMessage = conflicts.Count > 0
                 ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
                 : "Preview only — no files written. Re-run with preview=false to apply.";
-            if (loaded.Degraded)
-            {
-                previewMessage =
-                    $"WARNING: the solution loaded degraded ({loaded.LoadDiagnostics.Count} load diagnostic(s) — " +
-                    "projects opened with dropped references), so this rename may be incomplete and miss references. " +
-                    previewMessage;
-            }
+            previewMessage = SolutionChangeSafety.DegradedPreviewWarning(loaded, "rename", previewMessage);
             return new RenameSymbolResult(true, oldName, newName, Applied: false,
                 edits, filesChanged, conflicts, previewMessage);
         }
@@ -140,122 +135,5 @@ public static class RenameSymbolLogic
                 $"'{symbol}' is a metadata symbol — only symbols defined in source can be renamed.",
                 new { symbol });
         }
-    }
-
-    private static async Task<IReadOnlyList<RenameConflict>> ComputeConflictsAsync(
-        LoadedSolution loaded, Solution renamed, CancellationToken ct)
-    {
-        var original = loaded.Solution;
-        var conflicts = new List<RenameConflict>();
-        foreach (var projectId in ComputeScanSet(original, renamed))
-        {
-            var afterProject = renamed.GetProject(projectId);
-            if (afterProject == null)
-                continue;
-
-            // Before side prefers the cached compilation (already built at load
-            // time); after side is the forked project. Both diagnostics passes
-            // are CPU-bound, so run them concurrently.
-            var beforeTask = Task.Run(async () =>
-            {
-                if (!loaded.Compilations.TryGetValue(projectId, out var compilation))
-                {
-                    compilation = await original.GetProject(projectId)!
-                        .GetCompilationAsync(ct).ConfigureAwait(false);
-                }
-                return compilation?.GetDiagnostics(ct);
-            }, ct);
-            var afterTask = Task.Run(async () =>
-            {
-                var compilation = await afterProject.GetCompilationAsync(ct).ConfigureAwait(false);
-                return compilation?.GetDiagnostics(ct);
-            }, ct);
-            await Task.WhenAll(beforeTask, afterTask).ConfigureAwait(false);
-
-            var before = await beforeTask.ConfigureAwait(false);
-            var after = await afterTask.ConfigureAwait(false);
-            if (before == null || after == null)
-                continue;
-
-            conflicts.AddRange(DiffNewErrors(before, after));
-        }
-        return conflicts;
-    }
-
-    /// <summary>
-    /// Projects to conflict-scan: those Renamer textually changed, plus their
-    /// direct dependents — a rename can break a downstream project without
-    /// touching its text (source generators, name-based lookup changes).
-    /// </summary>
-    internal static IReadOnlyList<ProjectId> ComputeScanSet(Solution original, Solution renamed)
-    {
-        var changed = renamed.GetChanges(original).GetProjectChanges()
-            .Select(c => c.ProjectId).ToList();
-        var graph = original.GetProjectDependencyGraph();
-
-        var seen = new HashSet<ProjectId>();
-        var scanSet = new List<ProjectId>();
-        foreach (var projectId in changed)
-        {
-            if (seen.Add(projectId))
-                scanSet.Add(projectId);
-        }
-        foreach (var projectId in changed)
-        {
-            foreach (var dependent in graph.GetProjectsThatDirectlyDependOnThisProject(projectId))
-            {
-                if (seen.Add(dependent))
-                    scanSet.Add(dependent);
-            }
-        }
-        return scanSet;
-    }
-
-    /// <summary>
-    /// Multiset diff of error diagnostics keyed by (Id, FilePath) — messages play
-    /// no role, so pre-existing errors whose message embeds the renamed symbol
-    /// don't become phantom conflicts, and a new error that duplicates an existing
-    /// one's message still surfaces as a count increase. Suppressed diagnostics
-    /// are skipped, matching GetDiagnosticsLogic's policy.
-    /// </summary>
-    internal static List<RenameConflict> DiffNewErrors(
-        IEnumerable<Diagnostic> before, IEnumerable<Diagnostic> after)
-    {
-        static bool IsReportableError(Diagnostic d)
-            => d.Severity == DiagnosticSeverity.Error && !d.IsSuppressed;
-        static string Key(Diagnostic d)
-            => $"{d.Id}|{d.Location.GetLineSpan().Path}";
-        static int Line(Diagnostic d)
-            => d.Location.GetLineSpan().StartLinePosition.Line + 1;
-
-        var beforeGroups = before.Where(IsReportableError)
-            .GroupBy(Key, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
-
-        var conflicts = new List<RenameConflict>();
-        foreach (var group in after.Where(IsReportableError)
-                     .GroupBy(Key, StringComparer.OrdinalIgnoreCase))
-        {
-            var afterDiags = group.ToList();
-            var beforeCount = beforeGroups.TryGetValue(group.Key, out var beforeDiags)
-                ? beforeDiags.Count : 0;
-            var newCount = afterDiags.Count - beforeCount;
-            if (newCount <= 0)
-                continue;
-
-            // Prefer diagnostics on lines the before side didn't have — those are
-            // most likely the genuinely new ones; fall back to arbitrary members.
-            var beforeLines = beforeDiags?.Select(Line).ToHashSet() ?? [];
-            foreach (var diag in afterDiags
-                         .OrderBy(d => beforeLines.Contains(Line(d)) ? 1 : 0)
-                         .Take(newCount))
-            {
-                var span = diag.Location.GetLineSpan();
-                conflicts.Add(new RenameConflict(
-                    diag.Id, diag.GetMessage(), span.Path,
-                    span.StartLinePosition.Line + 1));
-            }
-        }
-        return conflicts;
     }
 }

--- a/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
+++ b/src/RoslynCodeLens/Tools/RenameSymbolLogic.cs
@@ -46,56 +46,18 @@ public static class RenameSymbolLogic
         var renamed = await Renamer.RenameSymbolAsync(
             loaded.Solution, target, options, newName, ct).ConfigureAwait(false);
 
-        var edits = await SolutionChangeWriter.ExtractTextEditsAsync(
-            renamed, loaded.Solution, ct).ConfigureAwait(false);
-        var conflicts = await SolutionChangeSafety.ComputeConflictsAsync(
-            loaded, renamed, ct).ConfigureAwait(false);
-        var filesChanged = edits.Select(e => e.FilePath)
-            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
         var oldName = target.ToDisplayString();
 
-        if (preview)
-        {
-            var previewMessage = conflicts.Count > 0
-                ? $"{conflicts.Count} conflict(s) detected — applying would introduce new compiler errors."
-                : "Preview only — no files written. Re-run with preview=false to apply.";
-            previewMessage = SolutionChangeSafety.DegradedPreviewWarning(loaded, "rename", previewMessage);
-            return new RenameSymbolResult(true, oldName, newName, Applied: false,
-                edits, filesChanged, conflicts, previewMessage);
-        }
+        // The preview/conflict-gate/write/freshness/commit sequence is shared verbatim with
+        // change_signature — it decides whether bytes hit disk, so it lives in one place.
+        var outcome = await SolutionChangeSafety.PreviewOrApplyAsync(
+            loaded, renamed, "rename", preview, force,
+            filesChanged => $"Renamed {oldName} to {newName} in {filesChanged} file(s).",
+            commitToMemory, ct).ConfigureAwait(false);
 
-        if (conflicts.Count > 0 && !force)
-        {
-            return new RenameSymbolResult(false, oldName, newName, Applied: false,
-                edits, filesChanged, conflicts,
-                $"Refused to apply: {conflicts.Count} new compiler error(s) would be introduced. " +
-                "Inspect Conflicts, or re-run with force=true to apply anyway.");
-        }
-
-        var write = await SolutionChangeWriter.WriteChangesToDiskAsync(
-            renamed, loaded.Solution, ct).ConfigureAwait(false);
-        if (!write.Written)
-        {
-            // Freshness refusal (finding 1): something edited these files after the solution
-            // snapshot was taken — writing snapshot-derived text would clobber those edits.
-            return new RenameSymbolResult(false, oldName, newName, Applied: false,
-                edits, filesChanged, conflicts,
-                $"Refused to apply: {write.StaleFiles.Count} file(s) changed on disk after the solution " +
-                $"snapshot was taken: {string.Join(", ", write.StaleFiles)}. No files were written. " +
-                "Run rebuild_solution and retry.");
-        }
-
-        var message = $"Renamed {oldName} to {newName} in {filesChanged} file(s).";
-        // Post-write commit: make the in-memory snapshot reflect the new text immediately instead
-        // of waiting out the file watcher's debounce window. Shared with apply_code_action, and
-        // like it, no outcome here — cancellation included — may fail the rename: the files are
-        // already renamed on disk, so reporting failure would misdescribe what happened.
-        var commitWarning = await SolutionChangeWriter.CommitAsync(commitToMemory, write, ct).ConfigureAwait(false);
-        if (commitWarning != null)
-            message += " Warning: " + commitWarning;
-
-        return new RenameSymbolResult(true, oldName, newName, Applied: true,
-            edits, filesChanged, conflicts, message);
+        return new RenameSymbolResult(
+            outcome.Success, oldName, newName, outcome.Applied,
+            outcome.Edits, outcome.FilesChanged, outcome.Conflicts, outcome.Message);
     }
 
     internal static ISymbol ResolveSingleTarget(SymbolResolver resolver, string symbol)

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureBridgeTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureBridgeTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens.Analysis;
+using RoslynCodeLens.Tests.Fixtures;
+
+namespace RoslynCodeLens.Tests;
+
+public class ChangeSignatureBridgeTests
+{
+    /// <summary>
+    /// Every internal Roslyn member the bridge needs must resolve. If a Roslyn upgrade moves or
+    /// renames one, this fails loudly here rather than at a user's apply — which is the whole
+    /// reason the reflection is confined to one probeable surface.
+    /// </summary>
+    [Fact]
+    public void Probe_ResolvesEveryRequiredMember()
+    {
+        var missing = ChangeSignatureBridge.Probe();
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public async Task Reorder_RewritesDeclarationAndCallSite()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Demo.cs", """
+            namespace Demo;
+            public class Svc
+            {
+                public int Add(int a, string b) => a;
+                public int Use() => Add(1, "x");
+            }
+            """));
+        var method = (IMethodSymbol)resolver.FindSymbols("Svc.Add").Single();
+        var doc = loaded.Solution.GetDocument(
+            method.DeclaringSyntaxReferences[0].SyntaxTree)!;
+
+        var reordered = new[] { method.Parameters[1], method.Parameters[0] }
+            .Select(p => new DesiredParameter(p, null, null, null, null, null)).ToList();
+
+        var result = await ChangeSignatureBridge.ChangeSignatureAsync(doc, method, reordered, default);
+
+        Assert.True(result.Succeeded, result.FailureMessage);
+        var text = (await result.UpdatedSolution!.GetDocument(doc.Id)!.GetTextAsync()).ToString();
+        Assert.Contains("Add(string b, int a)", text, StringComparison.Ordinal);
+        Assert.Contains("Add(\"x\", 1)", text, StringComparison.Ordinal);   // call site followed
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureBridgeTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureBridgeTests.cs
@@ -18,6 +18,36 @@ public class ChangeSignatureBridgeTests
         Assert.Empty(missing);
     }
 
+    /// <summary>
+    /// Probe() returning empty only proves the members it LOOKED FOR resolved, so the probe's
+    /// coverage is asserted separately. Three things the original probe never checked are pinned
+    /// here: the service's parameterless constructor (used via Activator, so its absence would
+    /// only ever surface at a user's apply) and the two awaited return types — a signature change
+    /// that returned a different Task<T> would break at the GetTaskResult cast instead.
+    /// </summary>
+    [Fact]
+    public void Probe_CoversTheServiceConstructorAndBothAwaitedReturnTypes()
+    {
+        var probed = ChangeSignatureBridge.ProbedMembers();
+
+        Assert.Contains(probed, name => name.Contains("CSharpChangeSignatureService..ctor()", StringComparison.Ordinal));
+        Assert.Contains(probed, name =>
+            name.Contains("SemanticDocument.CreateAsync", StringComparison.Ordinal)
+            && name.Contains("Task<SemanticDocument>", StringComparison.Ordinal));
+        Assert.Contains(probed, name =>
+            name.Contains("ChangeSignatureWithContextAsync", StringComparison.Ordinal)
+            && name.Contains("Task<ChangeSignatureResult>", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ProbedMembers_IsASupersetOfWhateverIsMissing()
+    {
+        var probed = ChangeSignatureBridge.ProbedMembers();
+
+        Assert.NotEmpty(probed);
+        Assert.All(ChangeSignatureBridge.Probe(), missing => Assert.Contains(missing, probed));
+    }
+
     [Fact]
     public async Task Reorder_RewritesDeclarationAndCallSite()
     {

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureFixtureTests.cs
@@ -1,0 +1,70 @@
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Preview-only, so the checked-in TestSolution files stay pristine. `Greeter.Greet` really is
+/// `string Greet(string name)` — one parameter, virtual, implementing `IGreeter` and overridden by
+/// `FancyGreeter` — so `add` (not `reorder`) is the operation that exercises call-site rewriting
+/// across projects here.
+/// </summary>
+[Collection("TestSolution")]
+public class ChangeSignatureFixtureTests
+{
+    private readonly TestSolutionFixture _fixture;
+
+    public ChangeSignatureFixtureTests(TestSolutionFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public async Task PreviewAddParameterToGreet_EditsDeclarationAndCallSitesAcrossProjects()
+    {
+        var result = await ChangeSignatureLogic.ExecuteAsync(
+            _fixture.Loaded, _fixture.Resolver, "TestLib.Greeter.Greet",
+            [new SignatureOperation("add",
+                Name: "salutation", Type: "System.String", CallSiteValue: "\"Hello\"")],
+            preview: true, force: false, commitToMemory: null, CancellationToken.None);
+
+        Assert.True(result.Success, result.Message);
+        Assert.False(result.Applied);
+        Assert.Equal("Greet(string name)", result.OldSignature);
+        Assert.Equal("Greet(string name, string salutation)", result.NewSignature);
+
+        // The declaration itself.
+        Assert.Contains(result.Edits, e =>
+            string.Equals(Path.GetFileName(e.FilePath), "Greeter.cs", StringComparison.OrdinalIgnoreCase));
+
+        // Call sites live in the xUnit/NUnit/MSTest fixture projects, so edits span > 1 project.
+        var projects = result.Edits
+            .Select(e => Path.GetFileName(Path.GetDirectoryName(e.FilePath)!))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        Assert.True(projects.Count > 1,
+            $"Expected edits across multiple projects, got: {string.Join(", ", projects)}");
+
+        // Every existing call site receives the supplied call-site value.
+        Assert.Contains(result.Edits, e => e.NewText.Contains("\"Hello\"", StringComparison.Ordinal));
+
+        // FancyGreeter overrides Greet, so the cascade must name it.
+        Assert.Contains(result.CascadedTo, s => s.Contains("FancyGreeter.Greet", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PreviewLeavesFixtureFilesPristine()
+    {
+        var greeterPath = _fixture.Resolver.FindMethods("TestLib.Greeter.Greet")
+            .Select(m => m.Locations.First(l => l.IsInSource).SourceTree!.FilePath)
+            .First();
+        var before = await File.ReadAllTextAsync(greeterPath);
+
+        var result = await ChangeSignatureLogic.ExecuteAsync(
+            _fixture.Loaded, _fixture.Resolver, "TestLib.Greeter.Greet",
+            [new SignatureOperation("add",
+                Name: "salutation", Type: "System.String", CallSiteValue: "\"Hello\"")],
+            preview: true, force: false, commitToMemory: null, CancellationToken.None);
+
+        Assert.False(result.Applied);
+        Assert.Equal(before, await File.ReadAllTextAsync(greeterPath));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
@@ -263,6 +263,142 @@ public class ChangeSignatureLogicTests
         Assert.Contains("3.Twice(\"x\", 2)", after, StringComparison.Ordinal);
     }
 
+    private const string ExtensionSource = """
+        namespace SigDemo;
+        public static class Ext
+        {
+            public static int Twice(this int value, int factor, string label) => value;
+            public static int Use() => 3.Twice(2, "x");
+        }
+        """;
+
+    /// <summary>
+    /// The receiver is index 0 by position, not by identity: Roslyn's ParameterConfiguration
+    /// re-derives `this` from whatever lands first. A reorder that promotes another parameter
+    /// would silently rebind the receiver, so it is refused.
+    /// </summary>
+    [Fact]
+    public async Task ExtensionMethod_ReorderDisplacingReceiver_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Ext.cs", ExtensionSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Ext.Twice",
+                [new SignatureOperation("reorder", Order: ["factor", "value", "label"])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("value", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("extension", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExtensionMethod_RemovingReceiver_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Ext.cs", ExtensionSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Ext.Twice",
+                [new SignatureOperation("remove", Parameter: "value")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("extension", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Add_DuplicateParameterName_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Name: "a", Type: "System.Int32", CallSiteValue: "0")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("'a'", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Add_NameDifferingOnlyByCase_IsAllowed()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        // C# identifiers are case-sensitive, so `A` alongside `a` is legal.
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("add", Name: "A", Type: "System.Int32", CallSiteValue: "0")]);
+
+        Assert.True(result.Success, result.Message);
+    }
+
+    private const string ParamsSource = """
+        namespace SigDemo;
+        public class Svc
+        {
+            public int Sum(int a, params int[] rest) => a;
+            public int Use() => Sum(1, 2, 3);
+        }
+        """;
+
+    /// <summary>
+    /// Roslyn recognises `params` only on the LAST parameter, so an add that lands after it
+    /// would emit CS0231. Refused rather than silently reordered.
+    /// </summary>
+    [Fact]
+    public async Task ParamsMethod_Add_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", ParamsSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Sum",
+                [new SignatureOperation("add", Name: "seed", Type: "System.Int32", CallSiteValue: "0")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("params", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("rest", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ParamsMethod_ReorderMovingParamsOffTheEnd_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", ParamsSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Sum",
+                [new SignatureOperation("reorder", Order: ["rest", "a"])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("params", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ParamsMethod_RemovingTheParamsArray_IsAllowed()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", ParamsSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Sum",
+            [new SignatureOperation("remove", Parameter: "rest")]);
+
+        Assert.True(result.Success, result.Message);
+    }
+
+    [Theory]
+    [InlineData("1st")]
+    [InlineData("x, int y")]
+    [InlineData("a b")]
+    // NOTE: a reserved keyword ("class") is NOT rejected — SyntaxFacts.IsValidIdentifier checks
+    // lexical form only, and this deliberately uses the same guard as rename_symbol. Such a name
+    // produces parse errors that surface as Conflicts, so it cannot land silently.
+    public async Task Add_InvalidIdentifier_ThrowsInvalidArgument(string name)
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Name: name, Type: "System.Int32", CallSiteValue: "0")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("identifier", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     // ---------------------------------------------------------------- conflicts
 
     private const string BodyUsesParamSource = """
@@ -283,7 +419,10 @@ public class ChangeSignatureLogicTests
             [new SignatureOperation("remove", Parameter: "b")]);
 
         Assert.True(result.Success, result.Message);
-        Assert.NotEmpty(result.Conflicts);
+        // The body still says `b.Length` after `b` is gone: CS0103 (name does not exist).
+        var conflict = Assert.Single(result.Conflicts);
+        Assert.Equal("CS0103", conflict.Id);
+        Assert.Contains("b", conflict.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -371,6 +510,18 @@ public class ChangeSignatureLogicTests
             () => RunAsync(loaded, resolver, "Svc.Add", []));
 
         Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task NullOperations_ThrowsInvalidArgumentLikeAnEmptyArray()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add", null!));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("No operations supplied", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
@@ -1,0 +1,613 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using RoslynCodeLens;
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+public class ChangeSignatureLogicTests
+{
+    private static Task<ChangeSignatureResult> RunAsync(
+        LoadedSolution loaded, SymbolResolver resolver, string method,
+        IReadOnlyList<SignatureOperation> operations,
+        bool preview = true, bool force = false,
+        CommitWrittenDocuments? commit = null)
+        => ChangeSignatureLogic.ExecuteAsync(
+            loaded, resolver, method, operations, preview, force, commit, CancellationToken.None);
+
+    /// <summary>Applies preview edits for one file back onto its source, as the rename tests do.</summary>
+    private static string ApplyEdits(string source, IEnumerable<TextEdit> edits, string filePath)
+    {
+        var text = SourceText.From(source);
+        var changes = edits
+            .Where(e => string.Equals(e.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+            .Select(e => new TextChange(
+                TextSpan.FromBounds(
+                    text.Lines[e.StartLine - 1].Start + e.StartColumn - 1,
+                    text.Lines[e.EndLine - 1].Start + e.EndColumn - 1),
+                e.NewText));
+        return text.WithChanges(changes).ToString();
+    }
+
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) Degrade(
+        (LoadedSolution Loaded, SymbolResolver Resolver) workspace)
+    {
+        var degraded = new LoadedSolution
+        {
+            Solution = workspace.Loaded.Solution,
+            Compilations = workspace.Loaded.Compilations,
+            LoadDiagnostics = ["SigProj: metadata reference 'Missing.dll' could not be resolved"],
+        };
+        return (degraded, new SymbolResolver(degraded));
+    }
+
+    // ---------------------------------------------------------------- operations
+
+    private const string TwoParamSource = """
+        namespace SigDemo;
+        public class Svc
+        {
+            public int Add(int a, string b) => a;
+            public int Use() => Add(1, "x");
+        }
+        """;
+
+    [Fact]
+    public async Task Remove_DropsParameterAndUpdatesCallSites()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.False(result.Applied);
+        var after = ApplyEdits(TwoParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("Add(int a)", after, StringComparison.Ordinal);
+        Assert.Contains("Add(1)", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Reorder_RewritesCallSitesInNewOrder()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("reorder", Order: ["b", "a"])]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(TwoParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("Add(string b, int a)", after, StringComparison.Ordinal);
+        Assert.Contains("Add(\"x\", 1)", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Reorder_ReportsOldAndNewSignature()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("reorder", Order: ["b", "a"])]);
+
+        Assert.Equal("Add(int a, string b)", result.OldSignature);
+        Assert.Equal("Add(string b, int a)", result.NewSignature);
+        Assert.Equal("SigDemo.Svc.Add(int, string)", result.Method);
+    }
+
+    private const string OneParamSource = """
+        using System.Threading;
+
+        namespace SigDemo;
+        public class Svc
+        {
+            public int Add(int a) => a;
+            public int Use() => Add(1);
+        }
+        """;
+
+    /// <summary>
+    /// Also the proof for the bridge's positionForTypeBinding choice: the added parameter's type
+    /// name is bound/simplified with the file's usings in scope, so `System.Threading.CancellationToken`
+    /// renders as `CancellationToken` rather than degrading.
+    /// </summary>
+    [Fact]
+    public async Task Add_InsertsCallSiteValueEverywhere()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", OneParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+        [
+            new SignatureOperation("add",
+                Name: "token", Type: "System.Threading.CancellationToken",
+                CallSiteValue: "CancellationToken.None"),
+        ]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(OneParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("CancellationToken token", after, StringComparison.Ordinal);
+        Assert.Contains("Add(1, CancellationToken.None)", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Add_WithDefault_LeavesExistingCallSitesAlone()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", OneParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+        [
+            new SignatureOperation("add",
+                Name: "token", Type: "System.Threading.CancellationToken",
+                CallSiteValue: "CancellationToken.None", DefaultValue: "default"),
+        ]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(OneParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("CancellationToken token = default", after, StringComparison.Ordinal);
+        // isRequired:false + CallSiteKind.Omitted ⇒ the existing call keeps its single argument.
+        Assert.Contains("Add(1)", after, StringComparison.Ordinal);
+        Assert.DoesNotContain("CancellationToken.None", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NamedArguments_AreRewritten()
+    {
+        const string source = """
+            namespace SigDemo;
+            public class Svc
+            {
+                public int Add(int a, string b) => a;
+                public int Use() => Add(a: 1, b: "x");
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("reorder", Order: ["b", "a"])]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(source, result.Edits, "Svc.cs");
+        Assert.Contains("Add(string b, int a)", after, StringComparison.Ordinal);
+        Assert.Contains("Add(b: \"x\", a: 1)", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Combined_RemoveThenAdd_AppliesInOrder()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+        [
+            new SignatureOperation("remove", Parameter: "b"),
+            new SignatureOperation("add", Name: "count", Type: "System.Int32", CallSiteValue: "0"),
+        ]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(TwoParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("Add(int a, int count)", after, StringComparison.Ordinal);
+        Assert.Contains("Add(1, 0)", after, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------- cascade
+
+    [Fact]
+    public async Task InterfaceImplementation_IsCascaded()
+    {
+        const string source = """
+            namespace SigDemo;
+            public interface IGreet
+            {
+                string Greet(string name, int times);
+            }
+            public class Greeter : IGreet
+            {
+                public string Greet(string name, int times) => name;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Greet.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "IGreet.Greet",
+            [new SignatureOperation("remove", Parameter: "times")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Contains(result.CascadedTo, s => s.Contains("Greeter.Greet", StringComparison.Ordinal));
+        var after = ApplyEdits(source, result.Edits, "Greet.cs");
+        Assert.DoesNotContain("int times", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Override_IsCascaded()
+    {
+        const string source = """
+            namespace SigDemo;
+            public class Base
+            {
+                public virtual string Greet(string name, int times) => name;
+            }
+            public class Derived : Base
+            {
+                public override string Greet(string name, int times) => name;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Greet.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "Base.Greet",
+            [new SignatureOperation("remove", Parameter: "times")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Contains(result.CascadedTo, s => s.Contains("Derived.Greet", StringComparison.Ordinal));
+        var after = ApplyEdits(source, result.Edits, "Greet.cs");
+        Assert.DoesNotContain("int times", after, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExtensionMethod_ThisParameterPreserved()
+    {
+        const string source = """
+            namespace SigDemo;
+            public static class Ext
+            {
+                public static int Twice(this int value, int factor, string label) => value;
+                public static int Use() => 3.Twice(2, "x");
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Ext.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "Ext.Twice",
+            [new SignatureOperation("reorder", Order: ["value", "label", "factor"])]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(source, result.Edits, "Ext.cs");
+        Assert.Contains("Twice(this int value, string label, int factor)", after, StringComparison.Ordinal);
+        Assert.Contains("3.Twice(\"x\", 2)", after, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------- conflicts
+
+    private const string BodyUsesParamSource = """
+        namespace SigDemo;
+        public class Svc
+        {
+            public int Add(int a, string b) => a + b.Length;
+            public int Use() => Add(1, "x");
+        }
+        """;
+
+    [Fact]
+    public async Task RemovedParameterStillUsed_ProducesConflict()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", BodyUsesParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.NotEmpty(result.Conflicts);
+    }
+
+    [Fact]
+    public async Task RemovedParameterStillUsed_Apply_RefusesWithoutForce()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", BodyUsesParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")], preview: false);
+
+        Assert.False(result.Success);
+        Assert.False(result.Applied);
+        Assert.NotEmpty(result.Conflicts);
+        Assert.Contains("force", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------- resolution errors
+
+    [Fact]
+    public async Task Overloads_AreAmbiguous()
+    {
+        const string source = """
+            namespace SigDemo;
+            public class Svc
+            {
+                public int Add(int a) => a;
+                public int Add(int a, string b) => a;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", source));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "a")]));
+
+        Assert.Equal(ToolErrorCode.AmbiguousMatch, ex.Code);
+        Assert.Contains("Add(int, string)", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnknownMethod_ThrowsSymbolNotFound()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.NoSuchMethod",
+                [new SignatureOperation("remove", Parameter: "a")]));
+
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+    }
+
+    [Fact]
+    public async Task NonMethodTarget_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc",
+                [new SignatureOperation("remove", Parameter: "a")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task UnknownParameter_ThrowsSymbolNotFound()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "nope")]));
+
+        Assert.Equal(ToolErrorCode.SymbolNotFound, ex.Code);
+        Assert.Contains("nope", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------- argument validation
+
+    [Fact]
+    public async Task EmptyOperations_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add", []));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task UnknownKind_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("rename", Parameter: "a")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task ReorderNotAPermutation_ThrowsInvalidArgumentNamingTheDifference()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("reorder", Order: ["a"])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("b", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReorderWithUnknownName_ThrowsInvalidArgumentNamingTheDifference()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("reorder", Order: ["a", "zzz"])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("zzz", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddWithoutCallSiteValue_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Name: "token", Type: "System.Int32")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("callSiteValue", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AddWithoutNameOrType_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var missingName = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Type: "System.Int32", CallSiteValue: "0")]));
+        Assert.Equal(ToolErrorCode.InvalidArgument, missingName.Code);
+
+        var missingType = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Name: "token", CallSiteValue: "0")]));
+        Assert.Equal(ToolErrorCode.InvalidArgument, missingType.Code);
+    }
+
+    [Fact]
+    public async Task RemoveWithoutParameterName_ThrowsInvalidArgument()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add", [new SignatureOperation("remove")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public async Task RemovingEveryParameter_IsAllowed()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+        [
+            new SignatureOperation("remove", Parameter: "a"),
+            new SignatureOperation("remove", Parameter: "b"),
+        ]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(TwoParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("Add()", after, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------- degraded load
+
+    [Fact]
+    public async Task Degraded_Preview_MessageCarriesWarning()
+    {
+        var (loaded, resolver) = Degrade(RenameTestWorkspace.Create(("Svc.cs", TwoParamSource)));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Contains("degraded", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1 load diagnostic", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Degraded_Apply_RefusedWithoutForce()
+    {
+        var commitCalls = 0;
+        var (loaded, resolver) = Degrade(RenameTestWorkspace.Create(("Svc.cs", TwoParamSource)));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")], preview: false,
+            commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+        Assert.False(result.Success);
+        Assert.False(result.Applied);
+        Assert.Contains("degraded", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+        Assert.Contains("force=true", result.Message, StringComparison.Ordinal);
+        Assert.Equal(0, commitCalls);
+    }
+
+    // ---------------------------------------------------------------- write path
+
+    [Fact]
+    public async Task Preview_LeavesDiskUntouched()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-preview-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, TwoParamSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, TwoParamSource));
+
+            var commitCalls = 0;
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")],
+                commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+            Assert.False(result.Applied);
+            Assert.Equal(0, commitCalls);
+            Assert.Equal(TwoParamSource, await File.ReadAllTextAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Apply_WritesAndCommits()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-apply-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, TwoParamSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, TwoParamSource));
+
+            var commits = new List<IReadOnlyList<(DocumentId Id, SourceText Text)>>();
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")], preview: false,
+                commit: (docs, _) => { commits.Add(docs); return Task.CompletedTask; });
+
+            Assert.True(result.Success, result.Message);
+            Assert.True(result.Applied);
+            Assert.Equal(1, result.FilesChanged);
+
+            var onDisk = await File.ReadAllTextAsync(path);
+            Assert.Contains("Add(int a)", onDisk, StringComparison.Ordinal);
+            Assert.Contains("Add(1)", onDisk, StringComparison.Ordinal);
+
+            var docs = Assert.Single(commits);
+            var pair = Assert.Single(docs);
+            Assert.Equal(loaded.Solution.GetDocumentIdsWithFilePath(path).Single(), pair.Id);
+            Assert.Equal(onDisk, pair.Text.ToString());
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Apply_DiskChangedSinceSnapshot_RefusedAndFileNotOverwritten()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-stale-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, TwoParamSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, TwoParamSource));
+
+            var drifted = TwoParamSource + "\n// concurrent edit\n";
+            await File.WriteAllTextAsync(path, drifted);
+
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")], preview: false);
+
+            Assert.False(result.Success);
+            Assert.False(result.Applied);
+            Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+            Assert.Equal(drifted, await File.ReadAllTextAsync(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ---------------------------------------------------------------- Roslyn's own refusal
+
+    /// <summary>
+    /// Roslyn's <c>ChangeSignatureFailureKind</c> is narrow (None / DefinedInMetadata /
+    /// IncorrectKind) and both failure kinds are produced by the ANALYSIS step, which this design
+    /// bypasses by constructing a succeeded context from an already-resolved symbol. The
+    /// metadata-defined case is therefore refused one layer earlier, by the logic: a method with
+    /// no source declaration has no document to drive the change from. This test pins that
+    /// refusal so the metadata path can never reach the bridge silently.
+    /// </summary>
+    [Fact]
+    public async Task MetadataMethod_IsRefusedBeforeTheBridge()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "System.Object.GetHashCode",
+                [new SignatureOperation("add", Name: "seed", Type: "int", CallSiteValue: "0")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("source", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
@@ -890,6 +890,95 @@ public class ChangeSignatureLogicTests
         }
     }
 
+    // ---------------------------------------------------------------- force
+
+    /// <summary>
+    /// force=true is the conflict override: the caller has inspected the reported errors and
+    /// wants the change anyway.
+    /// </summary>
+    [Fact]
+    public async Task Conflicts_Apply_ForceWrites()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-force-conflict-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, BodyUsesParamSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BodyUsesParamSource));
+
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")], preview: false, force: true);
+
+            Assert.True(result.Success, result.Message);
+            Assert.True(result.Applied);
+            Assert.NotEmpty(result.Conflicts);   // reported, but not refused
+            Assert.Contains("Add(int a)", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Degraded_Apply_ForceWrites()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-force-degraded-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, TwoParamSource);
+            var (loaded, resolver) = Degrade(RenameTestWorkspace.Create((path, TwoParamSource)));
+
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")], preview: false, force: true);
+
+            Assert.True(result.Success, result.Message);
+            Assert.True(result.Applied);
+            Assert.Contains("Add(int a)", await File.ReadAllTextAsync(path), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// force overrides RISK judgements (conflicts, a degraded load) — never the freshness check.
+    /// That one guards against clobbering an edit the snapshot never saw, which no amount of
+    /// caller intent makes safe, because the text that would be written was computed from
+    /// something else entirely.
+    /// </summary>
+    [Fact]
+    public async Task Apply_DiskChangedSinceSnapshot_ForceStillRefusesAndWritesNothing()
+    {
+        var dir = Directory.CreateTempSubdirectory("sig-force-stale-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Svc.cs");
+            await File.WriteAllTextAsync(path, TwoParamSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, TwoParamSource));
+
+            var drifted = TwoParamSource + "\n// concurrent edit\n";
+            await File.WriteAllTextAsync(path, drifted);
+
+            var commitCalls = 0;
+            var result = await RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("remove", Parameter: "b")], preview: false, force: true,
+                commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+            Assert.False(result.Success);
+            Assert.False(result.Applied);
+            Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+            Assert.Equal(drifted, await File.ReadAllTextAsync(path));
+            Assert.Equal(0, commitCalls);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     // ---------------------------------------------------------------- Roslyn's own refusal
 
     /// <summary>

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
@@ -189,6 +189,81 @@ public class ChangeSignatureLogicTests
         Assert.Contains("Add(1, 0)", after, StringComparison.Ordinal);
     }
 
+    // ---------------------------------------------------------------- added-parameter types
+
+    private const string AmbiguousTypeSource = """
+        namespace Left { public class Thing { } }
+        namespace Right { public class Thing { } }
+        namespace SigDemo
+        {
+            public class Svc
+            {
+                public int Add(int a) => a;
+                public int Use() => Add(1);
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task Add_AmbiguousTypeName_ThrowsInvalidArgumentNamingTheCandidates()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", AmbiguousTypeSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "SigDemo.Svc.Add",
+                [new SignatureOperation("add", Name: "thing", Type: "Thing", CallSiteValue: "null")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("Left.Thing", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Right.Thing", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Add_QualifiedFormOfAnOtherwiseAmbiguousType_Resolves()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", AmbiguousTypeSource));
+
+        var result = await RunAsync(loaded, resolver, "SigDemo.Svc.Add",
+            [new SignatureOperation("add", Name: "thing", Type: "Left.Thing", CallSiteValue: "null")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.DoesNotContain("could not be resolved", result.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An unresolvable type CANNOT be written as a literal, contrary to what the original code
+    /// assumed: CSharpChangeSignatureService.CreateNewParameterSyntax calls
+    /// <c>addedParameter.Type.GenerateTypeSyntax()</c> unconditionally, so a null Type
+    /// NullReferenceExceptions deep inside Roslyn (surfacing as an opaque Internal error) rather
+    /// than degrading. It is therefore refused up front, with the reason stated.
+    /// </summary>
+    [Fact]
+    public async Task Add_UnresolvableType_ThrowsInvalidArgumentRatherThanCrashingRoslyn()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", OneParamSource));
+
+        var ex = await Assert.ThrowsAsync<McpToolException>(
+            () => RunAsync(loaded, resolver, "Svc.Add",
+                [new SignatureOperation("add", Name: "thing", Type: "Nowhere.NotYetWritten", CallSiteValue: "null")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("Nowhere.NotYetWritten", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("could not be resolved", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Add_KeywordAliasType_Resolves()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", OneParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("add", Name: "count", Type: "int", CallSiteValue: "0")]);
+
+        Assert.True(result.Success, result.Message);
+        var after = ApplyEdits(OneParamSource, result.Edits, "Svc.cs");
+        Assert.Contains("int count", after, StringComparison.Ordinal);
+    }
+
     // ---------------------------------------------------------------- cascade
 
     [Fact]

--- a/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/ChangeSignatureLogicTests.cs
@@ -316,6 +316,82 @@ public class ChangeSignatureLogicTests
         Assert.DoesNotContain("int times", after, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Roslyn cascades across the WHOLE hierarchy, not downward from the target. Targeting a
+    /// derived override must therefore report the base it overrides and the sibling overrides
+    /// that Roslyn also rewrites — walking only downward reported none of them.
+    /// </summary>
+    [Fact]
+    public async Task DerivedOverrideTarget_CascadesUpToTheBaseAndAcrossToSiblings()
+    {
+        const string source = """
+            namespace SigDemo;
+            public class Base
+            {
+                public virtual string Greet(string name, int times) => name;
+            }
+            public class Derived : Base
+            {
+                public override string Greet(string name, int times) => name;
+            }
+            public class Sibling : Base
+            {
+                public override string Greet(string name, int times) => name;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Greet.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "Derived.Greet",
+            [new SignatureOperation("remove", Parameter: "times")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Contains(result.CascadedTo, s => s.Contains("Base.Greet", StringComparison.Ordinal));
+        Assert.Contains(result.CascadedTo, s => s.Contains("Sibling.Greet", StringComparison.Ordinal));
+        // The target itself is not part of its own blast radius.
+        Assert.DoesNotContain(result.CascadedTo, s => s.Contains("Derived.Greet", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ImplementationTarget_CascadesUpToTheInterfaceAndAcrossToOtherImplementers()
+    {
+        const string source = """
+            namespace SigDemo;
+            public interface IGreet
+            {
+                string Greet(string name, int times);
+            }
+            public class First : IGreet
+            {
+                public string Greet(string name, int times) => name;
+            }
+            public class Second : IGreet
+            {
+                public string Greet(string name, int times) => name;
+            }
+            """;
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Greet.cs", source));
+
+        var result = await RunAsync(loaded, resolver, "First.Greet",
+            [new SignatureOperation("remove", Parameter: "times")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Contains(result.CascadedTo, s => s.Contains("IGreet.Greet", StringComparison.Ordinal));
+        Assert.Contains(result.CascadedTo, s => s.Contains("Second.Greet", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.CascadedTo, s => s.Contains("First.Greet", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task NoHierarchy_CascadesToNothing()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.Create(("Svc.cs", TwoParamSource));
+
+        var result = await RunAsync(loaded, resolver, "Svc.Add",
+            [new SignatureOperation("remove", Parameter: "b")]);
+
+        Assert.True(result.Success, result.Message);
+        Assert.Empty(result.CascadedTo);
+    }
+
     [Fact]
     public async Task ExtensionMethod_ThisParameterPreserved()
     {

--- a/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RenameTestWorkspace.cs
@@ -30,6 +30,22 @@ internal static class RenameTestWorkspace
             .ToArray());
 
     /// <summary>
+    /// Projects in a STRICT chain: each references only its immediate predecessor, so the last
+    /// project depends on the first transitively but not directly. The multi-project overload
+    /// above cannot express this — it references every earlier project — which makes it unable to
+    /// distinguish direct from transitive dependents.
+    /// </summary>
+    public static (LoadedSolution Loaded, SymbolResolver Resolver) CreateChain(
+        params (string ProjectName, (string FilePath, string Source)[] Files)[] projects)
+        => CreateCore(
+            projects
+                .Select(p => (p.ProjectName, p.Files
+                    .Select(f => (f.FilePath, SourceText.From(f.Source)))
+                    .ToArray()))
+                .ToArray(),
+            chainOnly: true);
+
+    /// <summary>
     /// Single project whose documents are read from existing files on disk, so each
     /// document's SourceText carries the detected encoding (incl. BOM presence).
     /// </summary>
@@ -45,6 +61,10 @@ internal static class RenameTestWorkspace
 
     private static (LoadedSolution Loaded, SymbolResolver Resolver) CreateCore(
         params (string ProjectName, (string FilePath, SourceText Text)[] Files)[] projects)
+        => CreateCore(projects, chainOnly: false);
+
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) CreateCore(
+        (string ProjectName, (string FilePath, SourceText Text)[] Files)[] projects, bool chainOnly)
     {
         var workspace = new AdhocWorkspace();
         var solution = workspace.CurrentSolution;
@@ -58,7 +78,9 @@ internal static class RenameTestWorkspace
                     compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
                 .WithMetadataReferences(
                     [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)])
-                .WithProjectReferences(projectIds.Select(id => new ProjectReference(id)));
+                .WithProjectReferences(
+                    (chainOnly ? projectIds.TakeLast(1) : projectIds)
+                        .Select(id => new ProjectReference(id)));
 
             solution = solution.AddProject(projectInfo);
             foreach (var (path, text) in files)

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -378,6 +378,41 @@ public class RenameSymbolLogicTests
         Assert.Equal(scanSet.Count, scanSet.Distinct().Count());
     }
 
+    /// <summary>
+    /// A break propagates as far as the reference graph does, so the scan set must too: with
+    /// LibA &lt;- LibB &lt;- LibC, LibC sees LibA's types through LibB and can break without LibB's
+    /// text changing. Scanning only DIRECT dependents left LibC unexamined and the conflict
+    /// unreported.
+    /// </summary>
+    [Fact]
+    public async Task ComputeScanSet_IncludesTransitiveDependents()
+    {
+        var (loaded, resolver) = RenameTestWorkspace.CreateChain(
+            ("LibA", [("Widget.cs", "namespace Lib; public class Widget { }")]),
+            ("LibB", [("Mid.cs", "namespace Mid; public class Mid { }")]),
+            ("LibC", [("Far.cs", "namespace Far; public class Far { }")]));
+
+        var target = RenameSymbolLogic.ResolveSingleTarget(resolver, "Widget");
+        var renamed = await Microsoft.CodeAnalysis.Rename.Renamer.RenameSymbolAsync(
+            loaded.Solution, target,
+            new Microsoft.CodeAnalysis.Rename.SymbolRenameOptions(), "Sprocket",
+            CancellationToken.None);
+
+        var byName = loaded.Solution.Projects.ToDictionary(p => p.Name, p => p.Id, StringComparer.Ordinal);
+
+        // Precondition: LibC really is transitive-only, otherwise this proves nothing.
+        var direct = loaded.Solution.GetProjectDependencyGraph()
+            .GetProjectsThatDirectlyDependOnThisProject(byName["LibA"]);
+        Assert.DoesNotContain(byName["LibC"], direct);
+
+        var scanSet = SolutionChangeSafety.ComputeScanSet(loaded.Solution, renamed);
+
+        Assert.Contains(byName["LibA"], scanSet);
+        Assert.Contains(byName["LibB"], scanSet);
+        Assert.Contains(byName["LibC"], scanSet);
+        Assert.Equal(scanSet.Count, scanSet.Distinct().Count());
+    }
+
     [Fact]
     public async Task DependentProjectWithPreexistingError_IsNotAConflict()
     {

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -369,7 +369,7 @@ public class RenameSymbolLogicTests
             new Microsoft.CodeAnalysis.Rename.SymbolRenameOptions(), "Sprocket",
             CancellationToken.None);
 
-        var scanSet = RenameSymbolLogic.ComputeScanSet(loaded.Solution, renamed);
+        var scanSet = SolutionChangeSafety.ComputeScanSet(loaded.Solution, renamed);
         var libA = loaded.Solution.Projects.Single(p => string.Equals(p.Name, "LibA", StringComparison.Ordinal)).Id;
         var libB = loaded.Solution.Projects.Single(p => string.Equals(p.Name, "LibB", StringComparison.Ordinal)).Id;
 
@@ -418,10 +418,10 @@ public class RenameSymbolLogicTests
         // level with a synthetic suppressed diagnostic (Diagnostic.Create supports
         // isSuppressed directly).
         var suppressed = MakeError("CS9999", "File.cs", 3, suppressed: true);
-        Assert.Empty(RenameSymbolLogic.DiffNewErrors(before: [], after: [suppressed]));
+        Assert.Empty(SolutionChangeSafety.DiffNewErrors(before: [], after: [suppressed]));
 
         var unsuppressed = MakeError("CS9999", "File.cs", 3);
-        var conflict = Assert.Single(RenameSymbolLogic.DiffNewErrors(before: [], after: [unsuppressed]));
+        var conflict = Assert.Single(SolutionChangeSafety.DiffNewErrors(before: [], after: [unsuppressed]));
         Assert.Equal("CS9999", conflict.Id);
         Assert.Equal(3, conflict.Line);
     }
@@ -432,7 +432,7 @@ public class RenameSymbolLogicTests
         var before = new[] { MakeError("CS0101", "Types.cs", 3) };
         var after = new[] { MakeError("CS0101", "Types.cs", 3), MakeError("CS0101", "Types.cs", 7) };
 
-        var conflict = Assert.Single(RenameSymbolLogic.DiffNewErrors(before, after));
+        var conflict = Assert.Single(SolutionChangeSafety.DiffNewErrors(before, after));
         Assert.Equal(7, conflict.Line);
     }
 

--- a/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/RenameSymbolLogicTests.cs
@@ -518,6 +518,41 @@ public class RenameSymbolLogicTests
         }
     }
 
+    /// <summary>
+    /// The invariant rename shares with change_signature: force overrides RISK judgements
+    /// (conflicts, a degraded load), never the freshness check. The text that would be written was
+    /// computed from a snapshot that no longer describes the file, so caller intent cannot make
+    /// writing it safe.
+    /// </summary>
+    [Fact]
+    public async Task Apply_DiskChangedSinceSnapshot_ForceStillRefusesAndWritesNothing()
+    {
+        var dir = Directory.CreateTempSubdirectory("rename-force-stale-").FullName;
+        try
+        {
+            var path = Path.Combine(dir, "Widget.cs");
+            await File.WriteAllTextAsync(path, BasicSource);
+            var (loaded, resolver) = RenameTestWorkspace.Create((path, BasicSource));
+
+            var drifted = BasicSource + "\n// concurrent edit\n";
+            await File.WriteAllTextAsync(path, drifted);
+
+            var commitCalls = 0;
+            var result = await RunAsync(loaded, resolver, "Widget", "Sprocket", preview: false, force: true,
+                commit: (_, _) => { commitCalls++; return Task.CompletedTask; });
+
+            Assert.False(result.Success);
+            Assert.False(result.Applied);
+            Assert.Contains("rebuild_solution", result.Message, StringComparison.Ordinal);
+            Assert.Equal(drifted, await File.ReadAllTextAsync(path));
+            Assert.Equal(0, commitCalls);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task Apply_InvokesCommitHookWithExactlyTheChangedDocuments()
     {

--- a/tools/DocGen/Program.cs
+++ b/tools/DocGen/Program.cs
@@ -38,6 +38,7 @@ var categoryMap = new Dictionary<string, string>(StringComparer.Ordinal)
     ["get_code_actions"]           = "diagnostics",
     ["apply_code_action"]          = "diagnostics",
     ["rename_symbol"]              = "diagnostics",
+    ["change_signature"]           = "diagnostics",
     ["find_unused_symbols"]        = "code-quality",
     ["get_complexity_metrics"]     = "code-quality",
     ["find_naming_violations"]     = "code-quality",


### PR DESCRIPTION
## Summary
The 64th tool, and the last refactoring gap from the SharpLens comparison. Adds, removes, and reorders a method's parameters and rewrites every call site.

- **`operations` apply in order**: `remove` by name, `reorder` with a full permutation of survivors, `add` with a **required `callSiteValue`** — the tool never guesses what a call site should pass. Give an added parameter a `defaultValue` instead and existing calls are left untouched.
- **Driven by Roslyn's own change-signature engine** through one isolated reflection bridge, so named/optional arguments, `params` arrays, the extension-method `this`, XML `<param>` docs, and the override/interface cascade are all handled by battle-tested code rather than hand-rolled rewriting.
- **`cascadedTo`** lists the overrides and interface implementations rewritten alongside the target, so the blast radius is visible in preview before applying.
- Same gates as `rename_symbol`: preview by default, conflict / degraded-load / freshness refusals, `force` overriding the first two but never freshness, immediate snapshot commit on apply.

### Why reflection
Roslyn exports **zero public `ChangeSignature` types** (unlike `Renamer`). A probe also caught the trap in this design: the public-looking `ChangeSignature(...)` returns a `SyntaxNode` — it rewrites the declaration only and would have left every call site broken. The real entry point is `ChangeSignatureWithContextAsync`. All reflection is confined to `ChangeSignatureBridge`, which probes every member it needs and fails loudly with `Internal` **before writing anything** if a Roslyn upgrade moves them.

### Also improves existing tools
The conflict scan now covers **transitive** dependents rather than direct only — a gap `rename_symbol` inherited from #300 — and the orchestration deciding whether bytes hit disk is extracted into `SolutionChangeSafety`, shared by both write tools so their gates can't drift.

## Test Plan
- [x] Full suite **930/930** (~60 new tests)
- [x] Pre-merge high-effort review; **all 10 findings fixed in-branch** — five were silent-corruption class: extension-method receiver silently rebound by a reorder, duplicate-named `add` silently dropped, `params` array demoted mid-list (CS0231), `cascadedTo` under-reporting the hierarchy, and unvalidated added-parameter identifiers
- [x] Fixture-pristine check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)