### PR TITLE
feat: check_architecture — enforce layering rules over the semantic type graph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ The `.mcp.json` configures the roslyn-codelens MCP server to analyze this soluti
 
 ## Skill
 
-The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 64 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
+The `plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md` skill teaches Claude when and how to use the 65 code intelligence tools. Use the MCP tools instead of Grep/Glob for any .NET semantic queries (finding implementations, callers, references, diagnostics, etc.).
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/marcel
 - **find_attribute_usages** — Find types and members decorated with a specific attribute
 - **find_obsolete_usage** — Every `[Obsolete]` call site grouped by deprecation message and severity, errors first; for planning migrations
 - **find_circular_dependencies** — Detect cycles in project or namespace dependency graphs
+- **check_architecture** — Enforce layering rules you supply (`forbid` and `allowOnly`) against the real semantic type graph rather than `using` directives; violations are grouped per boundary with a reference count and example sites
 - **get_complexity_metrics** — Cyclomatic complexity analysis per method
 - **find_naming_violations** — Check .NET naming convention compliance
 - **find_async_violations** — Sync-over-async, `async void` misuse, missing awaits, fire-and-forget tasks; per-violation report with severity

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -99,6 +99,9 @@ Items previously in this backlog, now merged. Listed for orientation; do not re-
 
 Items considered during design of shipped features and consciously punted on. Re-promote to the main backlog above if a use case emerges.
 
+### From `check_architecture` (shipped 2026-07-20, PR #314)
+- **Extract the shared solution-wide semantic scan walker** — `find_throw_sites`, `find_catch_blocks` and `check_architecture` now each hand-roll the same shape: enumerate compilations, skip generated trees, dedupe repeated trees by path, build a semantic model, walk nodes. They already differ in the details (only `check_architecture` dedupes scope-aware, falls back to a content hash for pathless trees, and checks cancellation inside the node loop), which is precisely the cost: every fix to the shape has to be made three times and in practice lands in one. A shared walker taking a per-tool node visitor would make each fix land once. Deferred from PR #314 as too large to land alongside the review fixes.
+
 ### From `get_method_source` (shipped 2026-07-19, PR #305)
 - **`KindOf` consolidation** — roughly five tools carry their own local symbol-kind mapper (`method`/`property`/`field`/...); extract one shared helper so kind strings can't drift between tools.
 - **Constructor resolution in `SymbolResolver`** — the `Type.Type` / `.ctor` request handling lives in `GetMethodSourceLogic`; move it into `SymbolResolver` so every tool resolves constructors the same way.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -46,11 +46,11 @@ Comparison against [sharplens-mcp](https://github.com/pzalutski-pixel/sharplens-
 
 ### Medium value
 
-- ✅ **`change_signature`** — *shipped* (PR #312). Add/remove/reorder parameters with all call sites updated, via a reflection bridge over Roslyn's internal change-signature engine (no public API exists, unlike `Renamer`). Design: [docs/plans/2026-07-20-change-signature-design.md](plans/2026-07-20-change-signature-design.md).
+- ✅ **`change_signature`** — *shipped* (PR #313). Add/remove/reorder parameters with all call sites updated, via a reflection bridge over Roslyn's internal change-signature engine (no public API exists, unlike `Renamer`). Design: [docs/plans/2026-07-20-change-signature-design.md](plans/2026-07-20-change-signature-design.md).
 - **`get_extension_methods`** — which extension methods (including C# 14 extension blocks) apply to a given type. Not answerable with current tools.
 - **`get_instantiation_options`** — "how do I construct this type": accessible constructors, factory methods, DI registration. Pairs well with `generate_test_skeleton`.
 - **Cognitive complexity + nesting depth in `get_complexity_metrics`** — we only report cyclomatic; cognitive complexity is a better refactoring-priority signal. Enhancement to the existing tool.
-- **`check_architecture`** — enforce user-defined namespace/project dependency rules over the type graph (e.g. "Domain must not reference Infrastructure"). `find_circular_dependencies` only catches cycles; layering violations go undetected.
+- ✅ **`check_architecture`** — *shipped* (PR #314). Enforces user-supplied `forbid`/`allowOnly` rules over the semantic type graph (not `using` directives), grouped per violated boundary. Design: [docs/plans/2026-07-20-check-architecture-design.md](plans/2026-07-20-check-architecture-design.md).
 - **`find_similar_code`** — folded into the existing `find_duplicated_code` entry in §2 above.
 
 ---
@@ -69,7 +69,8 @@ Items previously in this backlog, now merged. Listed for orientation; do not re-
 
 | Tool | Theme | PR |
 |---|---|---|
-| `change_signature` | Refactoring | #312 |
+| `check_architecture` | Code quality | #314 |
+| `change_signature` | Refactoring | #313 |
 | `get_exception_flow` | Analysis | #309 |
 | `find_throw_sites` | Analysis | #309 |
 | `find_catch_blocks` | Analysis | #309 |

--- a/docs/plans/2026-07-20-check-architecture-design.md
+++ b/docs/plans/2026-07-20-check-architecture-design.md
@@ -1,0 +1,64 @@
+# `check_architecture` — Design
+
+Date: 2026-07-20
+Status: Approved
+Origin: SharpLensMcp gap analysis (docs/BACKLOG.md §5, medium tier). Enforce user-defined namespace/project dependency rules over the semantic type graph. `find_circular_dependencies` catches cycles; layering violations ("Domain must not reference Infrastructure") go undetected today. Tool count 64 → 65.
+
+## Decisions (brainstorming outcomes)
+
+| Question | Decision |
+|---|---|
+| Rule source | **Inline `rules` parameter.** Agent-native, no new file format to own (discovery, versioning, parse errors). A repo that wants durable policy stores rules in its own file and the agent passes them. |
+| Edge derivation | **Semantic type references**, not `using` directives. `find_circular_dependencies` uses usings, which both over-report (an unused using) and under-report (a fully-qualified reference) — both failures silent. A tool whose output drives architectural decisions cannot make false accusations. |
+| Rule kinds | **`forbid` + `allowOnly`.** `forbid` catches the violation you already know about; `allowOnly` catches the dependencies you haven't thought of, which is what actually prevents drift. |
+| Output | **Grouped per violated (rule, sourceScope → targetScope) edge**, with a reference count and the first `maxSitesPerViolation` sites. One stray cross-boundary reference is one actionable item, not hundreds of lines. |
+
+## Tool contract
+
+```
+check_architecture(
+  rules: [
+    { kind: "forbid",    from: "Demo.Domain.*", to: "Demo.Infrastructure.*", description?: "layering" },
+    { kind: "allowOnly", from: "Demo.Api.*",    to: ["Demo.Application.*", "Demo.Domain.*"] }
+  ],
+  scope: "namespace" | "project" = "namespace",
+  maxSitesPerViolation: int = 5,
+  limit?: int)
+```
+
+`forbid.to` is a single pattern; `allowOnly.to` is the permitted set. Patterns are exact (`Demo.Domain`) or prefix-wildcard (`Demo.Domain.*` — matches that scope and everything beneath it). `*` alone matches everything.
+
+## Semantics — the two rules that decide whether this tool is usable
+
+1. **`allowOnly` considers only solution-internal targets.** Otherwise `using System;` violates "Api may depend only on Application", which is absurd and would bury every real finding. To restrict a framework namespace, write an explicit `forbid` — that path *does* evaluate metadata targets.
+2. **Self-references are always allowed.** A scope depending on itself is not a layering violation, under either rule kind.
+
+A `forbid` fires when the source scope matches `from` **and** the target matches `to`. An `allowOnly` fires when the source matches `from`, the target is solution-internal, is not the source scope itself, and matches none of the `to` patterns.
+
+## Edge derivation
+
+For each source document (generated code skipped, matching the sibling scan tools): determine its scope — the enclosing namespace declaration, or the project name when `scope: "project"`. **Source-side filtering happens first**: if that scope matches no rule's `from`, the document is skipped before any symbol resolution, so cost tracks the rules written rather than solution size.
+
+For surviving documents, walk the syntax nodes that can bind to a type, resolve each through the semantic model, and derive the target scope from the resolved symbol's containing namespace (or its project/assembly for `scope: "project"`). Each `(rule, sourceScope, targetScope)` triple accumulates a count and its first sites.
+
+## Result
+
+Standard list envelope. `ArchitectureViolation { RuleKind, RuleDescription?, FromPattern, ToPattern, SourceScope, TargetScope, ReferenceCount, Sites[] }` where `Sites[] = { File, Line, Column, SourceSymbol, TargetSymbol }`. Summary: `{ byRule: { pattern: count }, totalReferences, rulesEvaluated }`.
+
+Sorted by rule order, then by descending reference count — the worst breach of the first rule you wrote appears first.
+
+## Errors
+
+Empty `rules` → `InvalidArgument`. Unknown `kind`, `allowOnly` without a non-empty `to`, `forbid` without `to`, or a malformed pattern (e.g. an interior `*`) → `InvalidArgument` naming the offending rule index. Unknown `scope` → `InvalidArgument`. `EnsureLoaded()` as usual.
+
+## Known limits
+
+Static analysis: reflection- and `dynamic`-mediated dependencies are invisible, as are dependencies expressed only in configuration or DI registration by string. A type referenced only inside a lambda or local function still counts — it is a real dependency of the containing document. `scope: "project"` compares project names, so two projects sharing a name in different solution folders are indistinguishable.
+
+## Testing
+
+Matrix on `RenameTestWorkspace` (multi-project, since project scope and cross-project edges matter): `forbid` violated and satisfied; `allowOnly` catching an unlisted dependency; `allowOnly` ignoring a BCL target while `forbid` catches the same one; self-reference allowed under both kinds; exact vs prefix-wildcard vs `*` patterns; grouping (many references → one item with the right count) and `maxSitesPerViolation` truncation; `scope: "project"`; generated code skipped; every error case; and a fully-qualified reference with no `using` — the case the existing usings-based approach would miss, which is the reason this tool is semantic. Fixture integration on TestSolution.
+
+## Docs
+
+SKILL.md: Red Flags row ("is anything violating our layering?" / "does Domain reference Infrastructure?"), tool bullet near `find_circular_dependencies`, Quick Reference row, metadata-support row (source scan; `forbid` may target metadata namespaces). CLAUDE.md 64 → **65**. DocGen categoryMap → `code-quality` (with `find_circular_dependencies`). README bullet. BACKLOG: shipped + Recently-shipped row.

--- a/docs/plans/2026-07-20-check-architecture-design.md
+++ b/docs/plans/2026-07-20-check-architecture-design.md
@@ -30,10 +30,12 @@ check_architecture(
 
 ## Semantics — the two rules that decide whether this tool is usable
 
-1. **`allowOnly` considers only solution-internal targets.** Otherwise `using System;` violates "Api may depend only on Application", which is absurd and would bury every real finding. To restrict a framework namespace, write an explicit `forbid` — that path *does* evaluate metadata targets.
+1. **`allowOnly` considers only targets the caller can act on: solution-internal and not pure generator output.** Otherwise `using System;` violates "Api may depend only on Application", which is absurd and would bury every real finding; likewise generator output (regex implementations, JSON contexts, DI registries) would be reported as an unlisted dependency nobody can remove. Its target set is open-ended, so it needs the noise suppression. To restrict a framework *or* generated namespace, write an explicit `forbid` — that path names its target and *does* evaluate metadata and generated ones.
 2. **Self-references are always allowed.** A scope depending on itself is not a layering violation, under either rule kind.
 
-A `forbid` fires when the source scope matches `from` **and** the target matches `to`. An `allowOnly` fires when the source matches `from`, the target is solution-internal, is not the source scope itself, and matches none of the `to` patterns.
+A `forbid` fires when the source scope matches `from` **and** the target matches `to`. An `allowOnly` fires when the source matches `from`, the target is solution-internal and not generated-only, is not the source scope itself, and matches none of the `to` patterns.
+
+**"Solution-internal" is a property of the solution, not of how it loaded.** A target counts as internal when its containing assembly name matches one of the solution's own project or assembly names, falling back to a source-location check. Asking the symbol whether it has a source location answers the wrong question: when a ProjectReference resolves as a metadata reference instead — a real MSBuildWorkspace failure mode — every `allowOnly` rule over that boundary would silently return empty, indistinguishable from clean architecture.
 
 ## Edge derivation
 
@@ -41,21 +43,28 @@ For each source document (generated code skipped, matching the sibling scan tool
 
 For surviving documents, walk the syntax nodes that can bind to a type, resolve each through the semantic model, and derive the target scope from the resolved symbol's containing namespace (or its project/assembly for `scope: "project"`). Each `(rule, sourceScope, targetScope)` triple accumulates a count and its first sites.
 
+Two node kinds are deliberately **not** counted, because counting them reports dependencies nobody wrote:
+
+* **`using` directives.** A using is not a dependency, it is a name-resolution convenience — the code beneath it is the dependency. Counting it also attributes a file-level using to the *global* namespace and double-counts an in-namespace using or alias. Skipping them is what makes the promise "an unused `using` is not reported" true.
+* **`var`.** It is a `SimpleNameSyntax` whose `GetSymbolInfo` returns the *inferred* type. The intended count is references a human reading the code would point at, so `var o = new Demo.Domain.Order(); return o.Id;` is **two** dependencies on `Order` — exactly what the explicitly-typed form yields.
+
 ## Result
 
-Standard list envelope. `ArchitectureViolation { RuleKind, RuleDescription?, FromPattern, ToPattern, SourceScope, TargetScope, ReferenceCount, Sites[] }` where `Sites[] = { File, Line, Column, SourceSymbol, TargetSymbol }`. Summary: `{ byRule: { pattern: count }, totalReferences, rulesEvaluated }`.
+Standard list envelope. `ArchitectureViolation { RuleIndex, RuleKind, RuleDescription?, FromPattern, ToPattern, SourceScope, TargetScope, ReferenceCount, Sites[] }` where `Sites[] = { File, Line, Column, SourceSymbol, TargetSymbol }`. `RuleIndex` is the position in the caller's own `rules` array, so a violation is always traceable back to the rule as written. Summary: `{ byRule: { rule: count }, totalReferences, rulesEvaluated }`, where `byRule` is keyed by the **rule as written** (index + kind + from + full to-set) — one written rule is always one bucket, even when it has several `to` patterns and several of them are violated.
 
 Sorted by rule order, then by descending reference count — the worst breach of the first rule you wrote appears first.
 
 ## Errors
 
-Empty `rules` → `InvalidArgument`. Unknown `kind`, `allowOnly` without a non-empty `to`, `forbid` without `to`, or a malformed pattern (e.g. an interior `*`) → `InvalidArgument` naming the offending rule index. Unknown `scope` → `InvalidArgument`. `EnsureLoaded()` as usual.
+Empty `rules` → `InvalidArgument`. Unknown `kind`, `allowOnly` without a non-empty `to`, `forbid` without `to`, or a malformed pattern (e.g. an interior `*`) → `InvalidArgument` naming the offending rule index. Unknown `scope` → `InvalidArgument`. A `maxSitesPerViolation` below 1 → `InvalidArgument`: a violation with no sites is an accusation with no location. `EnsureLoaded()` as usual.
 
 ## Known limits
 
 Static analysis: reflection- and `dynamic`-mediated dependencies are invisible, as are dependencies expressed only in configuration or DI registration by string. A type referenced only inside a lambda or local function still counts — it is a real dependency of the containing document. `scope: "project"` compares project names, so two projects sharing a name in different solution folders are indistinguishable.
 
 ## Testing
+
+Every negative test carries a positive control on the same fixture — a rule that DOES fire — so a walk that silently found nothing cannot pass as clean architecture. Verified by mutation: stubbing `Execute` to return an empty list fails every test that asserts on its output.
 
 Matrix on `RenameTestWorkspace` (multi-project, since project scope and cross-project edges matter): `forbid` violated and satisfied; `allowOnly` catching an unlisted dependency; `allowOnly` ignoring a BCL target while `forbid` catches the same one; self-reference allowed under both kinds; exact vs prefix-wildcard vs `*` patterns; grouping (many references → one item with the right count) and `maxSitesPerViolation` truncation; `scope: "project"`; generated code skipped; every error case; and a fully-qualified reference with no `using` — the case the existing usings-based approach would miss, which is the reason this tool is semantic. Fixture integration on TestSolution.
 

--- a/docs/plans/2026-07-20-check-architecture-design.md
+++ b/docs/plans/2026-07-20-check-architecture-design.md
@@ -62,6 +62,8 @@ Empty `rules` → `InvalidArgument`. Unknown `kind`, `allowOnly` without a non-e
 
 Static analysis: reflection- and `dynamic`-mediated dependencies are invisible, as are dependencies expressed only in configuration or DI registration by string. A type referenced only inside a lambda or local function still counts — it is a real dependency of the containing document. `scope: "project"` compares project names, so two projects sharing a name in different solution folders are indistinguishable.
 
+Under `scope: "project"` the *target* scope falls back to the containing assembly name when the owning project can't be identified — the same load-dependence that the internal/external check above deliberately avoids. In practice an assembly name matches its project name, so a rule keeps matching; but a project deliberately renamed away from its assembly could be missed by a `forbid` written against the project name if its reference resolves as metadata. Namespace scope, the default, is unaffected.
+
 ## Testing
 
 Every negative test carries a positive control on the same fixture — a rule that DOES fire — so a walk that silently found nothing cannot pass as clean architecture. Verified by mutation: stubbing `Execute` to return an empty list fails every test that asserts on its output.

--- a/docs/plans/2026-07-20-check-architecture-design.md
+++ b/docs/plans/2026-07-20-check-architecture-design.md
@@ -43,10 +43,13 @@ For each source document (generated code skipped, matching the sibling scan tool
 
 For surviving documents, walk the syntax nodes that can bind to a type, resolve each through the semantic model, and derive the target scope from the resolved symbol's containing namespace (or its project/assembly for `scope: "project"`). Each `(rule, sourceScope, targetScope)` triple accumulates a count and its first sites.
 
-Two node kinds are deliberately **not** counted, because counting them reports dependencies nobody wrote:
+**The counting standard is: references a human reading the code would point at.** Three node kinds are deliberately **not** counted, because counting them reports dependencies nobody wrote:
 
 * **`using` directives.** A using is not a dependency, it is a name-resolution convenience — the code beneath it is the dependency. Counting it also attributes a file-level using to the *global* namespace and double-counts an in-namespace using or alias. Skipping them is what makes the promise "an unused `using` is not reported" true.
-* **`var`.** It is a `SimpleNameSyntax` whose `GetSymbolInfo` returns the *inferred* type. The intended count is references a human reading the code would point at, so `var o = new Demo.Domain.Order(); return o.Id;` is **two** dependencies on `Order` — exactly what the explicitly-typed form yields.
+* **`var`.** It is a `SimpleNameSyntax` whose `GetSymbolInfo` returns the *inferred* type, so `var o = new Demo.Domain.Order(); return o.Id;` is **two** dependencies on `Order` — exactly what the explicitly-typed form yields.
+* **Initializer member names.** A member resolves to its `ContainingType`, so `new Demo.Domain.Order { Id = 1, Name = "x" }` would count `Order` three times — once for the type the reader actually wrote, once per assigned member. When the assigned member's containing type *is* the type the initializer initializes, the member is dropped; the count is **one**. This covers `new T { … }`, `new() { … }`, `x with { … }` and the nested `P = { … }` form. Assignment through a local (`other.Id = 1`) is *not* an initializer and still counts — it is a separately written reference. Consequence, accepted for the same reason as `var`: in `new Box { Inner = { Id = 1 } }` the type of `Inner` is never written, so it is not counted.
+
+**Deduping the walk is scope-aware.** A linked or multi-targeted file appears in several compilations and must be walked once — but "once" means something different per scope. Under `namespace` scope its source scope is identical in every compilation, so the key is the file path: walking it twice would double-count one written reference. Under `project` scope its source scope *differs* per compilation, so the key is `(project name, path)`: a path-only key would credit the file to whichever project was enumerated first and silently drop every violation the other project's copy produces. Multi-targeting still collapses, since its several compilations share one project name. A tree with no file path falls back to a hash of its own text, so it dedupes too rather than being counted once per compilation.
 
 ## Result
 

--- a/docs/plans/2026-07-20-check-architecture-implementation.md
+++ b/docs/plans/2026-07-20-check-architecture-implementation.md
@@ -1,0 +1,194 @@
+# check_architecture — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A `check_architecture` tool that evaluates user-supplied layering rules against the solution's real semantic dependencies and reports grouped violations with sample sites.
+
+**Architecture:** `Analysis/ScopePattern.cs` is a pure matcher (exact / prefix-wildcard / `*`). `CheckArchitectureLogic` walks source documents — skipping any whose scopes match no rule's `from`, which is what keeps cost proportional to the rules rather than the solution — resolves each referencing node through the semantic model, and accumulates `(rule, sourceScope → targetScope)` groups. `CheckArchitectureTool` validates rules and wraps the envelope. Design doc: `docs/plans/2026-07-20-check-architecture-design.md` — **read it first**, especially the two semantics that decide whether the tool is usable.
+
+**Tech Stack:** Roslyn (existing deps), xUnit, `RenameTestWorkspace` (has multi-project `Create` and strict-chain `CreateChain` overloads).
+
+**Working directory:** `.worktrees/check-architecture`, branch `feature/check-architecture`.
+
+**Conventions:** `McpToolException(ToolErrorCode.X, msg, details)`; `ToolListResult.Create(items, limit, summary)`; string kinds; generated code skipped via `GeneratedCodeDetector.IsGenerated(tree)` as the first statement of the tree loop (see `FindThrowSitesLogic.cs:50`); tool `[Description]` must pass `ToolDescriptionMdxSafetyTests` (backtick every code token, no bare `<`/`{`); commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Models
+
+**Files:** Create `src/RoslynCodeLens/Models/ArchitectureRule.cs`, `ArchitectureViolation.cs`.
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+/// <summary>
+/// One layering rule. Kind: forbid | allowOnly.
+/// forbid    → a dependency from `From` to any scope matching `To` is a violation.
+/// allowOnly → a dependency from `From` to any solution-internal scope NOT in `To` is a violation.
+/// Patterns are exact ("Demo.Domain"), prefix-wildcard ("Demo.Domain.*"), or "*".
+/// </summary>
+public record ArchitectureRule(
+    string Kind,
+    string From,
+    IReadOnlyList<string> To,
+    string? Description = null);
+```
+
+```csharp
+namespace RoslynCodeLens.Models;
+
+public record ViolationSite(string File, int Line, int Column, string SourceSymbol, string TargetSymbol);
+
+/// <summary>
+/// One violated (rule, sourceScope → targetScope) edge. ReferenceCount is the full count;
+/// Sites carries only the first maxSitesPerViolation of them.
+/// </summary>
+public record ArchitectureViolation(
+    string RuleKind,
+    string? RuleDescription,
+    string FromPattern,
+    string ToPattern,
+    string SourceScope,
+    string TargetScope,
+    int ReferenceCount,
+    IReadOnlyList<ViolationSite> Sites);
+```
+
+Build → commit `feat: check_architecture models`.
+
+---
+
+### Task 2: ScopePattern (TDD — pure matcher)
+
+**Files:** Create `tests/RoslynCodeLens.Tests/ScopePatternTests.cs`, `src/RoslynCodeLens/Analysis/ScopePattern.cs`.
+
+**Step 1: failing tests**
+
+```csharp
+using RoslynCodeLens.Analysis;
+
+namespace RoslynCodeLens.Tests;
+
+public class ScopePatternTests
+{
+    [Theory]
+    // exact
+    [InlineData("Demo.Domain", "Demo.Domain", true)]
+    [InlineData("Demo.Domain", "Demo.Domain.Orders", false)]   // exact does NOT match children
+    [InlineData("Demo.Domain", "Demo.DomainX", false)]
+    // prefix wildcard: the scope itself AND everything beneath it
+    [InlineData("Demo.Domain.*", "Demo.Domain", true)]
+    [InlineData("Demo.Domain.*", "Demo.Domain.Orders", true)]
+    [InlineData("Demo.Domain.*", "Demo.Domain.Orders.Rules", true)]
+    [InlineData("Demo.Domain.*", "Demo.DomainX", false)]        // not a segment boundary
+    [InlineData("Demo.Domain.*", "Demo.Infrastructure", false)]
+    // match-all
+    [InlineData("*", "Anything.At.All", true)]
+    [InlineData("*", "", true)]
+    public void Matches(string pattern, string scope, bool expected)
+        => Assert.Equal(expected, ScopePattern.Matches(pattern, scope));
+
+    [Theory]
+    [InlineData("Demo.*.Orders")]   // interior wildcard unsupported
+    [InlineData("*.Orders")]        // suffix wildcard unsupported
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RejectsMalformedPatterns(string pattern)
+        => Assert.False(ScopePattern.IsValid(pattern));
+
+    [Theory]
+    [InlineData("Demo.Domain")]
+    [InlineData("Demo.Domain.*")]
+    [InlineData("*")]
+    public void AcceptsWellFormedPatterns(string pattern)
+        => Assert.True(ScopePattern.IsValid(pattern));
+}
+```
+
+**Step 2:** red run (type missing).
+
+**Step 3: implement** — `IsValid` (non-blank; either `*`, or no `*` at all, or exactly one trailing `.*`), and `Matches` (ordinal comparison; `*` ⇒ true; trailing `.*` ⇒ scope equals the prefix or starts with `prefix + "."`; otherwise exact equality). Ordinal, not case-insensitive: C# namespaces are case-sensitive.
+
+**Step 4/5:** green; commit `feat: ScopePattern matcher for architecture rules`.
+
+---
+
+### Task 3: CheckArchitectureLogic (TDD — the core)
+
+**Files:** Create `tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs`, `src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs`.
+
+Signature: `Execute(LoadedSolution loaded, SymbolResolver resolver, IReadOnlyList<ArchitectureRule> rules, string scope, int maxSitesPerViolation)` → `IReadOnlyList<ArchitectureViolation>`.
+
+**Algorithm**
+
+1. Validate: `rules` non-empty; each `Kind` is `forbid`/`allowOnly`; `To` non-empty; every pattern `ScopePattern.IsValid`; `scope` is `namespace`/`project`. Failures → `InvalidArgument` naming the rule index.
+2. For each compilation, for each syntax tree: skip generated. Compute the document's candidate source scopes — for `scope: "namespace"`, the namespace names declared in the tree (`BaseNamespaceDeclarationSyntax`, covering both block and file-scoped forms; a tree with none is the global namespace, `""`); for `scope: "project"`, the project name. **If no candidate scope matches any rule's `From`, skip the tree entirely — before creating a semantic model.** This is the optimisation that keeps cost proportional to the rules.
+3. Otherwise get the semantic model and walk descendant nodes. For each node, `model.GetSymbolInfo(node).Symbol` — take `ITypeSymbol` directly, otherwise the symbol's `ContainingType`; skip when neither. Derive:
+   - `sourceScope`: for namespace scope, the nearest enclosing `BaseNamespaceDeclarationSyntax`'s name (else `""`); for project scope, the project name.
+   - `targetScope`: for namespace scope, the type's `ContainingNamespace.ToDisplayString()` (empty for global); for project scope, the project owning the type's source location, else its containing assembly name.
+   - `isInternal`: `type.Locations.Any(l => l.IsInSource)`.
+4. Skip when `sourceScope == targetScope` (self-reference — never a violation, both kinds).
+5. Evaluate each rule: `forbid` fires when `From` matches source and any `To` matches target. `allowOnly` fires when `From` matches source, the target `isInternal`, and no `To` matches target.
+6. Accumulate per `(ruleIndex, sourceScope, targetScope)`: increment count, and append a `ViolationSite` while `Sites.Count < maxSitesPerViolation`.
+7. Sort by rule index, then descending `ReferenceCount`.
+
+**Tests** — fixture with two projects so project scope and cross-project edges are real:
+
+```csharp
+private static (LoadedSolution, SymbolResolver) Layered() => RenameTestWorkspace.Create(
+    ("Domain", new[] { ("Order.cs", """
+        namespace Demo.Domain;
+        public class Order { public int Id; }
+        """) }),
+    ("Infra", new[] { ("Repo.cs", """
+        namespace Demo.Infrastructure;
+        public class Repo { public Demo.Domain.Order? Load() => null; }
+        """) }));
+```
+
+1. `Forbid_Violated` — forbid `Demo.Infrastructure.*` → `Demo.Domain.*` ⇒ one violation, `SourceScope`/`TargetScope` correct, `ReferenceCount` ≥ 1, a site with a real file/line.
+2. `Forbid_Satisfied` — forbid the opposite direction (`Demo.Domain.*` → `Demo.Infrastructure.*`) ⇒ empty.
+3. `AllowOnly_CatchesUnlistedDependency` — allowOnly `Demo.Infrastructure.*` → `["Demo.Shared.*"]` ⇒ violation naming `Demo.Domain`.
+4. `AllowOnly_SatisfiedWhenListed` — allowOnly `Demo.Infrastructure.*` → `["Demo.Domain.*"]` ⇒ empty.
+5. `AllowOnly_IgnoresFrameworkTargets` — a source file using `System.Collections.Generic.List<int>` under an allowOnly rule that doesn't list `System.*` ⇒ **empty** (the design's key semantic).
+6. `Forbid_CanTargetFrameworkNamespace` — forbid `Demo.Domain.*` → `System.Collections.Generic` on a file using `List<int>` ⇒ violation (the same target the previous test ignores).
+7. `SelfReference_IsAllowed` — a type referencing another type in its own namespace, under both a `forbid Demo.Domain.* → Demo.Domain.*` and an `allowOnly` with an empty-ish `to` ⇒ empty in both.
+8. `FullyQualifiedReference_WithNoUsing_IsDetected` — the fixture above deliberately writes `Demo.Domain.Order` fully qualified with no `using`. Assert the violation is still found. **This is the test justifying the semantic approach over the existing usings-based one — do not delete it.**
+9. `Grouping_CountsAllReferencesButLimitsSites` — a file with 5 references across the boundary and `maxSitesPerViolation: 2` ⇒ one item, `ReferenceCount == 5`, `Sites.Count == 2`.
+10. `ProjectScope_UsesProjectNames` — same fixture with `scope: "project"`, forbid `Infra` → `Domain` ⇒ violation with those scopes.
+11. `GeneratedCode_IsSkipped` — a generated-looking tree contributing no violations.
+12. `ExactPatternDoesNotMatchChildren` — forbid `Demo.Domain` (no `.*`) against a reference to `Demo.Domain.Orders.Thing` ⇒ empty; with `Demo.Domain.*` ⇒ violation.
+13. Error cases: empty rules; unknown kind; `allowOnly` with empty `to`; malformed pattern; unknown scope — each `InvalidArgument` mentioning the rule index where applicable.
+14. `Sorting_WorstFirstWithinRuleOrder`.
+
+Commit `feat: check_architecture rule evaluation over the semantic type graph`.
+
+---
+
+### Task 4: Tool wrapper + fixture test
+
+**Files:** Create `src/RoslynCodeLens/Tools/CheckArchitectureTool.cs`, `tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs`.
+
+Wrapper mirrors `FindReferencesTool`: `EnsureLoaded()`, `GetAnalysisContext()`, envelope with summary `{ byRule, totalReferences, rulesEvaluated }`. Parameters: `rules` (array of the model), `scope = "namespace"`, `maxSitesPerViolation = 5`, `limit`. The `[Description]` must state both semantics explicitly — `allowOnly` ignores framework targets, self-references are always allowed — because an agent that doesn't know them will misread an empty result.
+
+Fixture test: a rule pair against the real TestSolution (e.g. forbid the test projects' namespace from depending on something it genuinely doesn't, expecting empty; and one that genuinely fires, e.g. `allowOnly` on `TestLib` with an implausible allow-list). Read the fixture's namespaces first rather than guessing.
+
+Commit `feat: expose check_architecture MCP tool`.
+
+---
+
+### Task 5: Docs + verification
+
+- SKILL.md: Red Flags row `| "Is anything violating our layering?" / "Does Domain reference Infrastructure?" | check_architecture |`; a bullet beside `find_circular_dependencies` covering both rule kinds, the two semantics, and grouping; Quick Reference row; metadata-support row (source scan; `forbid` may target metadata namespaces, `allowOnly` ignores them).
+- CLAUDE.md: 64 → **65**.
+- `tools/DocGen/Program.cs`: `["check_architecture"] = "code-quality"`.
+- README.md: one bullet in the existing style.
+- `docs/BACKLOG.md`: medium-tier bullet → ✅ shipped (PR #n) + Recently-shipped row.
+- Full `dotnet build` + `dotnet test` (~950 expected; ~9 min — run in background). Fixture-pristine check.
+
+Commit `docs: document check_architecture (65 tools)`.
+
+---
+
+## Deviations
+Report anything about node-level symbol resolution that proved too broad or too narrow (the walk in step 3 is the part most likely to need tuning), the real cost on the TestSolution fixture, and any case where source-side filtering skipped a document that should have been analysed.

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -246,6 +246,7 @@ Solutions passed on the CLI at server startup are auto-trusted in session scope 
 - `find_large_classes` — oversized types.
 - `find_god_objects` — Types crossing all 3 size thresholds (lines/members/fields) AND a coupling threshold (incoming or outgoing namespace count). Sharper than raw size: a large but isolated class isn't flagged; a 200-line class with 15 callers across many namespaces is.
 - `find_circular_dependencies` — project/namespace cycles.
+- `check_architecture` — enforce layering rules you supply inline. `forbid` (`Domain.*` must not depend on `Infrastructure.*`) catches the violation you know about; `allowOnly` (`Api.*` may depend only on `Application.*`, `Domain.*`) catches the ones you haven't thought of. Edges come from resolved symbols, not `using` directives, so a fully qualified reference with no `using` is still caught and an unused `using` is not reported. **Two semantics you need to read an empty result correctly:** `allowOnly` evaluates only solution-internal targets (framework namespaces are ignored — otherwise every file would violate every rule; use `forbid` to restrict one), and self-references are never violations. Results group per violated edge with a full `referenceCount` and the first `maxSitesPerViolation` sites, so one stray cross-boundary reference is one item, not hundreds.
 - `get_project_health` — Composite audit: complexity, large classes, naming, unused, reflection, async violations, disposable misuse — counts + top-N hotspots per dimension, per project. Use when you'd otherwise call 7 separate audit tools.
 
 ### Source Generators
@@ -361,6 +362,7 @@ Reference concrete types, interfaces, and call sites in your analysis. Not *"the
 | `find_large_classes` | "Find classes that need splitting" |
 | `find_god_objects` | "Which classes are doing too much?" |
 | `find_circular_dependencies` | "Any circular dependencies?" |
+| `check_architecture` | "Is anything violating our layering?" / "Does Domain reference Infrastructure?" |
 | `get_project_health` | "How is this project doing?" / "Top hotspots across all dimensions" |
 | `get_source_generators` | "What source generators are active?" |
 | `get_generated_code` | "Show generated code" |
@@ -432,6 +434,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `find_naming_violations` | No — source only | | |
 | `find_large_classes` | No — source only | | |
 | `find_circular_dependencies` | No — source only | | |
+| `check_architecture` | Source scan; `forbid` may target metadata namespaces | `allowOnly` ignores metadata targets by design | |
 | `get_source_generators` | No — source only | | |
 | `get_generated_code` | No — source only | | |
 | `get_di_registrations` | No — source only | | |

--- a/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
+++ b/plugins/roslyn-codelens/skills/roslyn-codelens/SKILL.md
@@ -246,7 +246,7 @@ Solutions passed on the CLI at server startup are auto-trusted in session scope 
 - `find_large_classes` — oversized types.
 - `find_god_objects` — Types crossing all 3 size thresholds (lines/members/fields) AND a coupling threshold (incoming or outgoing namespace count). Sharper than raw size: a large but isolated class isn't flagged; a 200-line class with 15 callers across many namespaces is.
 - `find_circular_dependencies` — project/namespace cycles.
-- `check_architecture` — enforce layering rules you supply inline. `forbid` (`Domain.*` must not depend on `Infrastructure.*`) catches the violation you know about; `allowOnly` (`Api.*` may depend only on `Application.*`, `Domain.*`) catches the ones you haven't thought of. Edges come from resolved symbols, not `using` directives, so a fully qualified reference with no `using` is still caught and an unused `using` is not reported. **Two semantics you need to read an empty result correctly:** `allowOnly` evaluates only solution-internal targets (framework namespaces are ignored — otherwise every file would violate every rule; use `forbid` to restrict one), and self-references are never violations. Results group per violated edge with a full `referenceCount` and the first `maxSitesPerViolation` sites, so one stray cross-boundary reference is one item, not hundreds.
+- `check_architecture` — enforce layering rules you supply inline. `forbid` (`Domain.*` must not depend on `Infrastructure.*`) catches the violation you know about; `allowOnly` (`Api.*` may depend only on `Application.*`, `Domain.*`) catches the ones you haven't thought of. Edges come from resolved symbols, not `using` directives, so a fully qualified reference with no `using` is still caught and an unused `using` is not reported. **Two semantics you need to read an empty result correctly:** `allowOnly` evaluates only solution-internal, non-generated targets (framework namespaces are ignored — otherwise every file would violate every rule — and so is generator output, which you cannot remove; use `forbid` to restrict either), and self-references are never violations. Results group per violated edge with a full `referenceCount` and the first `maxSitesPerViolation` sites, so one stray cross-boundary reference is one item, not hundreds.
 - `get_project_health` — Composite audit: complexity, large classes, naming, unused, reflection, async violations, disposable misuse — counts + top-N hotspots per dimension, per project. Use when you'd otherwise call 7 separate audit tools.
 
 ### Source Generators
@@ -434,7 +434,7 @@ State the reason when you take the exception. If you're about to type a Grep/Glo
 | `find_naming_violations` | No — source only | | |
 | `find_large_classes` | No — source only | | |
 | `find_circular_dependencies` | No — source only | | |
-| `check_architecture` | Source scan; `forbid` may target metadata namespaces | `allowOnly` ignores metadata targets by design | |
+| `check_architecture` | Source scan; `forbid` may target metadata namespaces | `allowOnly` ignores metadata and generated targets by design | |
 | `get_source_generators` | No — source only | | |
 | `get_generated_code` | No — source only | | |
 | `get_di_registrations` | No — source only | | |

--- a/src/RoslynCodeLens/Analysis/ExceptionQueries.cs
+++ b/src/RoslynCodeLens/Analysis/ExceptionQueries.cs
@@ -90,11 +90,18 @@ internal static class ExceptionQueries
     /// throw or catch lives in. A throw inside a lambda or local function reports the member that
     /// declares it, since that is the location a reader navigates to.
     /// </summary>
+    /// <remarks>
+    /// A namespace declaration is a <see cref="MemberDeclarationSyntax"/> too, and it does declare
+    /// a symbol, so without the skip below a node that sits in no type at all would be described as
+    /// its namespace — naming a scope rather than a member, which is never what the caller wants.
+    /// Exception sites are always inside a member so this is a no-op for them; <c>check_architecture</c>
+    /// walks every name node and does hit the case.
+    /// </remarks>
     public static string DescribeContainingMember(SyntaxNode node, SemanticModel model)
     {
         for (var current = node; current != null; current = current.Parent)
         {
-            if (current is not MemberDeclarationSyntax member)
+            if (current is not MemberDeclarationSyntax member || member is BaseNamespaceDeclarationSyntax)
                 continue;
 
             var symbol = model.GetDeclaredSymbol(member)

--- a/src/RoslynCodeLens/Analysis/ScopePattern.cs
+++ b/src/RoslynCodeLens/Analysis/ScopePattern.cs
@@ -1,0 +1,66 @@
+namespace RoslynCodeLens.Analysis;
+
+/// <summary>
+/// Matcher for architecture-rule scope patterns (namespace or project names).
+/// Three forms only, so a pattern's meaning is obvious from reading it:
+///   * <c>*</c>              — matches every scope, including the global namespace ("").
+///   * <c>Demo.Domain.*</c>  — that scope AND everything beneath it, on segment boundaries.
+///   * <c>Demo.Domain</c>    — exactly that scope; children do NOT match.
+/// Comparison is ordinal: C# namespaces and project names are case-sensitive.
+/// </summary>
+public static class ScopePattern
+{
+    private const string MatchAll = "*";
+    private const string WildcardSuffix = ".*";
+
+    /// <summary>
+    /// True when the pattern is one of the three supported forms. Interior or suffix
+    /// wildcards (<c>Demo.*.Orders</c>, <c>*.Orders</c>, <c>Demo.Domain*</c>) are rejected
+    /// rather than silently reinterpreted — a rule that does not mean what it reads is worse
+    /// than no rule.
+    /// </summary>
+    public static bool IsValid(string? pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+            return false;
+
+        if (string.Equals(pattern, MatchAll, StringComparison.Ordinal))
+            return true;
+
+        var wildcards = pattern.Count(c => c == '*');
+        if (wildcards == 0)
+            return true;
+
+        // Exactly one '*', and it must terminate the pattern as a ".*" suffix with a
+        // non-empty prefix in front of it.
+        return wildcards == 1
+            && pattern.EndsWith(WildcardSuffix, StringComparison.Ordinal)
+            && pattern.Length > WildcardSuffix.Length;
+    }
+
+    /// <summary>
+    /// True when <paramref name="scope"/> falls inside <paramref name="pattern"/>.
+    /// Callers are expected to have validated the pattern; an invalid one matches nothing.
+    /// </summary>
+    public static bool Matches(string pattern, string? scope)
+    {
+        if (!IsValid(pattern))
+            return false;
+
+        scope ??= string.Empty;
+
+        if (string.Equals(pattern, MatchAll, StringComparison.Ordinal))
+            return true;
+
+        if (pattern.EndsWith(WildcardSuffix, StringComparison.Ordinal))
+        {
+            var prefix = pattern[..^WildcardSuffix.Length];
+            return string.Equals(scope, prefix, StringComparison.Ordinal)
+                || (scope.Length > prefix.Length
+                    && scope.StartsWith(prefix, StringComparison.Ordinal)
+                    && scope[prefix.Length] == '.');
+        }
+
+        return string.Equals(scope, pattern, StringComparison.Ordinal);
+    }
+}

--- a/src/RoslynCodeLens/Models/ArchitectureRule.cs
+++ b/src/RoslynCodeLens/Models/ArchitectureRule.cs
@@ -1,0 +1,13 @@
+namespace RoslynCodeLens.Models;
+
+/// <summary>
+/// One layering rule. Kind: forbid | allowOnly.
+/// forbid    → a dependency from <c>From</c> to any scope matching <c>To</c> is a violation.
+/// allowOnly → a dependency from <c>From</c> to any solution-internal scope NOT in <c>To</c> is a violation.
+/// Patterns are exact ("Demo.Domain"), prefix-wildcard ("Demo.Domain.*"), or "*".
+/// </summary>
+public record ArchitectureRule(
+    string Kind,
+    string From,
+    IReadOnlyList<string> To,
+    string? Description = null);

--- a/src/RoslynCodeLens/Models/ArchitectureViolation.cs
+++ b/src/RoslynCodeLens/Models/ArchitectureViolation.cs
@@ -1,0 +1,20 @@
+namespace RoslynCodeLens.Models;
+
+/// <summary>
+/// One concrete source location where the violating dependency is expressed.
+/// </summary>
+public record ViolationSite(string File, int Line, int Column, string SourceSymbol, string TargetSymbol);
+
+/// <summary>
+/// One violated (rule, sourceScope → targetScope) edge. ReferenceCount is the full count;
+/// Sites carries only the first maxSitesPerViolation of them.
+/// </summary>
+public record ArchitectureViolation(
+    string RuleKind,
+    string? RuleDescription,
+    string FromPattern,
+    string ToPattern,
+    string SourceScope,
+    string TargetScope,
+    int ReferenceCount,
+    IReadOnlyList<ViolationSite> Sites);

--- a/src/RoslynCodeLens/Models/ArchitectureViolation.cs
+++ b/src/RoslynCodeLens/Models/ArchitectureViolation.cs
@@ -7,9 +7,12 @@ public record ViolationSite(string File, int Line, int Column, string SourceSymb
 
 /// <summary>
 /// One violated (rule, sourceScope → targetScope) edge. ReferenceCount is the full count;
-/// Sites carries only the first maxSitesPerViolation of them.
+/// Sites carries only the first maxSitesPerViolation of them. RuleIndex is the position of the
+/// rule in the caller's own `rules` array, so a violation is always traceable back to the rule
+/// as written — several `to` patterns of one rule stay one rule.
 /// </summary>
 public record ArchitectureViolation(
+    int RuleIndex,
     string RuleKind,
     string? RuleDescription,
     string FromPattern,

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -80,7 +80,15 @@ public static class CheckArchitectureLogic
 
                 var model = compilation.GetSemanticModel(tree);
 
-                foreach (var name in root.DescendantNodes().OfType<SimpleNameSyntax>())
+                // `using` directives are deliberately NOT walked. A using is not itself a
+                // dependency — it is a name-resolution convenience — and counting it breaks the
+                // tool twice over: a file-level using is attributed to the GLOBAL namespace (an
+                // accusation against a scope that wrote no code), and an in-namespace using or
+                // alias double-counts the single real usage below it. Skipping them is also what
+                // makes the tool's own promise true: "an unused `using` is not reported".
+                foreach (var name in root
+                             .DescendantNodes(descendIntoChildren: n => n is not UsingDirectiveSyntax)
+                             .OfType<SimpleNameSyntax>())
                 {
                     var target = ResolveTargetType(name, model);
                     if (target is null)

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -44,7 +44,7 @@ public static class CheckArchitectureLogic
         int maxSitesPerViolation = 5,
         CancellationToken cancellationToken = default)
     {
-        Validate(rules, scope);
+        Validate(rules, scope, maxSitesPerViolation);
 
         var byNamespace = string.Equals(scope, NamespaceScope, StringComparison.Ordinal);
         var groups = new Dictionary<(int RuleIndex, string Source, string Target), Accumulator>();
@@ -176,8 +176,16 @@ public static class CheckArchitectureLogic
             .ToList();
     }
 
-    private static void Validate(IReadOnlyList<ArchitectureRule> rules, string scope)
+    private static void Validate(IReadOnlyList<ArchitectureRule> rules, string scope, int maxSitesPerViolation)
     {
+        // A violation with no sites is an accusation with no location — unactionable, and never
+        // what the caller meant.
+        if (maxSitesPerViolation <= 0)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"maxSitesPerViolation must be at least 1 (got {maxSitesPerViolation}).");
+        }
+
         if (!string.Equals(scope, NamespaceScope, StringComparison.Ordinal)
             && !string.Equals(scope, ProjectScope, StringComparison.Ordinal))
         {

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -11,10 +11,13 @@ namespace RoslynCodeLens.Tools;
 /// <remarks>
 /// Two semantics decide whether this tool is usable, and both are deliberate:
 /// <list type="number">
-/// <item><description><b>allowOnly considers only solution-internal targets.</b> Otherwise
-/// <c>using System;</c> violates "Api may depend only on Application" — absurd, and it would bury
-/// every real finding. To restrict a framework namespace, write an explicit <c>forbid</c>; that
-/// path <i>does</i> evaluate metadata targets.</description></item>
+/// <item><description><b>allowOnly considers only solution-internal, non-generated targets.</b>
+/// Otherwise <c>using System;</c> violates "Api may depend only on Application" — absurd, and it
+/// would bury every real finding; likewise generator output (regex implementations, JSON contexts,
+/// DI registries) would be reported as an unlisted dependency the author cannot remove. Its target
+/// set is open-ended, so it only reports targets the author can act on. To restrict a framework or
+/// generated namespace, write an explicit <c>forbid</c>; that path names its target and <i>does</i>
+/// evaluate metadata and generated ones.</description></item>
 /// <item><description><b>Self-references are always allowed.</b> A scope depending on itself is
 /// not a layering violation, under either rule kind.</description></item>
 /// </list>
@@ -48,6 +51,7 @@ public static class CheckArchitectureLogic
         // A linked or multi-targeted file appears in several compilations; walking it once keeps
         // reference counts honest and project attribution deterministic (see FindThrowSitesLogic).
         var walkedPaths = new HashSet<string>(StringComparer.Ordinal);
+        var generatedTargets = new Dictionary<ISymbol, bool>(SymbolEqualityComparer.Default);
 
         foreach (var (projectId, compilation) in loaded.Compilations)
         {
@@ -103,7 +107,12 @@ public static class CheckArchitectureLogic
                     if (string.Equals(sourceScope, targetScope, StringComparison.Ordinal))
                         continue;
 
-                    var isInternal = target.Locations.Any(l => l.IsInSource);
+                    // allowOnly's target set is open-ended, so it only evaluates targets the
+                    // author can actually act on: solution-internal, and not pure generator
+                    // output. `forbid` names its target explicitly and evaluates everything.
+                    var eligibleForAllowOnly =
+                        target.Locations.Any(l => l.IsInSource)
+                        && !IsGeneratedOnly(target, generatedTargets);
 
                     for (var i = 0; i < rules.Count; i++)
                     {
@@ -121,7 +130,7 @@ public static class CheckArchitectureLogic
                         else
                         {
                             // allowOnly ignores everything outside the solution.
-                            if (!isInternal || rule.To.Any(p => ScopePattern.Matches(p, targetScope)))
+                            if (!eligibleForAllowOnly || rule.To.Any(p => ScopePattern.Matches(p, targetScope)))
                                 continue;
                             toPattern = string.Join(", ", rule.To);
                         }
@@ -355,6 +364,28 @@ public static class CheckArchitectureLogic
             { TypeKind: TypeKind.Error or TypeKind.Dynamic or TypeKind.Submission } => null,
             _ => candidate,
         };
+    }
+
+    /// <summary>
+    /// True when every syntax tree that declares the type is generated code — nothing the author
+    /// could edit. A partial type with one hand-written part is NOT generated-only: that part is
+    /// editable, so a dependency on it is actionable.
+    /// </summary>
+    /// <remarks>
+    /// Cached per symbol: the same target type is re-resolved at every reference site, and
+    /// <see cref="GeneratedCodeDetector.IsGenerated"/> reads tree text.
+    /// </remarks>
+    private static bool IsGeneratedOnly(ITypeSymbol type, Dictionary<ISymbol, bool> cache)
+    {
+        if (cache.TryGetValue(type, out var known))
+            return known;
+
+        var declarations = type.DeclaringSyntaxReferences;
+        var generated = declarations.Length > 0
+            && declarations.All(r => GeneratedCodeDetector.IsGenerated(r.SyntaxTree));
+
+        cache[type] = generated;
+        return generated;
     }
 
     private static string DescribeSource(SyntaxNode node, SemanticModel model)

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -297,9 +297,22 @@ public static class CheckArchitectureLogic
     /// this one reports 5.</para>
     /// <para>Locals, parameters, range variables, labels and discards are skipped: a reference to a
     /// local is not a dependency on the type that happens to contain it.</para>
+    /// <para><b><c>var</c> is skipped.</b> It is an <c>IdentifierNameSyntax</c> whose
+    /// <c>GetSymbolInfo</c> returns the <i>inferred</i> type, so counting it reports a dependency
+    /// the author never wrote and makes the count depend on whether the declaration was written
+    /// explicitly. The intended count is <b>references a human reading the code would point at</b>:
+    /// <c>var o = new Demo.Domain.Order(); return o.Id;</c> is two dependencies on <c>Order</c> —
+    /// the construction and the member access — exactly what
+    /// <c>Demo.Domain.Order o = new(); return o.Id;</c> yields. The check is syntactic, so a user
+    /// type literally named <c>var</c> and referenced unqualified would also be skipped; that is
+    /// accepted, since such a type cannot be written as a plain identifier without shadowing the
+    /// contextual keyword anyway.</para>
     /// </remarks>
     private static ITypeSymbol? ResolveTargetType(SimpleNameSyntax name, SemanticModel model)
     {
+        if (name is IdentifierNameSyntax { IsVar: true })
+            return null;
+
         var symbol = model.GetSymbolInfo(name).Symbol;
         var target = TypeOf(symbol);
         if (target is null)

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -52,6 +52,7 @@ public static class CheckArchitectureLogic
         // reference counts honest and project attribution deterministic (see FindThrowSitesLogic).
         var walkedPaths = new HashSet<string>(StringComparer.Ordinal);
         var generatedTargets = new Dictionary<ISymbol, bool>(SymbolEqualityComparer.Default);
+        var solutionScopeNames = SolutionScopeNames(loaded.Solution);
 
         foreach (var (projectId, compilation) in loaded.Compilations)
         {
@@ -111,7 +112,7 @@ public static class CheckArchitectureLogic
                     // author can actually act on: solution-internal, and not pure generator
                     // output. `forbid` names its target explicitly and evaluates everything.
                     var eligibleForAllowOnly =
-                        target.Locations.Any(l => l.IsInSource)
+                        IsSolutionInternal(target, solutionScopeNames)
                         && !IsGeneratedOnly(target, generatedTargets);
 
                     for (var i = 0; i < rules.Count; i++)
@@ -365,6 +366,41 @@ public static class CheckArchitectureLogic
             _ => candidate,
         };
     }
+
+    /// <summary>
+    /// Every name an assembly produced by this solution can carry: each project's assembly name
+    /// and its project name (they differ often enough that checking only one would miss).
+    /// </summary>
+    internal static IReadOnlySet<string> SolutionScopeNames(Solution solution)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var project in solution.Projects)
+        {
+            if (!string.IsNullOrEmpty(project.AssemblyName))
+                names.Add(project.AssemblyName);
+            if (!string.IsNullOrEmpty(project.Name))
+                names.Add(project.Name);
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Whether a target belongs to the solution — the question <c>allowOnly</c> turns on.
+    /// </summary>
+    /// <remarks>
+    /// Asking the symbol whether it has a source location answers a different question: whether it
+    /// happened to LOAD as source. When a ProjectReference resolves as a metadata reference
+    /// instead — a real MSBuildWorkspace failure mode — every source location disappears and every
+    /// <c>allowOnly</c> rule over that boundary silently returns empty, which reads exactly like
+    /// clean architecture. Matching the containing assembly against the solution's own projects
+    /// keeps the answer a property of the solution rather than of the load. The source-location
+    /// check remains as a fallback, for a project whose assembly name we cannot see.
+    /// </remarks>
+    internal static bool IsSolutionInternal(ITypeSymbol target, IReadOnlySet<string> solutionScopeNames)
+        => (target.ContainingAssembly is { Name.Length: > 0 } assembly
+            && solutionScopeNames.Contains(assembly.Name))
+           || target.Locations.Any(l => l.IsInSource);
 
     /// <summary>
     /// True when every syntax tree that declares the type is generated code — nothing the author

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -48,11 +48,25 @@ public static class CheckArchitectureLogic
 
         var byNamespace = string.Equals(scope, NamespaceScope, StringComparison.Ordinal);
         var groups = new Dictionary<(int RuleIndex, string Source, string Target), Accumulator>();
+
         // A linked or multi-targeted file appears in several compilations; walking it once keeps
         // reference counts honest and project attribution deterministic (see FindThrowSitesLogic).
-        var walkedPaths = new HashSet<string>(StringComparer.Ordinal);
-        var generatedTargets = new Dictionary<ISymbol, bool>(SymbolEqualityComparer.Default);
+        //
+        // The key is SCOPE-AWARE, because "the same work twice" means different things per scope.
+        // Under namespace scope a linked file declares the same namespace in every compilation, so
+        // walking it twice would double-count one written reference — dedupe by path alone. Under
+        // project scope its source scope DIFFERS per compilation, so a path-only key would credit
+        // the file to whichever project was enumerated first and silently drop the other project's
+        // violations entirely. Including the project name still collapses multi-targeting, where
+        // the several compilations share one project name.
+        var walkedTrees = new HashSet<(string Scope, string Identity)>();
+        var generatedTargets = new Dictionary<string, bool>(StringComparer.Ordinal);
         var solutionScopeNames = SolutionScopeNames(loaded.Solution);
+
+        // Hoisted: with a forbid-only rule set nothing ever consults this, and computing it per
+        // name node meant re-resolving generated-ness and solution membership for every reference
+        // in the solution to answer a question no rule asked.
+        var hasAllowOnly = rules.Any(r => string.Equals(r.Kind, AllowOnlyKind, StringComparison.Ordinal));
 
         foreach (var (projectId, compilation) in loaded.Compilations)
         {
@@ -69,7 +83,7 @@ public static class CheckArchitectureLogic
                 if (GeneratedCodeDetector.IsGenerated(tree))
                     continue;
 
-                if (!string.IsNullOrEmpty(tree.FilePath) && !walkedPaths.Add(tree.FilePath))
+                if (!walkedTrees.Add((byNamespace ? string.Empty : projectName, TreeIdentity(tree, cancellationToken))))
                     continue;
 
                 cancellationToken.ThrowIfCancellationRequested();
@@ -91,10 +105,18 @@ public static class CheckArchitectureLogic
                 // accusation against a scope that wrote no code), and an in-namespace using or
                 // alias double-counts the single real usage below it. Skipping them is also what
                 // makes the tool's own promise true: "an unused `using` is not reported".
+                var walkedNodes = 0;
                 foreach (var name in root
                              .DescendantNodes(descendIntoChildren: n => n is not UsingDirectiveSyntax)
                              .OfType<SimpleNameSyntax>())
                 {
+                    // One generated or machine-written file can hold hundreds of thousands of name
+                    // nodes, so a token checked only per tree leaves the caller unable to cancel
+                    // partway through one. Every 1024 nodes is far below human latency and costs
+                    // nothing measurable.
+                    if ((++walkedNodes & 0x3FF) == 0)
+                        cancellationToken.ThrowIfCancellationRequested();
+
                     var target = ResolveTargetType(name, model);
                     if (target is null)
                         continue;
@@ -111,8 +133,8 @@ public static class CheckArchitectureLogic
                     // allowOnly's target set is open-ended, so it only evaluates targets the
                     // author can actually act on: solution-internal, and not pure generator
                     // output. `forbid` names its target explicitly and evaluates everything.
-                    var eligibleForAllowOnly =
-                        IsSolutionInternal(target, solutionScopeNames)
+                    var eligibleForAllowOnly = hasAllowOnly
+                        && IsSolutionInternal(target, solutionScopeNames)
                         && !IsGeneratedOnly(target, generatedTargets);
 
                     for (var i = 0; i < rules.Count; i++)
@@ -151,7 +173,7 @@ public static class CheckArchitectureLogic
                                 File: position.Path,
                                 Line: position.StartLinePosition.Line + 1,
                                 Column: position.StartLinePosition.Character + 1,
-                                SourceSymbol: DescribeSource(name, model),
+                                SourceSymbol: ExceptionQueries.DescribeContainingMember(name, model),
                                 TargetSymbol: target.ToDisplayString()));
                         }
                     }
@@ -337,18 +359,46 @@ public static class CheckArchitectureLogic
         if (target is null)
             return null;
 
+        if (symbol is ITypeSymbol)
+            return target;
+
         // Drop the trailing member of `SomeType.Member` — the qualifier already counted it.
-        if (name.Parent is MemberAccessExpressionSyntax access
-            && access.Name == name
-            && symbol is not ITypeSymbol)
+        if (name.Parent is MemberAccessExpressionSyntax access && access.Name == name)
         {
             var qualifier = TypeOf(model.GetSymbolInfo(access.Expression).Symbol);
             if (qualifier is not null && SymbolEqualityComparer.Default.Equals(qualifier, target))
                 return null;
         }
 
+        // Drop an initializer's member name for the same reason: `new Demo.Domain.Order { Id = 1 }`
+        // writes Order once, and `Id`'s ContainingType IS Order, so counting it would report one
+        // dependency per assigned member. `other.Id = 1` is untouched — that is an assignment
+        // through a local, not an initializer, and is a separately written reference.
+        if (name.Parent is AssignmentExpressionSyntax { Parent: InitializerExpressionSyntax initializer } assignment
+            && assignment.Left == name
+            && initializer.Parent is ExpressionSyntax initialized)
+        {
+            // Covers `new T { ... }`, `new() { ... }`, `x with { ... }` and the nested
+            // `P = { ... }` form — in every one of them the type of the expression the initializer
+            // hangs off IS the type whose members are being assigned.
+            var initializedType = model.GetTypeInfo(initialized).Type;
+            if (initializedType is not null && SymbolEqualityComparer.Default.Equals(initializedType, target))
+                return null;
+        }
+
         return target;
     }
+
+    /// <summary>
+    /// A stable per-tree key for the walk dedupe. File path when there is one; otherwise a hash of
+    /// the tree's own text, because a pathless tree (in-memory documents, some generators) is a
+    /// different object in every compilation and would otherwise be walked — and counted — once per
+    /// compilation it appears in.
+    /// </summary>
+    private static string TreeIdentity(SyntaxTree tree, CancellationToken cancellationToken)
+        => string.IsNullOrEmpty(tree.FilePath)
+            ? "\0content:" + Convert.ToBase64String(tree.GetText(cancellationToken).GetContentHash().AsSpan())
+            : tree.FilePath;
 
     private static ITypeSymbol? TypeOf(ISymbol? symbol)
     {
@@ -417,28 +467,24 @@ public static class CheckArchitectureLogic
     /// editable, so a dependency on it is actionable.
     /// </summary>
     /// <remarks>
-    /// Cached per symbol: the same target type is re-resolved at every reference site, and
-    /// <see cref="GeneratedCodeDetector.IsGenerated"/> reads tree text.
+    /// Cached: the same target type is re-resolved at every reference site, and
+    /// <see cref="GeneratedCodeDetector.IsGenerated"/> reads tree text. Keyed by fully-qualified
+    /// name rather than by symbol — the convention <see cref="ExceptionQueries.Fqn"/> already
+    /// adopted — because symbols are compilation-scoped: the same logical type bound in two
+    /// projects is not <c>SymbolEqualityComparer</c>-equal, so a symbol key re-reads the tree text
+    /// once per compilation that references it.
     /// </remarks>
-    private static bool IsGeneratedOnly(ITypeSymbol type, Dictionary<ISymbol, bool> cache)
+    private static bool IsGeneratedOnly(ITypeSymbol type, Dictionary<string, bool> cache)
     {
-        if (cache.TryGetValue(type, out var known))
+        var key = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        if (cache.TryGetValue(key, out var known))
             return known;
 
         var declarations = type.DeclaringSyntaxReferences;
         var generated = declarations.Length > 0
             && declarations.All(r => GeneratedCodeDetector.IsGenerated(r.SyntaxTree));
 
-        cache[type] = generated;
+        cache[key] = generated;
         return generated;
-    }
-
-    private static string DescribeSource(SyntaxNode node, SemanticModel model)
-    {
-        var member = node.Ancestors()
-            .OfType<MemberDeclarationSyntax>()
-            .FirstOrDefault(m => m is not BaseNamespaceDeclarationSyntax);
-
-        return member is null ? string.Empty : model.GetDeclaredSymbol(member)?.ToDisplayString() ?? string.Empty;
     }
 }

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -165,6 +165,7 @@ public static class CheckArchitectureLogic
             .ThenBy(g => g.Key.Source, StringComparer.Ordinal)
             .ThenBy(g => g.Key.Target, StringComparer.Ordinal)
             .Select(g => new ArchitectureViolation(
+                RuleIndex: g.Key.RuleIndex,
                 RuleKind: rules[g.Key.RuleIndex].Kind,
                 RuleDescription: rules[g.Key.RuleIndex].Description,
                 FromPattern: rules[g.Key.RuleIndex].From,

--- a/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureLogic.cs
@@ -1,0 +1,347 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RoslynCodeLens.Analysis;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+/// <summary>
+/// Evaluates user-supplied layering rules against the solution's real semantic type graph.
+/// </summary>
+/// <remarks>
+/// Two semantics decide whether this tool is usable, and both are deliberate:
+/// <list type="number">
+/// <item><description><b>allowOnly considers only solution-internal targets.</b> Otherwise
+/// <c>using System;</c> violates "Api may depend only on Application" — absurd, and it would bury
+/// every real finding. To restrict a framework namespace, write an explicit <c>forbid</c>; that
+/// path <i>does</i> evaluate metadata targets.</description></item>
+/// <item><description><b>Self-references are always allowed.</b> A scope depending on itself is
+/// not a layering violation, under either rule kind.</description></item>
+/// </list>
+/// </remarks>
+public static class CheckArchitectureLogic
+{
+    public const string NamespaceScope = "namespace";
+    public const string ProjectScope = "project";
+    public const string ForbidKind = "forbid";
+    public const string AllowOnlyKind = "allowOnly";
+
+    private sealed class Accumulator
+    {
+        public int Count;
+        public readonly List<ViolationSite> Sites = [];
+        public string ToPattern = string.Empty;
+    }
+
+    public static IReadOnlyList<ArchitectureViolation> Execute(
+        LoadedSolution loaded,
+        SymbolResolver resolver,
+        IReadOnlyList<ArchitectureRule> rules,
+        string scope = NamespaceScope,
+        int maxSitesPerViolation = 5,
+        CancellationToken cancellationToken = default)
+    {
+        Validate(rules, scope);
+
+        var byNamespace = string.Equals(scope, NamespaceScope, StringComparison.Ordinal);
+        var groups = new Dictionary<(int RuleIndex, string Source, string Target), Accumulator>();
+        // A linked or multi-targeted file appears in several compilations; walking it once keeps
+        // reference counts honest and project attribution deterministic (see FindThrowSitesLogic).
+        var walkedPaths = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (projectId, compilation) in loaded.Compilations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var projectName = resolver.GetProjectName(projectId);
+
+            // Source-side filtering, part 1: under project scope a whole compilation is either in
+            // play or not, so decide before touching its trees.
+            if (!byNamespace && !rules.Any(r => ScopePattern.Matches(r.From, projectName)))
+                continue;
+
+            foreach (var tree in compilation.SyntaxTrees)
+            {
+                if (GeneratedCodeDetector.IsGenerated(tree))
+                    continue;
+
+                if (!string.IsNullOrEmpty(tree.FilePath) && !walkedPaths.Add(tree.FilePath))
+                    continue;
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var root = tree.GetRoot(cancellationToken);
+
+                // Source-side filtering, part 2: if none of the scopes this tree declares can match
+                // any rule's From, the tree cannot produce a violation — skip it BEFORE creating a
+                // semantic model. This is what keeps cost proportional to the rules written rather
+                // than to solution size.
+                if (byNamespace && !DeclaredScopes(root).Any(s => rules.Any(r => ScopePattern.Matches(r.From, s))))
+                    continue;
+
+                var model = compilation.GetSemanticModel(tree);
+
+                foreach (var name in root.DescendantNodes().OfType<SimpleNameSyntax>())
+                {
+                    var target = ResolveTargetType(name, model);
+                    if (target is null)
+                        continue;
+
+                    var sourceScope = byNamespace ? EnclosingNamespace(name) : projectName;
+                    var targetScope = byNamespace
+                        ? NamespaceOf(target)
+                        : TargetProject(target, resolver);
+
+                    // Self-reference: never a violation, under either rule kind.
+                    if (string.Equals(sourceScope, targetScope, StringComparison.Ordinal))
+                        continue;
+
+                    var isInternal = target.Locations.Any(l => l.IsInSource);
+
+                    for (var i = 0; i < rules.Count; i++)
+                    {
+                        var rule = rules[i];
+                        if (!ScopePattern.Matches(rule.From, sourceScope))
+                            continue;
+
+                        string? toPattern;
+                        if (string.Equals(rule.Kind, ForbidKind, StringComparison.Ordinal))
+                        {
+                            toPattern = rule.To.FirstOrDefault(p => ScopePattern.Matches(p, targetScope));
+                            if (toPattern is null)
+                                continue;
+                        }
+                        else
+                        {
+                            // allowOnly ignores everything outside the solution.
+                            if (!isInternal || rule.To.Any(p => ScopePattern.Matches(p, targetScope)))
+                                continue;
+                            toPattern = string.Join(", ", rule.To);
+                        }
+
+                        var key = (i, sourceScope, targetScope);
+                        if (!groups.TryGetValue(key, out var accumulator))
+                        {
+                            accumulator = new Accumulator { ToPattern = toPattern };
+                            groups[key] = accumulator;
+                        }
+
+                        accumulator.Count++;
+                        if (accumulator.Sites.Count < maxSitesPerViolation)
+                        {
+                            var position = name.GetLocation().GetLineSpan();
+                            accumulator.Sites.Add(new ViolationSite(
+                                File: position.Path,
+                                Line: position.StartLinePosition.Line + 1,
+                                Column: position.StartLinePosition.Character + 1,
+                                SourceSymbol: DescribeSource(name, model),
+                                TargetSymbol: target.ToDisplayString()));
+                        }
+                    }
+                }
+            }
+        }
+
+        return groups
+            .OrderBy(g => g.Key.RuleIndex)
+            .ThenByDescending(g => g.Value.Count)
+            .ThenBy(g => g.Key.Source, StringComparer.Ordinal)
+            .ThenBy(g => g.Key.Target, StringComparer.Ordinal)
+            .Select(g => new ArchitectureViolation(
+                RuleKind: rules[g.Key.RuleIndex].Kind,
+                RuleDescription: rules[g.Key.RuleIndex].Description,
+                FromPattern: rules[g.Key.RuleIndex].From,
+                ToPattern: g.Value.ToPattern,
+                SourceScope: g.Key.Source,
+                TargetScope: g.Key.Target,
+                ReferenceCount: g.Value.Count,
+                Sites: g.Value.Sites))
+            .ToList();
+    }
+
+    private static void Validate(IReadOnlyList<ArchitectureRule> rules, string scope)
+    {
+        if (!string.Equals(scope, NamespaceScope, StringComparison.Ordinal)
+            && !string.Equals(scope, ProjectScope, StringComparison.Ordinal))
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                $"Unknown scope '{scope}'. Expected '{NamespaceScope}' or '{ProjectScope}'.");
+        }
+
+        if (rules is null || rules.Count == 0)
+        {
+            throw new McpToolException(ToolErrorCode.InvalidArgument,
+                "At least one architecture rule is required.");
+        }
+
+        for (var i = 0; i < rules.Count; i++)
+        {
+            var rule = rules[i];
+
+            if (!string.Equals(rule.Kind, ForbidKind, StringComparison.Ordinal)
+                && !string.Equals(rule.Kind, AllowOnlyKind, StringComparison.Ordinal))
+            {
+                throw new McpToolException(ToolErrorCode.InvalidArgument,
+                    $"rules[{i}]: unknown kind '{rule.Kind}'. Expected '{ForbidKind}' or '{AllowOnlyKind}'.",
+                    new { ruleIndex = i });
+            }
+
+            if (rule.To is null || rule.To.Count == 0)
+            {
+                throw new McpToolException(ToolErrorCode.InvalidArgument,
+                    $"rules[{i}]: '{rule.Kind}' requires a non-empty 'to'.",
+                    new { ruleIndex = i });
+            }
+
+            if (!ScopePattern.IsValid(rule.From))
+            {
+                throw new McpToolException(ToolErrorCode.InvalidArgument,
+                    $"rules[{i}]: malformed 'from' pattern '{rule.From}'. " +
+                    "Use an exact scope, a prefix wildcard like 'Demo.Domain.*', or '*'.",
+                    new { ruleIndex = i });
+            }
+
+            foreach (var pattern in rule.To)
+            {
+                if (!ScopePattern.IsValid(pattern))
+                {
+                    throw new McpToolException(ToolErrorCode.InvalidArgument,
+                        $"rules[{i}]: malformed 'to' pattern '{pattern}'. " +
+                        "Use an exact scope, a prefix wildcard like 'Demo.Domain.*', or '*'.",
+                        new { ruleIndex = i });
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every scope a tree could count as a source for. All namespace declarations (block and
+    /// file-scoped, nested ones flattened), plus the global namespace when any member sits outside
+    /// them — so a multi-namespace or partly-global file is never wrongly filtered out.
+    /// </summary>
+    private static IReadOnlyList<string> DeclaredScopes(SyntaxNode root)
+    {
+        var scopes = new List<string>();
+
+        foreach (var declaration in root
+                     .DescendantNodes(descendIntoChildren: n =>
+                         n is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+                     .OfType<BaseNamespaceDeclarationSyntax>())
+        {
+            scopes.Add(FullNamespaceName(declaration));
+        }
+
+        if (scopes.Count == 0
+            || (root is CompilationUnitSyntax unit
+                && unit.Members.Any(m => m is not BaseNamespaceDeclarationSyntax)))
+        {
+            scopes.Add(string.Empty);
+        }
+
+        return scopes;
+    }
+
+    private static string FullNamespaceName(BaseNamespaceDeclarationSyntax declaration)
+    {
+        var parts = new List<string> { declaration.Name.ToString() };
+        foreach (var outer in declaration.Ancestors().OfType<BaseNamespaceDeclarationSyntax>())
+            parts.Insert(0, outer.Name.ToString());
+        return string.Join('.', parts);
+    }
+
+    private static string EnclosingNamespace(SyntaxNode node)
+    {
+        var declaration = node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
+        return declaration is null ? string.Empty : FullNamespaceName(declaration);
+    }
+
+    private static string NamespaceOf(ITypeSymbol type)
+    {
+        var ns = type.ContainingNamespace;
+        return ns is null || ns.IsGlobalNamespace ? string.Empty : ns.ToDisplayString();
+    }
+
+    private static string TargetProject(ITypeSymbol type, SymbolResolver resolver)
+    {
+        var project = resolver.GetProjectName(type);
+        return string.IsNullOrEmpty(project)
+            ? type.ContainingAssembly?.Name ?? string.Empty
+            : project;
+    }
+
+    /// <summary>
+    /// The type a name node depends on, or null when the node expresses no type dependency.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why only <see cref="SimpleNameSyntax"/>, and why the qualifier check — the dedupe.</b>
+    /// Resolving <i>every</i> descendant node double-counts: <c>Demo.Domain.Order</c> binds as a
+    /// whole <c>QualifiedNameSyntax</c> AND again as its right-hand <c>Order</c> identifier, so one
+    /// reference a human sees once would be counted twice (and three times once a member access is
+    /// chained on). Restricting the walk to leaf name nodes counts each dotted name exactly once:
+    /// the <c>Demo</c> and <c>Domain</c> parts bind to namespaces and drop out here, leaving only
+    /// <c>Order</c>.</para>
+    /// <para>The remaining duplicate is member access on a type — <c>Order.Zero</c> yields the type
+    /// <c>Order</c> for the qualifier and, via <c>ContainingType</c>, <c>Order</c> again for
+    /// <c>Zero</c>. When the qualifier already resolves to the same type, the member name is
+    /// dropped. <c>local.Id</c> is unaffected: the qualifier is a local, not a type, so the member
+    /// still counts — it is a genuine dependency on the field's declaring type.</para>
+    /// <para>Measured on the <c>Grouping_CountsAllReferencesButLimitsSites</c> fixture, whose five
+    /// cross-boundary references a human counts as five: the naive all-descendants walk reports 17;
+    /// this one reports 5.</para>
+    /// <para>Locals, parameters, range variables, labels and discards are skipped: a reference to a
+    /// local is not a dependency on the type that happens to contain it.</para>
+    /// </remarks>
+    private static ITypeSymbol? ResolveTargetType(SimpleNameSyntax name, SemanticModel model)
+    {
+        var symbol = model.GetSymbolInfo(name).Symbol;
+        var target = TypeOf(symbol);
+        if (target is null)
+            return null;
+
+        // Drop the trailing member of `SomeType.Member` — the qualifier already counted it.
+        if (name.Parent is MemberAccessExpressionSyntax access
+            && access.Name == name
+            && symbol is not ITypeSymbol)
+        {
+            var qualifier = TypeOf(model.GetSymbolInfo(access.Expression).Symbol);
+            if (qualifier is not null && SymbolEqualityComparer.Default.Equals(qualifier, target))
+                return null;
+        }
+
+        return target;
+    }
+
+    private static ITypeSymbol? TypeOf(ISymbol? symbol)
+    {
+        var candidate = symbol switch
+        {
+            null => null,
+            ILocalSymbol or IParameterSymbol or IRangeVariableSymbol or ILabelSymbol or IDiscardSymbol => null,
+            ITypeSymbol type => type,
+            _ => symbol.ContainingType,
+        };
+
+        // Unwrap arrays/pointers so `Order[]` is a dependency on Order, not on a namespace-less
+        // synthesized type.
+        while (candidate is IArrayTypeSymbol array)
+            candidate = array.ElementType;
+        while (candidate is IPointerTypeSymbol pointer)
+            candidate = pointer.PointedAtType;
+
+        return candidate switch
+        {
+            null => null,
+            ITypeParameterSymbol => null,               // T is not a dependency on anything
+            { TypeKind: TypeKind.Error or TypeKind.Dynamic or TypeKind.Submission } => null,
+            _ => candidate,
+        };
+    }
+
+    private static string DescribeSource(SyntaxNode node, SemanticModel model)
+    {
+        var member = node.Ancestors()
+            .OfType<MemberDeclarationSyntax>()
+            .FirstOrDefault(m => m is not BaseNamespaceDeclarationSyntax);
+
+        return member is null ? string.Empty : model.GetDeclaredSymbol(member)?.ToDisplayString() ?? string.Empty;
+    }
+}

--- a/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
@@ -38,16 +38,19 @@ public static class CheckArchitectureTool
                  "Rule kinds: `forbid` (a dependency from `from` to `to` is a violation) and " +
                  "`allowOnly` (a dependency from `from` to anything outside `to` is a violation). " +
                  "TWO SEMANTICS YOU MUST KNOW TO READ AN EMPTY RESULT CORRECTLY. " +
-                 "(1) `allowOnly` evaluates ONLY solution-internal targets: references to framework " +
-                 "and NuGet namespaces such as `System.Collections.Generic` are ignored, otherwise " +
-                 "every file would violate every `allowOnly` rule. To restrict a framework " +
-                 "namespace, write an explicit `forbid` — that path DOES evaluate metadata targets. " +
+                 "(1) `allowOnly` evaluates ONLY solution-internal, non-generated targets: " +
+                 "references to framework and NuGet namespaces such as `System.Collections.Generic` " +
+                 "are ignored (otherwise every file would violate every `allowOnly` rule), and so " +
+                 "are types declared entirely in generated code, which the caller cannot remove. " +
+                 "To restrict a framework or generated namespace, write an explicit `forbid` — that " +
+                 "path DOES evaluate metadata and generated targets. " +
                  "(2) Self-references are always allowed: a scope depending on itself is never a " +
                  "violation, under either kind. " +
                  "Results are grouped per violated `rule` plus `sourceScope` plus `targetScope` " +
                  "edge, each with a full `referenceCount` and the first `maxSitesPerViolation` " +
                  "sites. Sorted by rule order, then by descending reference count. Generated code " +
-                 "is skipped. Envelope adds a `byRule` / `totalReferences` / `rulesEvaluated` " +
+                 "is never reported as the SOURCE of a violation under either kind. Envelope adds " +
+                 "a `byRule` / `totalReferences` / `rulesEvaluated` " +
                  "summary.")]
     public static ToolListResult<ArchitectureViolation> Execute(
         MultiSolutionManager manager,

--- a/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
@@ -90,8 +90,11 @@ public static class CheckArchitectureTool
 
     internal static object BuildSummary(IReadOnlyList<ArchitectureViolation> items, int rulesEvaluated)
     {
+        // Keyed by kind + from + to, not by `from` alone: two rules can share a source pattern
+        // (a `forbid` and an `allowOnly` over the same layer is a normal thing to write), and
+        // collapsing them into one bucket would silently merge their counts.
         var byRule = items
-            .GroupBy(v => v.FromPattern, StringComparer.Ordinal)
+            .GroupBy(v => $"{v.RuleKind} {v.FromPattern} -> {v.ToPattern}", StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.Sum(v => v.ReferenceCount), StringComparer.Ordinal);
 
         return new

--- a/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
@@ -73,7 +73,7 @@ public static class CheckArchitectureTool
         var raw = CheckArchitectureLogic.Execute(
             context.Loaded, context.Resolver, parsed, scope, maxSitesPerViolation);
 
-        return BuildResult(raw, parsed.Count, limit ?? DefaultLimit);
+        return BuildResult(raw, parsed, limit ?? DefaultLimit);
     }
 
     internal static IReadOnlyList<ArchitectureRule> ToModel(ArchitectureRuleInput[]? rules)
@@ -88,23 +88,29 @@ public static class CheckArchitectureTool
     /// rather than the page the caller happened to receive.
     /// </summary>
     internal static ToolListResult<ArchitectureViolation> BuildResult(
-        IReadOnlyList<ArchitectureViolation> raw, int rulesEvaluated, int limit)
-        => ToolListResult.Create(raw, limit, BuildSummary(raw, rulesEvaluated));
+        IReadOnlyList<ArchitectureViolation> raw, IReadOnlyList<ArchitectureRule> rules, int limit)
+        => ToolListResult.Create(raw, limit, BuildSummary(raw, rules));
 
-    internal static object BuildSummary(IReadOnlyList<ArchitectureViolation> items, int rulesEvaluated)
+    internal static object BuildSummary(
+        IReadOnlyList<ArchitectureViolation> items, IReadOnlyList<ArchitectureRule> rules)
     {
-        // Keyed by kind + from + to, not by `from` alone: two rules can share a source pattern
-        // (a `forbid` and an `allowOnly` over the same layer is a normal thing to write), and
-        // collapsing them into one bucket would silently merge their counts.
+        // Keyed by the RULE AS WRITTEN, so one rule is always one bucket. Keying on the matched
+        // `to` pattern instead split a `forbid` with several `to` patterns across several
+        // buckets while `rulesEvaluated` reported one — a summary that contradicted itself.
+        // The index is part of the key because two rules can be textually identical, and the
+        // kind/from/to text is there because an index alone tells the reader nothing.
         var byRule = items
-            .GroupBy(v => $"{v.RuleKind} {v.FromPattern} -> {v.ToPattern}", StringComparer.Ordinal)
+            .GroupBy(v => RuleKey(v.RuleIndex, rules[v.RuleIndex]), StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.Sum(v => v.ReferenceCount), StringComparer.Ordinal);
 
         return new
         {
             byRule,
             totalReferences = items.Sum(v => v.ReferenceCount),
-            rulesEvaluated,
+            rulesEvaluated = rules.Count,
         };
     }
+
+    private static string RuleKey(int index, ArchitectureRule rule)
+        => $"[{index}] {rule.Kind} {rule.From} -> {string.Join(", ", rule.To)}";
 }

--- a/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
+++ b/src/RoslynCodeLens/Tools/CheckArchitectureTool.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+using RoslynCodeLens.Models;
+
+namespace RoslynCodeLens.Tools;
+
+/// <summary>
+/// Wire shape for one rule. Kept separate from <see cref="ArchitectureRule"/> so the generated
+/// JSON schema can carry per-property descriptions without the model depending on
+/// System.ComponentModel.
+/// </summary>
+public sealed record ArchitectureRuleInput
+{
+    [Description("`forbid` or `allowOnly`.")]
+    public string Kind { get; init; } = string.Empty;
+
+    [Description("Source scope pattern: exact (`Demo.Domain`), prefix wildcard (`Demo.Domain.*`, " +
+                 "matching that scope and everything beneath it), or `*` for everything.")]
+    public string From { get; init; } = string.Empty;
+
+    [Description("Target scope patterns, same syntax as `from`. Always an array: for `forbid` give " +
+                 "the single forbidden pattern; for `allowOnly` give the full permitted set.")]
+    public string[] To { get; init; } = [];
+
+    [Description("Optional note echoed back on every violation this rule produces.")]
+    public string? Description { get; init; }
+}
+
+[McpServerToolType]
+public static class CheckArchitectureTool
+{
+    private const int DefaultLimit = 100;
+
+    [McpServerTool(Name = "check_architecture"),
+     Description("Check user-supplied layering rules against the solution's real semantic type " +
+                 "graph (resolved symbols, not `using` directives — so a fully qualified reference " +
+                 "with no `using` is still caught, and an unused `using` is not reported). " +
+                 "Rule kinds: `forbid` (a dependency from `from` to `to` is a violation) and " +
+                 "`allowOnly` (a dependency from `from` to anything outside `to` is a violation). " +
+                 "TWO SEMANTICS YOU MUST KNOW TO READ AN EMPTY RESULT CORRECTLY. " +
+                 "(1) `allowOnly` evaluates ONLY solution-internal targets: references to framework " +
+                 "and NuGet namespaces such as `System.Collections.Generic` are ignored, otherwise " +
+                 "every file would violate every `allowOnly` rule. To restrict a framework " +
+                 "namespace, write an explicit `forbid` — that path DOES evaluate metadata targets. " +
+                 "(2) Self-references are always allowed: a scope depending on itself is never a " +
+                 "violation, under either kind. " +
+                 "Results are grouped per violated `rule` plus `sourceScope` plus `targetScope` " +
+                 "edge, each with a full `referenceCount` and the first `maxSitesPerViolation` " +
+                 "sites. Sorted by rule order, then by descending reference count. Generated code " +
+                 "is skipped. Envelope adds a `byRule` / `totalReferences` / `rulesEvaluated` " +
+                 "summary.")]
+    public static ToolListResult<ArchitectureViolation> Execute(
+        MultiSolutionManager manager,
+        [Description("Layering rules to evaluate, in priority order. Each is `kind` (`forbid` or " +
+                     "`allowOnly`), `from`, `to` (array of patterns), and an optional `description`.")]
+            ArchitectureRuleInput[] rules,
+        [Description("Scope compared by the rules: `namespace` (default) or `project`.")]
+            string scope = "namespace",
+        [Description("Maximum example sites recorded per violated edge (default: 5). The full " +
+                     "reference count is reported regardless.")]
+            int maxSitesPerViolation = 5,
+        [Description("Maximum number of items to return (default: 100). Items are sorted by rule " +
+                     "order, then by descending reference count.")]
+            int? limit = null)
+    {
+        manager.EnsureLoaded();
+        var context = manager.GetAnalysisContext();
+
+        var parsed = ToModel(rules);
+        var raw = CheckArchitectureLogic.Execute(
+            context.Loaded, context.Resolver, parsed, scope, maxSitesPerViolation);
+
+        return BuildResult(raw, parsed.Count, limit ?? DefaultLimit);
+    }
+
+    internal static IReadOnlyList<ArchitectureRule> ToModel(ArchitectureRuleInput[]? rules)
+        => rules is null
+            ? []
+            : rules
+                .Select(r => new ArchitectureRule(r.Kind, r.From, r.To ?? [], r.Description))
+                .ToList();
+
+    /// <summary>
+    /// Summary is computed over the unsliced list, so `totalReferences` describes the solution
+    /// rather than the page the caller happened to receive.
+    /// </summary>
+    internal static ToolListResult<ArchitectureViolation> BuildResult(
+        IReadOnlyList<ArchitectureViolation> raw, int rulesEvaluated, int limit)
+        => ToolListResult.Create(raw, limit, BuildSummary(raw, rulesEvaluated));
+
+    internal static object BuildSummary(IReadOnlyList<ArchitectureViolation> items, int rulesEvaluated)
+    {
+        var byRule = items
+            .GroupBy(v => v.FromPattern, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Sum(v => v.ReferenceCount), StringComparer.Ordinal);
+
+        return new
+        {
+            byRule,
+            totalReferences = items.Sum(v => v.ReferenceCount),
+            rulesEvaluated,
+        };
+    }
+}

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Tests.Fixtures;
 using RoslynCodeLens.Tools;
@@ -17,9 +18,17 @@ public class CheckArchitectureFixtureTests
     private IReadOnlyList<ArchitectureViolation> Run(IReadOnlyList<ArchitectureRule> rules, string scope = "namespace")
         => CheckArchitectureLogic.Execute(_fixture.Loaded, _fixture.Resolver, rules, scope, maxSitesPerViolation: 5);
 
+    /// <summary>
+    /// XUnitFixture does not touch TestLib2. The control assertion is what makes this a test:
+    /// swap TestLib2 for TestLib — a namespace the same source really does reference — and the
+    /// same rule shape fires, so emptiness above cannot come from a walk that found nothing.
+    /// </summary>
     [Fact]
     public void ForbidARelationshipTheSolutionDoesNotHave_IsClean()
-        => Assert.Empty(Run([new ArchitectureRule("forbid", "XUnitFixture", ["TestLib2.*"])]));
+    {
+        Assert.Empty(Run([new ArchitectureRule("forbid", "XUnitFixture", ["TestLib2.*"])]));
+        Assert.NotEmpty(Run([new ArchitectureRule("forbid", "XUnitFixture", ["TestLib.*"])]));
+    }
 
     [Fact]
     public void AllowOnlyWithAnImplausibleAllowList_CatchesTheRealDependency()
@@ -56,8 +65,17 @@ public class CheckArchitectureFixtureTests
 
         var result = CheckArchitectureTool.BuildResult(raw, rules, limit: 100);
 
+        Assert.NotEmpty(raw);
         Assert.Equal(raw.Count, result.TotalCount);
         Assert.False(result.Truncated);
         Assert.NotNull(result.Summary);
+
+        // The envelope must actually describe the findings, not merely exist.
+        using var summary = JsonDocument.Parse(JsonSerializer.Serialize(result.Summary));
+        Assert.Equal(1, summary.RootElement.GetProperty("rulesEvaluated").GetInt32());
+        Assert.Equal(
+            raw.Sum(v => v.ReferenceCount),
+            summary.RootElement.GetProperty("totalReferences").GetInt32());
+        Assert.Single(summary.RootElement.GetProperty("byRule").EnumerateObject());
     }
 }

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
@@ -54,7 +54,7 @@ public class CheckArchitectureFixtureTests
         var rules = new[] { new ArchitectureRule("forbid", "XUnitFixture", ["TestLib"]) };
         var raw = Run(rules);
 
-        var result = CheckArchitectureTool.BuildResult(raw, rules.Length, limit: 100);
+        var result = CheckArchitectureTool.BuildResult(raw, rules, limit: 100);
 
         Assert.Equal(raw.Count, result.TotalCount);
         Assert.False(result.Truncated);

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureFixtureTests.cs
@@ -1,0 +1,63 @@
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+/// <summary>
+/// Read-only checks against the real TestSolution. XUnitFixture genuinely references
+/// TestLib (SampleTests news up TestLib.Greeter) and genuinely does not touch TestLib2.
+/// </summary>
+[Collection("TestSolution")]
+public class CheckArchitectureFixtureTests
+{
+    private readonly TestSolutionFixture _fixture;
+    public CheckArchitectureFixtureTests(TestSolutionFixture fixture) => _fixture = fixture;
+
+    private IReadOnlyList<ArchitectureViolation> Run(IReadOnlyList<ArchitectureRule> rules, string scope = "namespace")
+        => CheckArchitectureLogic.Execute(_fixture.Loaded, _fixture.Resolver, rules, scope, maxSitesPerViolation: 5);
+
+    [Fact]
+    public void ForbidARelationshipTheSolutionDoesNotHave_IsClean()
+        => Assert.Empty(Run([new ArchitectureRule("forbid", "XUnitFixture", ["TestLib2.*"])]));
+
+    [Fact]
+    public void AllowOnlyWithAnImplausibleAllowList_CatchesTheRealDependency()
+    {
+        var violations = Run([new ArchitectureRule("allowOnly", "XUnitFixture", ["Demo.Nothing.AtAll"])]);
+
+        var toTestLib = Assert.Single(violations, v => string.Equals(v.TargetScope, "TestLib", StringComparison.Ordinal));
+        Assert.Equal("XUnitFixture", toTestLib.SourceScope);
+        Assert.True(toTestLib.ReferenceCount >= 1);
+        Assert.NotEmpty(toTestLib.Sites);
+        Assert.EndsWith("SampleTests.cs", toTestLib.Sites[0].File, StringComparison.OrdinalIgnoreCase);
+
+        // The key semantic on a real solution: xunit's `Fact`/`Assert` live in metadata, so
+        // allowOnly must not report them despite not being on the allow-list.
+        Assert.DoesNotContain(violations, v => v.TargetScope.StartsWith("Xunit", StringComparison.Ordinal));
+        Assert.DoesNotContain(violations, v => v.TargetScope.StartsWith("System", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ProjectScope_SeesTheFixtureToTestLibEdge()
+    {
+        var violation = Assert.Single(
+            Run([new ArchitectureRule("forbid", "XUnitFixture", ["TestLib"])], scope: "project"));
+
+        Assert.Equal("XUnitFixture", violation.SourceScope);
+        Assert.Equal("TestLib", violation.TargetScope);
+    }
+
+    [Fact]
+    public void ToolWrapper_ProducesSummaryAndEnvelope()
+    {
+        var rules = new[] { new ArchitectureRule("forbid", "XUnitFixture", ["TestLib"]) };
+        var raw = Run(rules);
+
+        var result = CheckArchitectureTool.BuildResult(raw, rules.Length, limit: 100);
+
+        Assert.Equal(raw.Count, result.TotalCount);
+        Assert.False(result.Truncated);
+        Assert.NotNull(result.Summary);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -266,6 +266,39 @@ public class CheckArchitectureLogicTests
         Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
     }
 
+    // 11b — the target side. allowOnly's target set is open-ended, so generator output (regex
+    // implementations, JSON contexts, DI registries) would show up as "unlisted dependencies"
+    // the user can neither list naturally nor delete. Mirrors the metadata-target rule.
+    [Fact]
+    public void AllowOnly_IgnoresGeneratedTargets()
+    {
+        var workspace = GeneratedTargetWorkspace();
+
+        Assert.Empty(Run(workspace, [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
+    }
+
+    // 11c — the contrast, exactly as with metadata targets: an explicit `forbid` names its
+    // target, so it DOES evaluate generated ones.
+    [Fact]
+    public void Forbid_StillTargetsGeneratedCode()
+    {
+        var violation = Assert.Single(
+            Run(GeneratedTargetWorkspace(), [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+    }
+
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) GeneratedTargetWorkspace()
+        => RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.g.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? A; }
+                """) }));
+
     // 12
     [Fact]
     public void ExactPatternDoesNotMatchChildren()

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -462,6 +462,19 @@ public class CheckArchitectureLogicTests
         Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
     }
 
+    // A violation with no sites is unactionable: the caller gets an accusation and no location.
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void NonPositiveMaxSitesPerViolation_IsInvalidArgument(int maxSites)
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")], maxSitesPerViolation: maxSites));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("maxSitesPerViolation", ex.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void UnknownScope_IsInvalidArgument()
     {

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -182,6 +182,35 @@ public class CheckArchitectureLogicTests
         Assert.Equal(1, violation.ReferenceCount);
     }
 
+    // 8d — `var` is a SimpleNameSyntax whose symbol is the INFERRED type, so counting it turns
+    // one written reference into two. A human reading this method counts two dependencies on
+    // Order: the `new Order()` and the `o.Id` member access.
+    [Fact]
+    public void Var_IsNotCountedAsAReference()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo
+                {
+                    public int Load()
+                    {
+                        var o = new Demo.Domain.Order();
+                        return o.Id;
+                    }
+                }
+                """) }));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        Assert.Equal(2, violation.ReferenceCount);
+        Assert.Equal(2, violation.Sites.Count);
+    }
+
     // 9 — grouping: 5 human-visible references, sites capped at 2.
     [Fact]
     public void Grouping_CountsAllReferencesButLimitsSites()

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -139,6 +139,49 @@ public class CheckArchitectureLogicTests
         Assert.Equal("Demo.Domain", violation.TargetScope);
     }
 
+    // 8b — a `using` directive is NOT itself a dependency. The tool's description promises
+    // "an unused `using` is not reported"; a file-level using also sits in the GLOBAL namespace,
+    // so counting it accuses the wrong scope entirely.
+    [Fact]
+    public void FileLevelUsingStatic_WithNoOtherUsage_IsNotReported()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Constants.cs", """
+                namespace Demo.Domain;
+                public static class Constants { public const int Zero = 0; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                using static Demo.Domain.Constants;
+                namespace Demo.Infrastructure;
+                public class Repo { public int Id; }
+                """) }));
+
+        // `*` so the global namespace the using lives in is in scope: without the fix this
+        // reports a violation whose SourceScope is "" — an accusation against nobody.
+        Assert.Empty(Run(workspace, [Forbid("*", "Demo.Domain.*")]));
+    }
+
+    // 8c — an in-namespace using alias must not double-count the one real usage.
+    [Fact]
+    public void UsingAlias_CountsOnlyTheActualUsage()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                using Alias = Demo.Domain.Order;
+                public class Repo { public Alias? A; }
+                """) }));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+        Assert.Equal(1, violation.ReferenceCount);
+    }
+
     // 9 — grouping: 5 human-visible references, sites capped at 2.
     [Fact]
     public void Grouping_CountsAllReferencesButLimitsSites()

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -1,0 +1,351 @@
+using RoslynCodeLens.Models;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests;
+
+public class CheckArchitectureLogicTests
+{
+    private static ArchitectureRule Forbid(string from, string to, string? description = null)
+        => new("forbid", from, [to], description);
+
+    private static ArchitectureRule AllowOnly(string from, params string[] to)
+        => new("allowOnly", from, to);
+
+    /// <summary>
+    /// Two projects so cross-project edges and `scope: "project"` are real. Repo deliberately
+    /// writes `Demo.Domain.Order` fully qualified with NO using directive — the case a
+    /// usings-based scan cannot see.
+    /// </summary>
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) Layered() => RenameTestWorkspace.Create(
+        ("Domain", new[] { ("Order.cs", """
+            namespace Demo.Domain;
+            public class Order { public int Id; }
+            """) }),
+        ("Infra", new[] { ("Repo.cs", """
+            namespace Demo.Infrastructure;
+            public class Repo { public Demo.Domain.Order? Load() => null; }
+            """) }));
+
+    private static IReadOnlyList<ArchitectureViolation> Run(
+        (LoadedSolution Loaded, SymbolResolver Resolver) workspace,
+        IReadOnlyList<ArchitectureRule> rules,
+        string scope = "namespace",
+        int maxSitesPerViolation = 5)
+        => CheckArchitectureLogic.Execute(
+            workspace.Loaded, workspace.Resolver, rules, scope, maxSitesPerViolation);
+
+    // 1
+    [Fact]
+    public void Forbid_Violated()
+    {
+        var result = Run(Layered(), [Forbid("Demo.Infrastructure.*", "Demo.Domain.*", "layering")]);
+
+        var violation = Assert.Single(result);
+        Assert.Equal("forbid", violation.RuleKind);
+        Assert.Equal("layering", violation.RuleDescription);
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+        Assert.True(violation.ReferenceCount >= 1);
+
+        var site = Assert.Single(violation.Sites);
+        Assert.EndsWith("Repo.cs", site.File, StringComparison.Ordinal);
+        Assert.True(site.Line > 0);
+        Assert.True(site.Column > 0);
+        Assert.Contains("Repo", site.SourceSymbol, StringComparison.Ordinal);
+        Assert.Contains("Order", site.TargetSymbol, StringComparison.Ordinal);
+    }
+
+    // 2
+    [Fact]
+    public void Forbid_Satisfied()
+        => Assert.Empty(Run(Layered(), [Forbid("Demo.Domain.*", "Demo.Infrastructure.*")]));
+
+    // 3
+    [Fact]
+    public void AllowOnly_CatchesUnlistedDependency()
+    {
+        var violation = Assert.Single(Run(Layered(), [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
+
+        Assert.Equal("allowOnly", violation.RuleKind);
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+    }
+
+    // 4
+    [Fact]
+    public void AllowOnly_SatisfiedWhenListed()
+        => Assert.Empty(Run(Layered(), [AllowOnly("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+    // 5 — THE key semantic: allowOnly considers only solution-internal targets.
+    [Fact]
+    public void AllowOnly_IgnoresFrameworkTargets()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Bag.cs", """
+             namespace Demo.Domain;
+             public class Bag { public System.Collections.Generic.List<int>? Items; }
+             """));
+
+        Assert.Empty(Run(workspace, [AllowOnly("Demo.Domain.*", "Demo.Shared.*")]));
+    }
+
+    // 6 — the contrast: forbid DOES evaluate metadata targets.
+    [Fact]
+    public void Forbid_CanTargetFrameworkNamespace()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Bag.cs", """
+             namespace Demo.Domain;
+             public class Bag { public System.Collections.Generic.List<int>? Items; }
+             """));
+
+        var violation = Assert.Single(
+            Run(workspace, [Forbid("Demo.Domain.*", "System.Collections.Generic")]));
+
+        Assert.Equal("Demo.Domain", violation.SourceScope);
+        Assert.Equal("System.Collections.Generic", violation.TargetScope);
+    }
+
+    // 7 — self-references are never a violation, under either kind.
+    [Fact]
+    public void SelfReference_IsAllowed()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Order.cs", """
+             namespace Demo.Domain;
+             public class Order { public int Id; }
+             public class OrderService { public Order? Current; }
+             """));
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Domain.*", "Demo.Domain.*")]));
+        Assert.Empty(Run(workspace, [AllowOnly("Demo.Domain.*", "Demo.Nothing.AtAll")]));
+    }
+
+    // 8 — the test that justifies a semantic tool over the usings-based one. Do not weaken.
+    [Fact]
+    public void FullyQualifiedReference_WithNoUsing_IsDetected()
+    {
+        var workspace = Layered();
+
+        // Guard the premise: the fixture really has no using directive.
+        var repo = workspace.Loaded.Solution.Projects
+            .SelectMany(p => p.Documents)
+            .Single(d => string.Equals(d.Name, "Repo.cs", StringComparison.Ordinal));
+        Assert.DoesNotContain("using", repo.GetTextAsync().GetAwaiter().GetResult().ToString(),
+            StringComparison.Ordinal);
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+    }
+
+    // 9 — grouping: 5 human-visible references, sites capped at 2.
+    [Fact]
+    public void Grouping_CountsAllReferencesButLimitsSites()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public static readonly int Zero = 0; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo
+                {
+                    public Demo.Domain.Order? A;
+                    public Demo.Domain.Order? B;
+                    public Demo.Domain.Order? C;
+                    public int D() => Demo.Domain.Order.Zero;
+                    public int E() => Demo.Domain.Order.Zero;
+                }
+                """) }));
+
+        var violation = Assert.Single(
+            Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")], maxSitesPerViolation: 2));
+
+        Assert.Equal(5, violation.ReferenceCount);
+        Assert.Equal(2, violation.Sites.Count);
+    }
+
+    // 10
+    [Fact]
+    public void ProjectScope_UsesProjectNames()
+    {
+        var violation = Assert.Single(Run(Layered(), [Forbid("Infra", "Domain")], scope: "project"));
+
+        Assert.Equal("Infra", violation.SourceScope);
+        Assert.Equal("Domain", violation.TargetScope);
+    }
+
+    // 11
+    [Fact]
+    public void GeneratedCode_IsSkipped()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.g.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? Load() => null; }
+                """) }));
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+    }
+
+    // 12
+    [Fact]
+    public void ExactPatternDoesNotMatchChildren()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Thing.cs", """
+                namespace Demo.Domain.Orders;
+                public class Thing { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Use.cs", """
+                namespace Demo.Infrastructure;
+                public class Use { public Demo.Domain.Orders.Thing? T; }
+                """) }));
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain")]));
+        Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+    }
+
+    // 13 — error cases
+    [Fact]
+    public void EmptyRules_IsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(), []));
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public void UnknownKind_IsInvalidArgumentNamingRuleIndex()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [Forbid("Demo.Domain.*", "Demo.Infrastructure.*"), new ArchitectureRule("banish", "A", ["B"])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("1", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AllowOnlyWithEmptyTo_IsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [new ArchitectureRule("allowOnly", "Demo.Api.*", [])]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedPattern_IsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [Forbid("Demo.*.Domain", "Demo.Infrastructure.*")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+        Assert.Contains("0", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedTargetPattern_IsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [Forbid("Demo.Infrastructure.*", "*.Domain")]));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    [Fact]
+    public void UnknownScope_IsInvalidArgument()
+    {
+        var ex = Assert.Throws<McpToolException>(() => Run(Layered(),
+            [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")], scope: "assembly"));
+
+        Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    // 14
+    [Fact]
+    public void Sorting_WorstFirstWithinRuleOrder()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Types.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """), ("More.cs", """
+                namespace Demo.Shared;
+                public class Helper { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo
+                {
+                    public Demo.Domain.Order? A;
+                    public Demo.Domain.Order? B;
+                    public Demo.Shared.Helper? C;
+                }
+                """) }));
+
+        var result = Run(workspace, [
+            AllowOnly("Demo.Infrastructure.*", "Demo.Nothing"),   // rule 0 → two groups
+            Forbid("Demo.Infrastructure.*", "Demo.Shared.*"),     // rule 1 → one group
+        ]);
+
+        Assert.Equal(3, result.Count);
+        // Rule 0 first, worst group first within it.
+        Assert.Equal("allowOnly", result[0].RuleKind);
+        Assert.Equal("Demo.Domain", result[0].TargetScope);
+        Assert.Equal(2, result[0].ReferenceCount);
+        Assert.Equal("allowOnly", result[1].RuleKind);
+        Assert.Equal("Demo.Shared", result[1].TargetScope);
+        Assert.Equal(1, result[1].ReferenceCount);
+        Assert.Equal("forbid", result[2].RuleKind);
+    }
+
+    // Source-side filtering must not skip a tree that declares several namespaces,
+    // only one of which a rule cares about.
+    [Fact]
+    public void TreeWithMultipleNamespaces_IsNotSkipped()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Mixed.cs", """
+                namespace Demo.Unrelated
+                {
+                    public class Bystander { public int Id; }
+                }
+                namespace Demo.Infrastructure
+                {
+                    public class Repo { public Demo.Domain.Order? Load() => null; }
+                }
+                """) }));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+    }
+
+    // The global namespace is a real source scope, reachable via `*`.
+    [Fact]
+    public void GlobalNamespaceSource_IsAnalysedUnderMatchAll()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Loose.cs", """
+                public class Loose { public Demo.Domain.Order? Load() => null; }
+                """) }));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("*", "Demo.Domain.*")]));
+        Assert.Equal("", violation.SourceScope);
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.Json;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using RoslynCodeLens.Models;
@@ -482,6 +483,74 @@ public class CheckArchitectureLogicTests
             [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")], scope: "assembly"));
 
         Assert.Equal(ToolErrorCode.InvalidArgument, ex.Code);
+    }
+
+    // Summary buckets are per RULE AS WRITTEN. Keying on the matched `to` pattern split one
+    // forbid with several `to` patterns across several buckets while `rulesEvaluated` said 1 —
+    // the summary contradicted itself.
+    [Fact]
+    public void Summary_OneWrittenRuleIsOneBucket()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Types.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """), ("More.cs", """
+                namespace Demo.Shared;
+                public class Helper { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo
+                {
+                    public Demo.Domain.Order? A;
+                    public Demo.Shared.Helper? B;
+                }
+                """) }));
+
+        var rules = new[]
+        {
+            new ArchitectureRule("forbid", "Demo.Infrastructure.*", ["Demo.Domain.*", "Demo.Shared.*"]),
+        };
+
+        var raw = Run(workspace, rules);
+        Assert.Equal(2, raw.Count);                     // two edges...
+        Assert.All(raw, v => Assert.Equal(0, v.RuleIndex));
+
+        var byRule = ByRule(CheckArchitectureTool.BuildSummary(raw, rules));
+
+        var bucket = Assert.Single(byRule);             // ...but one rule, so one bucket
+        Assert.Equal(2, bucket.Value);
+    }
+
+    [Fact]
+    public void Summary_KeepsTwoRulesSharingAFromPatternApart()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? A; }
+                """) }));
+
+        var rules = new[]
+        {
+            new ArchitectureRule("forbid", "Demo.Infrastructure.*", ["Demo.Domain.*"]),
+            new ArchitectureRule("allowOnly", "Demo.Infrastructure.*", ["Demo.Shared.*"]),
+        };
+
+        Assert.Equal(2, ByRule(CheckArchitectureTool.BuildSummary(Run(workspace, rules), rules)).Count);
+    }
+
+    /// <summary>Reads the summary's `byRule` map off the wire shape it is actually serialized as.</summary>
+    private static IReadOnlyDictionary<string, int> ByRule(object summary)
+    {
+        using var document = JsonDocument.Parse(JsonSerializer.Serialize(summary));
+        return document.RootElement.GetProperty("byRule").EnumerateObject()
+            .ToDictionary(p => p.Name, p => p.Value.GetInt32(), StringComparer.Ordinal);
     }
 
     // 14

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -264,6 +264,94 @@ public class CheckArchitectureLogicTests
         Assert.Equal(2, violation.Sites.Count);
     }
 
+    // 8e — an object initializer's member names are not separate dependencies. A human reading
+    // `new Demo.Domain.Order { Id = 1, Name = "x" }` points at Order ONCE; counting `Id` and
+    // `Name` (whose ContainingType is Order) turns one written reference into three. Same
+    // over-count class as `var`.
+    [Fact]
+    public void ObjectInitializerMembers_AreNotCountedSeparately()
+    {
+        var violation = Assert.Single(
+            Run(InitializerWorkspace("""
+                public object Make() => new Demo.Domain.Order { Id = 1, Name = "x" };
+                """),
+                [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        Assert.Equal(1, violation.ReferenceCount);
+        Assert.Equal(1, violation.Sites.Count);
+    }
+
+    // 8f — nested and `with` initializers take the same path: the member being assigned belongs
+    // to the type the initializer is initializing, which is already counted.
+    [Fact]
+    public void NestedInitializerMembers_AreNotCountedSeparately()
+    {
+        var violation = Assert.Single(
+            Run(InitializerWorkspace("""
+                public object Make() => new Demo.Domain.Box { Inner = { Id = 1, Name = "x" } };
+                """),
+                [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        // One: the single written type name, `Demo.Domain.Box`. `Inner` is a member of the type
+        // the outer initializer initializes, and `Id`/`Name` are members of the type the NESTED
+        // one initializes, so all three are the same over-count `new Order { Id = 1 }` avoids.
+        // `Order` itself is never written here — like `var`, an inferred type is not a reference a
+        // reader would point at.
+        Assert.Equal(1, violation.ReferenceCount);
+    }
+
+    // 8g — the control for 8e: assignment to a member through a LOCAL is not an initializer and
+    // is a genuine, separately written reference. It must still count.
+    [Fact]
+    public void MemberAssignmentThroughALocal_StillCounts()
+    {
+        var violation = Assert.Single(
+            Run(InitializerWorkspace("""
+                public void Set(Demo.Domain.Order other) { other.Id = 1; }
+                """),
+                [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        // The parameter type, and the `other.Id` member access.
+        Assert.Equal(2, violation.ReferenceCount);
+    }
+
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) InitializerWorkspace(string body)
+        => RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id { get; set; } public string? Name { get; set; } }
+                public class Box { public Order Inner { get; } = new(); }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", $$"""
+                namespace Demo.Infrastructure;
+                public class Repo
+                {
+                    {{body}}
+                }
+                """) }));
+
+    // A site inside a field declaration must still name the field. GetDeclaredSymbol on a
+    // FieldDeclarationSyntax returns null (a declaration can declare several variables), so a
+    // naive walk reports an empty SourceSymbol — a violation site with no owner.
+    [Fact]
+    public void FieldDeclarationSite_NamesTheField()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? A; }
+                """) }));
+
+        var site = Assert.Single(
+            Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")])).Sites);
+
+        Assert.Equal("Demo.Infrastructure.Repo.A", site.SourceSymbol, StringComparer.Ordinal);
+    }
+
     // 9 — grouping: 5 human-visible references, sites capped at 2.
     [Fact]
     public void Grouping_CountsAllReferencesButLimitsSites()
@@ -300,6 +388,55 @@ public class CheckArchitectureLogicTests
 
         Assert.Equal("Infra", violation.SourceScope);
         Assert.Equal("Domain", violation.TargetScope);
+    }
+
+    // 10b — a LINKED file (one path, compiled into two projects) has a DIFFERENT source scope in
+    // each project under `scope: "project"`. Deduping the walk by path alone attributes it to
+    // whichever project was enumerated first and silently drops the other project's violations —
+    // exactly the case a linked-file repo would rely on the tool to catch.
+    [Fact]
+    public void LinkedFile_UnderProjectScope_IsReportedForEveryProject()
+    {
+        var violations = Run(LinkedFileWorkspace(), [Forbid("App.*", "Domain")], scope: "project");
+
+        Assert.Equal(2, violations.Count);
+        Assert.Equal(
+            new[] { "App.A", "App.B" },
+            violations.Select(v => v.SourceScope).OrderBy(s => s, StringComparer.Ordinal));
+        Assert.All(violations, v => Assert.Equal("Domain", v.TargetScope));
+    }
+
+    // 10c — the counterpart: under `scope: "namespace"` the source scope of a linked file is the
+    // SAME in every compilation, so walking it once per project would double-count a single
+    // written reference. The dedupe must still apply there.
+    [Fact]
+    public void LinkedFile_UnderNamespaceScope_IsStillCountedOnce()
+    {
+        var violation = Assert.Single(
+            Run(LinkedFileWorkspace(), [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        Assert.Equal(1, violation.ReferenceCount);
+        Assert.Equal(1, violation.Sites.Count);
+    }
+
+    /// <summary>
+    /// One source path compiled into two projects — the shape a `&lt;Compile Include="..\Shared.cs" /&gt;`
+    /// link produces. Both documents carry the identical FilePath, which is what makes them linked.
+    /// </summary>
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) LinkedFileWorkspace()
+    {
+        const string Linked = """
+            namespace Demo.Infrastructure;
+            public class Repo { public Demo.Domain.Order? A; }
+            """;
+
+        return RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("App.A", new[] { ("Shared.cs", Linked) }),
+            ("App.B", new[] { ("Shared.cs", Linked) }));
     }
 
     // 11

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using RoslynCodeLens.Models;
 using RoslynCodeLens.Tests.Fixtures;
 using RoslynCodeLens.Tools;
@@ -298,6 +301,101 @@ public class CheckArchitectureLogicTests
                 namespace Demo.Infrastructure;
                 public class Repo { public Demo.Domain.Order? A; }
                 """) }));
+
+    // 11d — "solution-internal" must not depend on HOW the solution loaded. When a
+    // ProjectReference resolves as a metadata reference instead (a real MSBuildWorkspace failure
+    // mode in this repo), Locations.IsInSource goes false and EVERY allowOnly rule over that
+    // boundary silently returns empty — indistinguishable from clean architecture.
+    [Fact]
+    public void AllowOnly_SeesTargetsWhoseProjectResolvedAsMetadata()
+    {
+        var workspace = MetadataResolvedReference();
+
+        var violation = Assert.Single(
+            Run(workspace, [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
+
+        Assert.Equal("Demo.Domain", violation.TargetScope);
+    }
+
+    [Fact]
+    public void IsSolutionInternal_TrueForMetadataTypeFromASolutionProject()
+    {
+        var workspace = MetadataResolvedReference();
+        var order = OrderAsSeenByInfra(workspace);
+
+        // Guard the premise: this really is a metadata symbol, not a source one.
+        Assert.DoesNotContain(order.Locations, l => l.IsInSource);
+        Assert.Equal("Domain", order.ContainingAssembly.Name, StringComparer.Ordinal);
+
+        Assert.True(CheckArchitectureLogic.IsSolutionInternal(
+            order, CheckArchitectureLogic.SolutionScopeNames(workspace.Loaded.Solution)));
+    }
+
+    [Fact]
+    public void IsSolutionInternal_FalseForAnAssemblyNoProjectProduces()
+    {
+        var workspace = MetadataResolvedReference();
+        var order = OrderAsSeenByInfra(workspace);
+
+        Assert.False(CheckArchitectureLogic.IsSolutionInternal(
+            order, new HashSet<string>(StringComparer.Ordinal) { "SomethingElse" }));
+    }
+
+    private static INamedTypeSymbol OrderAsSeenByInfra(
+        (LoadedSolution Loaded, SymbolResolver Resolver) workspace)
+    {
+        var infra = workspace.Loaded.Solution.Projects
+            .Single(p => string.Equals(p.Name, "Infra", StringComparison.Ordinal));
+        return workspace.Loaded.Compilations[infra.Id].GetTypeByMetadataName("Demo.Domain.Order")!;
+    }
+
+    /// <summary>
+    /// Two projects where Infra sees Domain's types ONLY through a compiled image, with no
+    /// ProjectReference — the shape a dropped project reference produces.
+    /// </summary>
+    private static (LoadedSolution Loaded, SymbolResolver Resolver) MetadataResolvedReference()
+    {
+        const string DomainSource = """
+            namespace Demo.Domain;
+            public class Order { public int Id; }
+            """;
+
+        var corlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+        var domainImage = CSharpCompilation.Create(
+            "Domain", [CSharpSyntaxTree.ParseText(DomainSource)], [corlib], options);
+        using var stream = new MemoryStream();
+        Assert.True(domainImage.Emit(stream).Success);
+        var domainMetadata = MetadataReference.CreateFromImage(stream.ToArray());
+
+        var solution = new AdhocWorkspace().CurrentSolution;
+
+        var domainId = ProjectId.CreateNewId();
+        solution = solution
+            .AddProject(ProjectInfo.Create(domainId, VersionStamp.Create(), "Domain", "Domain",
+                    LanguageNames.CSharp, compilationOptions: options)
+                .WithMetadataReferences([corlib]))
+            .AddDocument(DocumentId.CreateNewId(domainId), "Order.cs", DomainSource,
+                filePath: "Order.cs");
+
+        var infraId = ProjectId.CreateNewId();
+        solution = solution
+            .AddProject(ProjectInfo.Create(infraId, VersionStamp.Create(), "Infra", "Infra",
+                    LanguageNames.CSharp, compilationOptions: options)
+                .WithMetadataReferences([corlib, domainMetadata]))
+            .AddDocument(DocumentId.CreateNewId(infraId), "Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order A; }
+                """, filePath: "Repo.cs");
+
+        var compilations = new ConcurrentDictionary<ProjectId, Compilation>();
+        foreach (var project in solution.Projects)
+            compilations[project.Id] = project.GetCompilationAsync().GetAwaiter().GetResult()!;
+
+        var loaded = new LoadedSolution { Solution = solution, Compilations = compilations };
+        return (loaded, new SymbolResolver(loaded));
+    }
 
     // 12
     [Fact]

--- a/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
+++ b/tests/RoslynCodeLens.Tests/CheckArchitectureLogicTests.cs
@@ -60,10 +60,17 @@ public class CheckArchitectureLogicTests
         Assert.Contains("Order", site.TargetSymbol, StringComparison.Ordinal);
     }
 
-    // 2
+    // 2 — Domain does not reference Infrastructure. The second assertion is the control: the
+    // same fixture DOES produce a violation the other way round, so this test cannot pass just
+    // because Execute returned nothing.
     [Fact]
     public void Forbid_Satisfied()
-        => Assert.Empty(Run(Layered(), [Forbid("Demo.Domain.*", "Demo.Infrastructure.*")]));
+    {
+        var workspace = Layered();
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Domain.*", "Demo.Infrastructure.*")]));
+        Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+    }
 
     // 3
     [Fact]
@@ -76,10 +83,15 @@ public class CheckArchitectureLogicTests
         Assert.Equal("Demo.Domain", violation.TargetScope);
     }
 
-    // 4
+    // 4 — with the control: drop Demo.Domain from the allow-list and the same fixture fires.
     [Fact]
     public void AllowOnly_SatisfiedWhenListed()
-        => Assert.Empty(Run(Layered(), [AllowOnly("Demo.Infrastructure.*", "Demo.Domain.*")]));
+    {
+        var workspace = Layered();
+
+        Assert.Empty(Run(workspace, [AllowOnly("Demo.Infrastructure.*", "Demo.Domain.*")]));
+        Assert.Single(Run(workspace, [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
+    }
 
     // 5 — THE key semantic: allowOnly considers only solution-internal targets.
     [Fact]
@@ -92,6 +104,10 @@ public class CheckArchitectureLogicTests
              """));
 
         Assert.Empty(Run(workspace, [AllowOnly("Demo.Domain.*", "Demo.Shared.*")]));
+
+        // Control: the reference IS there and IS reachable — a `forbid` naming it fires on the
+        // very same fixture, so the emptiness above is the metadata rule, not a dead walk.
+        Assert.Single(Run(workspace, [Forbid("Demo.Domain.*", "System.Collections.Generic")]));
     }
 
     // 6 — the contrast: forbid DOES evaluate metadata targets.
@@ -124,6 +140,22 @@ public class CheckArchitectureLogicTests
 
         Assert.Empty(Run(workspace, [Forbid("Demo.Domain.*", "Demo.Domain.*")]));
         Assert.Empty(Run(workspace, [AllowOnly("Demo.Domain.*", "Demo.Nothing.AtAll")]));
+
+        // Control: the OrderService -> Order reference is real and visible. Put the two types in
+        // different namespaces and the identical rules fire — what was suppressed above is the
+        // self-reference, not the walk.
+        var split = RenameTestWorkspace.Create(
+            ("Order.cs", """
+             namespace Demo.Domain;
+             public class Order { public int Id; }
+             """),
+            ("Service.cs", """
+             namespace Demo.Services;
+             public class OrderService { public Demo.Domain.Order? Current; }
+             """));
+
+        Assert.Single(Run(split, [Forbid("Demo.Services.*", "Demo.Domain.*")]));
+        Assert.Single(Run(split, [AllowOnly("Demo.Services.*", "Demo.Nothing.AtAll")]));
     }
 
     // 8 — the test that justifies a semantic tool over the usings-based one. Do not weaken.
@@ -163,6 +195,23 @@ public class CheckArchitectureLogicTests
         // `*` so the global namespace the using lives in is in scope: without the fix this
         // reports a violation whose SourceScope is "" — an accusation against nobody.
         Assert.Empty(Run(workspace, [Forbid("*", "Demo.Domain.*")]));
+
+        // Control: add one real use of what the using imports and exactly one violation appears,
+        // attributed to the DECLARING namespace rather than the global one.
+        var used = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Constants.cs", """
+                namespace Demo.Domain;
+                public static class Constants { public const int Zero = 0; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                using static Demo.Domain.Constants;
+                namespace Demo.Infrastructure;
+                public class Repo { public int Id = Zero; }
+                """) }));
+
+        var violation = Assert.Single(Run(used, [Forbid("*", "Demo.Domain.*")]));
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+        Assert.Equal(1, violation.ReferenceCount);
     }
 
     // 8c — an in-namespace using alias must not double-count the one real usage.
@@ -268,6 +317,20 @@ public class CheckArchitectureLogicTests
                 """) }));
 
         Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+
+        // Control: the identical file under a non-generated name DOES violate, so the emptiness
+        // above is the generated-source skip and nothing else.
+        var handWritten = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? Load() => null; }
+                """) }));
+
+        Assert.Single(Run(handWritten, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
     }
 
     // 11b — the target side. allowOnly's target set is open-ended, so generator output (regex
@@ -279,6 +342,20 @@ public class CheckArchitectureLogicTests
         var workspace = GeneratedTargetWorkspace();
 
         Assert.Empty(Run(workspace, [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
+
+        // Control: an identical allowOnly over the same fixture with the target hand-written
+        // DOES fire, so the emptiness above is the generated-target rule, not a dead walk.
+        var handWritten = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure;
+                public class Repo { public Demo.Domain.Order? A; }
+                """) }));
+
+        Assert.Single(Run(handWritten, [AllowOnly("Demo.Infrastructure.*", "Demo.Shared.*")]));
     }
 
     // 11c — the contrast, exactly as with metadata targets: an explicit `forbid` names its
@@ -414,6 +491,41 @@ public class CheckArchitectureLogicTests
 
         Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain")]));
         Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+    }
+
+    // 12b — the FROM side, end to end. Nothing else pins that an exact `from` is exact: every
+    // other from-pattern in this file is a wildcard, so a prefix-matching bug would go unseen.
+    // "Demo.Infra" must not match the source scope "Demo.Infrastructure".
+    [Fact]
+    public void ExactFromPattern_DoesNotPrefixMatchALongerSourceScope()
+    {
+        var workspace = Layered();
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Infra", "Demo.Domain.*")]));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure", "Demo.Domain.*")]));
+        Assert.Equal("Demo.Infrastructure", violation.SourceScope);
+    }
+
+    // 12c — and the from side must not match a CHILD of an exact pattern either, while the
+    // wildcard form does.
+    [Fact]
+    public void ExactFromPattern_DoesNotMatchChildScopes()
+    {
+        var workspace = RenameTestWorkspace.Create(
+            ("Domain", new[] { ("Order.cs", """
+                namespace Demo.Domain;
+                public class Order { public int Id; }
+                """) }),
+            ("Infra", new[] { ("Repo.cs", """
+                namespace Demo.Infrastructure.Persistence;
+                public class Repo { public Demo.Domain.Order? A; }
+                """) }));
+
+        Assert.Empty(Run(workspace, [Forbid("Demo.Infrastructure", "Demo.Domain.*")]));
+
+        var violation = Assert.Single(Run(workspace, [Forbid("Demo.Infrastructure.*", "Demo.Domain.*")]));
+        Assert.Equal("Demo.Infrastructure.Persistence", violation.SourceScope);
     }
 
     // 13 — error cases

--- a/tests/RoslynCodeLens.Tests/ScopePatternTests.cs
+++ b/tests/RoslynCodeLens.Tests/ScopePatternTests.cs
@@ -1,0 +1,41 @@
+using RoslynCodeLens.Analysis;
+
+namespace RoslynCodeLens.Tests;
+
+public class ScopePatternTests
+{
+    [Theory]
+    // exact
+    [InlineData("Demo.Domain", "Demo.Domain", true)]
+    [InlineData("Demo.Domain", "Demo.Domain.Orders", false)]   // exact does NOT match children
+    [InlineData("Demo.Domain", "Demo.DomainX", false)]
+    // prefix wildcard: the scope itself AND everything beneath it
+    [InlineData("Demo.Domain.*", "Demo.Domain", true)]
+    [InlineData("Demo.Domain.*", "Demo.Domain.Orders", true)]
+    [InlineData("Demo.Domain.*", "Demo.Domain.Orders.Rules", true)]
+    [InlineData("Demo.Domain.*", "Demo.DomainX", false)]        // not a segment boundary
+    [InlineData("Demo.Domain.*", "Demo.Infrastructure", false)]
+    // case sensitivity: C# namespaces are case-sensitive
+    [InlineData("Demo.Domain", "demo.domain", false)]
+    // match-all
+    [InlineData("*", "Anything.At.All", true)]
+    [InlineData("*", "", true)]
+    public void Matches(string pattern, string scope, bool expected)
+        => Assert.Equal(expected, ScopePattern.Matches(pattern, scope));
+
+    [Theory]
+    [InlineData("Demo.*.Orders")]   // interior wildcard unsupported
+    [InlineData("*.Orders")]        // suffix wildcard unsupported
+    [InlineData("Demo.Domain*")]    // wildcard not on a segment boundary
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RejectsMalformedPatterns(string pattern)
+        => Assert.False(ScopePattern.IsValid(pattern));
+
+    [Theory]
+    [InlineData("Demo.Domain")]
+    [InlineData("Demo.Domain.*")]
+    [InlineData("*")]
+    public void AcceptsWellFormedPatterns(string pattern)
+        => Assert.True(ScopePattern.IsValid(pattern));
+}

--- a/tools/DocGen/Program.cs
+++ b/tools/DocGen/Program.cs
@@ -44,6 +44,7 @@ var categoryMap = new Dictionary<string, string>(StringComparer.Ordinal)
     ["find_naming_violations"]     = "code-quality",
     ["find_large_classes"]         = "code-quality",
     ["find_circular_dependencies"] = "code-quality",
+    ["check_architecture"]         = "code-quality",
     ["find_reflection_usage"]      = "code-quality",
     ["get_di_registrations"]       = "di-dependencies",
     ["get_nuget_dependencies"]     = "di-dependencies",


### PR DESCRIPTION
## Summary
The 65th tool. `find_circular_dependencies` catches cycles; layering violations ("Domain must not reference Infrastructure") went undetected until now.

- **Two rule kinds**, supplied inline: `forbid` catches the violation you already know about; `allowOnly` catches the dependencies you haven't thought of, which is what actually prevents drift.
- **Edges come from resolved symbols, not `using` directives** — so a fully qualified reference with no `using` is caught, and an unused `using` is not reported. That distinction is the reason this tool isn't just a rule layer over `find_circular_dependencies`, and there's a test named for it.
- **Grouped output**: one item per violated `(rule, sourceScope → targetScope)` edge with a full `referenceCount` and the first `maxSitesPerViolation` sites, so a stray cross-boundary reference is one actionable item rather than hundreds.
- **Cost tracks the rules, not the solution**: a tree whose scopes match no rule's `from` is skipped before a semantic model is ever created.

### Two semantics documented everywhere they're visible
`allowOnly` evaluates only targets the caller can act on — solution-internal and not pure generator output — because otherwise `using System;` violates every rule and generator output shows up as a dependency nobody can remove. `forbid` names its target explicitly, so it *does* evaluate metadata and generated ones. Self-references are never violations. An agent that doesn't know both will misread an empty result, so they're in the tool description, SKILL.md, and the design doc.

## Test Plan
- [x] Full suite **988/988** (6m18s clean; an earlier 43-minute run was machine contention from concurrent review agents, confirmed by re-measuring)
- [x] Pre-merge high-effort review; **all 7 findings fixed in-branch**, four confirmed by running the tool: `using` directives counted as dependencies (blaming the global namespace), `var` counted as a reference, generator output reported under `allowOnly`, `maxSitesPerViolation: 0` yielding siteless accusations, a `byRule` bucketing bug, a load-dependent internal/external check, and vacuous negative tests
- [x] Negative tests now carry positive controls — verified by mutation: stubbing `Execute` to return empty fails 29 of 39 tests (previously 12 still passed)
- [x] Fixture-pristine check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)