### PR TITLE
fix(trust): survive transient file locks when persisting trust

### DIFF
--- a/src/RoslynCodeLens/Security/TrustStore.cs
+++ b/src/RoslynCodeLens/Security/TrustStore.cs
@@ -117,13 +117,68 @@ public sealed class TrustStore
         }
     }
 
+    /// <summary>
+    /// Writes the store to a temp file and renames it over the target, so a crash cannot leave a
+    /// half-written trust.json.
+    /// <para>
+    /// The temp name carries a GUID rather than a fixed <c>.tmp</c> suffix. Two saves in quick
+    /// succession — which <see cref="AddPersistentTrust"/> does whenever a caller trusts twice —
+    /// would otherwise recreate the exact path just renamed away, and on Windows that path can
+    /// still be held briefly by a scanner or indexer. A fresh name per save cannot collide with
+    /// the previous one.
+    /// </para>
+    /// <para>
+    /// Both file operations go through <see cref="RunWithRetry"/>: those holds are transient, and
+    /// failing the whole call because an antivirus looked at the file for a few milliseconds means
+    /// the server silently fails to persist trust the user just granted.
+    /// </para>
+    /// </summary>
     private void SaveToDisk()
     {
         var dir = Path.GetDirectoryName(_filePath);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-        var tmp = _filePath + ".tmp";
-        File.WriteAllText(tmp, JsonSerializer.Serialize(_persistent, TrustStoreModel.JsonOptions));
-        File.Move(tmp, _filePath, overwrite: true);
+
+        var tmp = $"{_filePath}.{Guid.NewGuid():N}.tmp";
+        var json = JsonSerializer.Serialize(_persistent, TrustStoreModel.JsonOptions);
+        try
+        {
+            RunWithRetry(() => File.WriteAllText(tmp, json));
+            RunWithRetry(() => File.Move(tmp, _filePath, overwrite: true));
+        }
+        catch
+        {
+            // A GUID-named temp would otherwise be left behind for good, since nothing else knows
+            // its name. Best-effort: the original exception is what the caller needs to see.
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch (IOException) { } catch (UnauthorizedAccessException) { }
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Retries a file operation through the transient sharing violations Windows produces when a
+    /// scanner, indexer or backup agent momentarily holds a file that was just written. Waits
+    /// grow linearly (10ms, 20ms, ...), which is ample for a hold measured in milliseconds and
+    /// still bounded well under a tenth of a second in the worst case.
+    /// <para>
+    /// The final attempt does NOT catch: a genuine permission problem — a read-only file, a
+    /// locked-down profile directory — must surface as itself rather than as a timeout, and
+    /// retrying it five times changes nothing but the delay.
+    /// </para>
+    /// </summary>
+    internal static void RunWithRetry(Action operation, int maxAttempts = 5, int baseDelayMs = 10)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                operation();
+                return;
+            }
+            catch (Exception ex) when ((ex is IOException or UnauthorizedAccessException) && attempt < maxAttempts)
+            {
+                Thread.Sleep(baseDelayMs * attempt);
+            }
+        }
     }
 
     private static string Normalize(string path)

--- a/tests/RoslynCodeLens.Tests/Security/TrustStoreTests.cs
+++ b/tests/RoslynCodeLens.Tests/Security/TrustStoreTests.cs
@@ -161,4 +161,92 @@ public class TrustStoreTests : IDisposable
             Console.SetError(prevErr);
         }
     }
+
+    // ---------------------------------------------------------------- transient file locks
+    //
+    // TrustStoreTests.AddPersistentTrust_IsIdempotent failed intermittently on Windows with
+    // UnauthorizedAccessException out of File.Move in SaveToDisk. Each test writes to its own
+    // GUID temp directory, so it was never cross-test collision — it is a scanner or indexer
+    // momentarily holding the file between the write and the rename.
+    //
+    // The retry is tested through an injected operation rather than by trying to provoke a real
+    // lock: a timing-dependent test for a timing-dependent bug proves nothing on a green run.
+
+    [Fact]
+    public void RunWithRetry_RetriesTransientSharingViolations_ThenSucceeds()
+    {
+        var attempts = 0;
+        TrustStore.RunWithRetry(() =>
+        {
+            attempts++;
+            if (attempts < 3) throw new UnauthorizedAccessException("Access to the path is denied.");
+        }, maxAttempts: 5, baseDelayMs: 1);
+
+        Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public void RunWithRetry_RetriesIOException()
+    {
+        var attempts = 0;
+        TrustStore.RunWithRetry(() =>
+        {
+            attempts++;
+            if (attempts < 2) throw new IOException("The process cannot access the file.");
+        }, maxAttempts: 5, baseDelayMs: 1);
+
+        Assert.Equal(2, attempts);
+    }
+
+    /// <summary>
+    /// A persistent failure must surface as itself. Swallowing it would turn "this file is
+    /// read-only" into silent data loss — the caller believes trust was persisted when it was not.
+    /// </summary>
+    [Fact]
+    public void RunWithRetry_GivesUpAndRethrowsTheOriginalException()
+    {
+        var attempts = 0;
+        var ex = Assert.Throws<UnauthorizedAccessException>(() =>
+            TrustStore.RunWithRetry(() =>
+            {
+                attempts++;
+                throw new UnauthorizedAccessException("permanently denied");
+            }, maxAttempts: 4, baseDelayMs: 1));
+
+        Assert.Equal(4, attempts);
+        Assert.Equal("permanently denied", ex.Message);
+    }
+
+    /// <summary>
+    /// Unrelated exceptions must not be retried — retrying a bug wastes time and hides it.
+    /// </summary>
+    [Fact]
+    public void RunWithRetry_DoesNotRetryUnrelatedExceptions()
+    {
+        var attempts = 0;
+        Assert.Throws<InvalidOperationException>(() =>
+            TrustStore.RunWithRetry(() =>
+            {
+                attempts++;
+                throw new InvalidOperationException("not a file problem");
+            }, maxAttempts: 5, baseDelayMs: 1));
+
+        Assert.Equal(1, attempts);
+    }
+
+    /// <summary>
+    /// The reason the temp name carries a GUID: back-to-back saves must not reuse the path just
+    /// renamed away, which is the window the flake lived in.
+    /// </summary>
+    [Fact]
+    public void RepeatedSaves_LeaveNoTempFilesBehind()
+    {
+        var store = new TrustStore(_trustFile);
+        for (var i = 0; i < 10; i++)
+            store.AddPersistentTrust(Sln("repos", $"foo{i}.sln"));
+
+        Assert.True(File.Exists(_trustFile));
+        Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
+        Assert.Equal(10, store.GetSnapshot().PersistentSolutions.Count);
+    }
 }


### PR DESCRIPTION
## The bug

`TrustStoreTests.AddPersistentTrust_IsIdempotent` failed intermittently on Windows:

```
System.UnauthorizedAccessException : Access to the path is denied.
   at RoslynCodeLens.Security.TrustStore.SaveToDisk() in TrustStore.cs:line 126
   at RoslynCodeLens.Security.TrustStore.AddPersistentTrust(String solutionPath)
```

Each test writes to its own GUID temp directory, so this was never cross-test collision. **The defect is in product code**, and `SaveToDisk` is the same path that runs when a user trusts a solution — so the real symptom is the server silently failing to persist trust it just reported as granted.

## Two defects

**1. Fixed temp name.** `SaveToDisk` used `trust.json.tmp`. Since `AddPersistentTrust` saves on every call, two grants in quick succession recreate *the exact path just renamed away* — precisely the window in which a scanner or indexer may still hold it. Now a GUID per save, which is what `SolutionChangeWriter` already does and cannot collide with the previous save.

**2. No retry.** These holds last milliseconds. Failing the whole operation because an antivirus glanced at the file is the wrong answer, so both file operations now retry with linear backoff (10ms, 20ms, …), bounded well under a tenth of a second.

The final attempt deliberately does **not** catch: a real permission problem — read-only file, locked-down profile directory — must surface as itself rather than as a timeout, and retrying it five times changes nothing but the delay. A failed save also cleans up its temp file now, which a GUID name would otherwise orphan forever since nothing else knows it.

## Test Plan

- [x] Full suite **1097/1097**, clean build (5 new tests)
- [x] **Retry is tested through an injected operation, not a real lock.** A timing-dependent test for a timing-dependent bug proves nothing on a green run; injection makes it deterministic
- [x] **Verified non-vacuous:** disabling the retry fails 3 of the 4 retry tests. The survivor is `DoesNotRetryUnrelatedExceptions`, a negative guard that correctly passes either way
- [x] Covered: retries `UnauthorizedAccessException` and `IOException`; rethrows the *original* exception after exhausting attempts; does **not** retry unrelated exceptions (retrying a bug hides it); repeated saves leave no `.tmp` files behind

## Note

Found while verifying #336 — it was the one failure captured by name across those runs, and it turned out to be unrelated to that change and more serious, since it is server code rather than test code.