### PR TITLE
fix(deps): pin fast-uri 3.1.4 and svgo 3.3.4 to clear the last advisories

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -9993,9 +9993,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -18554,9 +18554,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -39,7 +39,9 @@
     "joi": "^18.0.0",
     "http-proxy-middleware": "^4.0.0",
     "@babel/core": "^8.0.0",
-    "brace-expansion": "^1.1.16"
+    "brace-expansion": "^1.1.16",
+    "fast-uri": "^3.1.4",
+    "svgo": "^3.3.4"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Clears the three remaining high-severity Dependabot alerts. Both packages are transitive to the docs site.

| Package | Was | Now | Advisory |
|---|---|---|---|
| `fast-uri` | 3.1.2 | **3.1.4** | host confusion via failed IDN canonicalization; and via literal backslash authority delimiter |
| `svgo` | 3.3.3 | **3.3.4** | `removeScripts` plugin leaves some executable scripts intact |

Dependency paths:
- `fast-uri` — `@docusaurus/core` → `webpack-dev-server` → `schema-utils` → `ajv`
- `svgo` — `cssnano-preset-default` → `postcss-svgo`, and `@docusaurus/plugin-svgr` → `@svgr/webpack` → `@svgr/plugin-svgo`

Both fixes are **patch bumps inside the major their dependents require**. `svgo` 4.x exists, but both consumers ask for `^3`, so pinning `^3.3.4` clears the advisory without forcing a major anywhere in the tree — same approach as #329 and #285.

## Test Plan

- [x] `npm audit` — **0 vulnerabilities** (was 3 high)
- [x] `npm ci` clean
- [x] `npm run build` succeeds. This one matters rather than being a formality: `svgo` sits in the SVG optimisation pipeline for both `postcss-svgo` and `@svgr/webpack`, so a bad bump would surface at build time
- [x] Confirmed the patched versions are published on the 3.x line before writing the overrides, rather than trusting the advisory's "fixed in" to be in-range

With this merged, the repo has no open Dependabot alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)