### PR TITLE
test(fixture): probe the metadata path before declaring the load healthy

### DIFF
--- a/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/TestSolutionFixture.cs
@@ -49,10 +49,14 @@ public class TestSolutionFixture : IAsyncLifetime
         {
             Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
             var resolver = new SymbolResolver(Loaded);
-            if (FixtureIsHealthy(Loaded, resolver, out problem))
+            // Built before the probe rather than after it, because one of the invariants runs
+            // through the metadata resolver — a path that was previously unprobed, and the one
+            // that kept flaking.
+            var metadata = new MetadataSymbolResolver(Loaded, resolver);
+            if (FixtureIsHealthy(Loaded, resolver, metadata, out problem))
             {
                 Resolver = resolver;
-                Metadata = new MetadataSymbolResolver(Loaded, Resolver);
+                Metadata = metadata;
                 return;
             }
         }
@@ -60,7 +64,9 @@ public class TestSolutionFixture : IAsyncLifetime
         throw new InvalidOperationException(
             $"TestSolution failed to load healthily after {MaxLoadAttempts} attempts: {problem}. " +
             "This is the MSBuildWorkspace design-time build flake from #260 — a fixture project's references were " +
-            "dropped, so [Fact]/[Test]/[TestMethod] or the call into TestLib.Greeter did not bind and discovery returns nothing.");
+            "dropped, so [Fact]/[Test]/[TestMethod] or the call into TestLib.Greeter did not bind and discovery returns " +
+            "nothing, or TestLib's framework references went and metadata types such as System.ObsoleteAttribute no " +
+            "longer resolve.");
     }
 
     /// <summary>
@@ -74,8 +80,21 @@ public class TestSolutionFixture : IAsyncLifetime
     /// A load that fails either dropped references — the caller retries on a fresh
     /// workspace. Checking coverage as well as discovery matters: the two use slightly
     /// different reference queries, and a load can satisfy one while degrading the other.
+    /// <para>
+    /// A third invariant covers the METADATA path, which the two above never touch: both
+    /// rest on the test→TestLib.Greeter <em>project</em> reference, so a load that drops
+    /// TestLib's framework references passes them while `System.ObsoleteAttribute` no longer
+    /// resolves. That gap let
+    /// <c>FindAttributeUsages_FullyQualifiedMetadata_FindsUsage</c> fail intermittently on CI
+    /// (twice in two days, on unrelated commits) with "Collection was empty" — the fixture
+    /// declared itself healthy and handed the test a solution that could not answer.
+    /// </para>
     /// </summary>
-    private static bool FixtureIsHealthy(LoadedSolution loaded, SymbolResolver resolver, out string problem)
+    private static bool FixtureIsHealthy(
+        LoadedSolution loaded,
+        SymbolResolver resolver,
+        MetadataSymbolResolver metadata,
+        out string problem)
     {
         var discovery = FindTestsForSymbolLogic.Execute(loaded, resolver, "Greeter.Greet", transitive: false, maxDepth: 3);
         var found = discovery.DirectTests.Select(t => t.Framework).ToHashSet();
@@ -91,6 +110,18 @@ public class TestSolutionFixture : IAsyncLifetime
         if (coverage.UncoveredSymbols.Any(s => string.Equals(s.Symbol, "Greeter.Greet", StringComparison.Ordinal)))
         {
             problem = "Greeter.Greet is reported uncovered despite having test callers (coverage reference query degraded)";
+            return false;
+        }
+
+        // Greeter.OldGreet carries [Obsolete], so resolving System.ObsoleteAttribute out of
+        // metadata and scanning for its usages must find it. Empty here means TestLib's
+        // framework references were dropped: the attribute type itself no longer resolves.
+        var attributeUsages = FindAttributeUsagesLogic.Execute(
+            loaded, resolver, metadata, "System.ObsoleteAttribute");
+        if (!attributeUsages.Any(u => u.TargetName.Contains("OldGreet", StringComparison.Ordinal)))
+        {
+            problem = $"System.ObsoleteAttribute usages do not include Greeter.OldGreet " +
+                      $"(found {attributeUsages.Count}) — the metadata reference set was degraded";
             return false;
         }
 


### PR DESCRIPTION
## The flake

`FindAttributeUsagesToolTests.FindAttributeUsages_FullyQualifiedMetadata_FindsUsage` has failed intermittently on CI with `Assert.NotEmpty() Failure: Collection was empty` — twice in two days, on unrelated commits ([main run 29836104996](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/actions/runs/29836104996), then on #329, which changed only `docs/site/package-lock.json` and so could not have caused it).

## Why the existing probe missed it

`TestSolutionFixture` already retries on a fresh workspace until the load looks healthy — the fix from #260. But both of its invariants rest on **the same** thing resolving, the `test → TestLib.Greeter` **project** reference:

- `Greeter.Greet` has a direct test caller in every framework fixture
- `Greeter.Greet` is not reported uncovered

Neither touches **metadata**. So when the design-time build dropped TestLib's *framework* references, both invariants still held, the fixture declared itself healthy, and it handed tests a solution where `System.ObsoleteAttribute` could not resolve. The test then failed with an empty collection and no explanation.

## The fix

A third invariant covering that path: `Greeter.OldGreet` carries `[Obsolete]`, so resolving `System.ObsoleteAttribute` out of metadata and scanning for usages must find it. A load that fails is retried like the other two cases, and the exhaustion diagnostic now names this cause too.

`MetadataSymbolResolver` is also constructed **before** the probe instead of after — previously it was built only once the load had already been declared healthy, so the probe structurally could not have tested this path.

## Test Plan

- [x] **Verified load-bearing, not decorative.** Pointed the probe at a non-existent attribute: the fixture exhausted all 6 attempts and threw its diagnostic instead of continuing. A probe that cannot fail is not a probe — this repo has shipped two vacuous tests before, so this check was explicit
- [x] Targeted: 7 `FindAttributeUsages` tests, 26 fixture-dependent tests (discovery + coverage families) pass
- [x] Full suite run three times

## Honest note on the suite runs

Three full runs on this branch: **2 failures, then 0, then 1**. None were fixture-family tests, and the one captured by name was `TrustStoreTests.AddPersistentTrust_IsIdempotent` — `UnauthorizedAccessException` from `File.Move` in `TrustStore.SaveToDisk`, a Windows file-lock race unrelated to this change (a scanner holding the just-written `.tmp` between `WriteAllText` and `Move`, which has no retry). Filed as a separate follow-up rather than folded in here.

So this change is green on the tests it concerns, but I am **not** claiming it eliminates all suite flakiness — only this one cause, which is now checked instead of assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)