### PR TITLE
feat: publish an npm launcher package for npx installs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - uses: actions/setup-node@v7
+        with:
+          # npm >= 11.5.1 is required for trusted publishing (OIDC); Node 24 ships it.
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
       - name: Build
         run: dotnet build -c Release -p:Version=${{ needs.release-please.outputs.version }}
 
@@ -51,6 +57,14 @@ jobs:
         # No --skip-duplicate: if the release version already exists on NuGet, fail loudly
         # rather than silently masking a version collision (see #225).
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+      # The npm package is a launcher that installs the NuGet tool at a matching
+      # version, so it must be published after the NuGet push, never before.
+      # Trusted publishing (OIDC) — no NODE_AUTH_TOKEN; uses the workflow-level
+      # `id-token: write` permission.
+      - name: Publish to npm
+        working-directory: npm
+        run: npm publish --provenance --access public
 
       - name: Upload to GitHub Release
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ./nupkg/*.nupkg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      # Required for npm publish --provenance
+      id-token: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -18,6 +23,13 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          # npm >= 11.5.1 is required for trusted publishing (OIDC); Node 24 ships it.
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Restore tools
         run: dotnet tool restore
@@ -48,3 +60,13 @@ jobs:
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+      # The npm package is a launcher that installs the NuGet tool at a matching
+      # version, so it must be published after the NuGet push, never before.
+      - name: Publish to npm
+        # Trusted publishing (OIDC) — no NODE_AUTH_TOKEN, same as LongtermMemory-MCP.
+        # Requires the job-level `id-token: write` permission above.
+        working-directory: npm
+        run: |
+          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      # Required for npm publish --provenance
-      id-token: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -23,13 +18,6 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
-
-      - name: Setup Node
-        uses: actions/setup-node@v7
-        with:
-          # npm >= 11.5.1 is required for trusted publishing (OIDC); Node 24 ships it.
-          node-version: 24
-          registry-url: https://registry.npmjs.org
 
       - name: Restore tools
         run: dotnet tool restore
@@ -60,13 +48,3 @@ jobs:
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-
-      # The npm package is a launcher that installs the NuGet tool at a matching
-      # version, so it must be published after the NuGet push, never before.
-      - name: Publish to npm
-        # Trusted publishing (OIDC) — no NODE_AUTH_TOKEN, same as LongtermMemory-MCP.
-        # Requires the job-level `id-token: write` permission above.
-        working-directory: npm
-        run: |
-          npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
-          npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ BenchmarkDotNet.Artifacts/
 # Git worktrees
 .worktrees/
 
+# npm launcher package. The `bin/` rule above is meant for .NET build output; npm/bin
+# holds the launcher script and must be tracked. Git cannot re-include a file whose
+# parent directory is excluded, so the directory itself has to be negated first.
+!npm/bin/
+npm/node_modules/
+npm/*.tgz
+
 # Docusaurus
 docs/site/node_modules/
 docs/site/build/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/RoslynCodeLens.Mcp?style=flat-square&logo=nuget&color=blue)](https://www.nuget.org/packages/RoslynCodeLens.Mcp)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/RoslynCodeLens.Mcp?style=flat-square&color=green)](https://www.nuget.org/packages/RoslynCodeLens.Mcp)
+[![npm](https://img.shields.io/npm/v/roslyn-codelens-mcp?style=flat-square&logo=npm&color=cb3837)](https://www.npmjs.com/package/roslyn-codelens-mcp)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/MarcelRoozekrans/roslyn-codelens-mcp/ci.yml?branch=main&style=flat-square&logo=github)](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/actions)
 [![License](https://img.shields.io/github/license/MarcelRoozekrans/roslyn-codelens-mcp?style=flat-square)](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue?style=flat-square)](https://marcelroozekrans.github.io/roslyn-codelens-mcp/)
@@ -170,6 +171,24 @@ Use the `list_trusted_paths` and `revoke_trust` tools to inspect and manage trus
 See [SECURITY.md](SECURITY.md) for the full threat model.
 
 ## Quick Start
+
+### npx (any MCP client)
+
+```json
+{
+  "mcpServers": {
+    "roslyn-codelens": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "roslyn-codelens-mcp"]
+    }
+  }
+}
+```
+
+The npm package ships no server code — it is a launcher that installs the `RoslynCodeLens.Mcp`
+.NET global tool at a matching version and execs it, so the **.NET 10 SDK must be on `PATH`**.
+Subsequent starts skip the install entirely and work offline.
 
 ### VS Code / Visual Studio (via dnx)
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,39 @@
+# roslyn-codelens-mcp
+
+npm launcher for [Roslyn CodeLens](https://github.com/MarcelRoozekrans/roslyn-codelens-mcp) — a Roslyn-based MCP server that gives AI agents deep semantic understanding of .NET codebases.
+
+```bash
+npx -y roslyn-codelens-mcp
+```
+
+This package contains no server code. It is a thin shim that ensures the
+[`RoslynCodeLens.Mcp`](https://www.nuget.org/packages/RoslynCodeLens.Mcp) .NET global tool is
+installed at the matching version, then execs it. **The .NET 10 SDK must be on `PATH`.**
+
+## MCP client config
+
+```json
+{
+  "mcpServers": {
+    "roslyn-codelens": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "roslyn-codelens-mcp"]
+    }
+  }
+}
+```
+
+Solution paths can be passed as extra `args`; without them the server walks up from the working
+directory to discover `.sln`/`.slnx` files.
+
+If you already have the .NET SDK and prefer no npm indirection, install the tool directly:
+
+```bash
+dotnet tool install -g RoslynCodeLens.Mcp
+```
+
+See the [full documentation](https://marcelroozekrans.github.io/roslyn-codelens-mcp/) for the tool
+catalog, runtime configuration, and the analyzer trust model.
+
+MIT licensed.

--- a/npm/bin/roslyn-codelens-mcp.js
+++ b/npm/bin/roslyn-codelens-mcp.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+// Launcher for the RoslynCodeLens.Mcp .NET global tool.
+//
+// This package ships no server code. It exists so the server can be started with
+// `npx -y roslyn-codelens-mcp` by clients and directories that only know how to run
+// npm-hosted MCP servers. Everything it does is: verify the .NET SDK is present,
+// make sure the global tool matches this package's version, then exec it.
+//
+// stdout is the JSON-RPC channel, so every diagnostic and every byte of dotnet's
+// install output goes to stderr.
+
+const { execFileSync, spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const PACKAGE_ID = "RoslynCodeLens.Mcp";
+const COMMAND = "roslyn-codelens-mcp";
+const { version } = require("../package.json");
+
+function fail(message) {
+  process.stderr.write(`roslyn-codelens-mcp: ${message}\n`);
+  process.exit(1);
+}
+
+function hasDotnet() {
+  try {
+    execFileSync("dotnet", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The installed version of the global tool, or null when it is not installed.
+// `dotnet tool list --global` lowercases the package id and prints it as
+// `roslyncodelens.mcp   2.14.0   roslyn-codelens-mcp`. Local lookup — no network.
+function installedVersion() {
+  try {
+    const output = execFileSync("dotnet", ["tool", "list", "--global"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    for (const line of output.split("\n")) {
+      const match = line.match(/^roslyncodelens\.mcp\s+(\S+)/i);
+      if (match) {
+        return match[1];
+      }
+    }
+  } catch {
+    // dotnet missing or the command failed — treat the tool as not installed.
+  }
+  return null;
+}
+
+// `dotnet tool install` fails when a different version is already present, so the
+// verb depends on what is there. Output is routed to stderr (fd 2) rather than
+// captured so a slow first-run restore still shows progress.
+function install(alreadyInstalled) {
+  const verb = alreadyInstalled ? "update" : "install";
+  process.stderr.write(
+    `roslyn-codelens-mcp: ${verb === "install" ? "installing" : "updating"} ${PACKAGE_ID} ${version}...\n`
+  );
+  execFileSync(
+    "dotnet",
+    ["tool", verb, "--global", PACKAGE_ID, "--version", version],
+    { stdio: ["ignore", 2, 2] }
+  );
+}
+
+// Global tools land in ~/.dotnet/tools, which is not necessarily on PATH — notably
+// in the same process that just installed them. Resolve the executable directly and
+// prepend the directory for the child so any tool-to-tool lookup also works.
+function toolsDir() {
+  return (
+    process.env.DOTNET_TOOLS_PATH ||
+    path.join(process.env.DOTNET_CLI_HOME || os.homedir(), ".dotnet", "tools")
+  );
+}
+
+function resolveExecutable() {
+  const dir = toolsDir();
+  const name = process.platform === "win32" ? `${COMMAND}.exe` : COMMAND;
+  const candidate = path.join(dir, name);
+  return fs.existsSync(candidate) ? candidate : COMMAND;
+}
+
+function launch() {
+  const dir = toolsDir();
+  const child = spawn(resolveExecutable(), process.argv.slice(2), {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      PATH: `${dir}${path.delimiter}${process.env.PATH || ""}`,
+    },
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => child.kill(signal));
+  }
+
+  child.on("error", (err) => fail(`failed to start ${COMMAND}: ${err.message}`));
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
+  });
+}
+
+if (!hasDotnet()) {
+  fail(
+    "the .NET SDK was not found on PATH. RoslynCodeLens requires the .NET 10 SDK — https://dotnet.microsoft.com/download"
+  );
+}
+
+const current = installedVersion();
+
+// Already on the matching version — skip the install round-trip entirely so startup
+// stays fast and works offline.
+if (current !== version) {
+  try {
+    install(current !== null);
+  } catch (err) {
+    if (current === null) {
+      fail(`failed to install ${PACKAGE_ID} ${version}: ${err.message}`);
+    }
+    // A version mismatch is not fatal when a working tool is already present:
+    // an offline or rate-limited NuGet should not take the server down.
+    process.stderr.write(
+      `roslyn-codelens-mcp: could not update to ${version}, continuing with installed ${current}\n`
+    );
+  }
+}
+
+launch();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "roslyn-codelens-mcp",
+  "version": "2.14.0",
+  "description": "Roslyn-based MCP server that gives AI agents deep semantic understanding of .NET codebases — navigation, call graphs, diagnostics, refactoring, code-quality auditing, test intelligence, and IL inspection.",
+  "bin": {
+    "roslyn-codelens-mcp": "./bin/roslyn-codelens-mcp.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "keywords": [
+    "mcp",
+    "mcp-server",
+    "modelcontextprotocol",
+    "roslyn",
+    "csharp",
+    "dotnet",
+    "code-analysis",
+    "code-intelligence",
+    "static-analysis",
+    "refactoring"
+  ],
+  "license": "MIT",
+  "author": "Marcel Roozekrans",
+  "homepage": "https://marcelroozekrans.github.io/roslyn-codelens-mcp/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MarcelRoozekrans/roslyn-codelens-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/MarcelRoozekrans/roslyn-codelens-mcp/issues"
+  },
+  "mcpName": "io.github.MarcelRoozekrans/roslyn-codelens",
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,16 @@
         },
         {
           "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[1].version"
+        },
+        {
+          "type": "json",
+          "path": "npm/package.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
           "path": ".claude-plugin/marketplace.json",
           "jsonpath": "$.version"
         },

--- a/server.json
+++ b/server.json
@@ -10,10 +10,23 @@
   "version": "2.14.0",
   "packages": [
     {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "roslyn-codelens-mcp",
+      "version": "2.14.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    },
+    {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
       "version": "2.14.0",
+      "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"
       },

--- a/src/RoslynCodeLens/.mcp/server.json
+++ b/src/RoslynCodeLens/.mcp/server.json
@@ -10,10 +10,23 @@
   "version": "0.0.0",
   "packages": [
     {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "roslyn-codelens-mcp",
+      "version": "0.0.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    },
+    {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "RoslynCodeLens.Mcp",
       "version": "0.0.0",
+      "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

NuGet is currently the only distribution channel, so directories and clients that can only start MCP servers from npm-hosted runtimes cannot install this server at all.

Glama is the concrete case. It lists the server, but reports **"cannot be installed"** and grades quality **"not tested"** — its score is computed from tool definitions (Tool Definition Quality 70% / Server Coherence 30%), which requires actually connecting and calling `tools/list`. Its sandbox runs `npx`, not `dotnet tool install -g`. Our 67 tools have perfectly good schemas; Glama has simply never seen them.

`sharplens-mcp` solves this with an npm shim and scores A/A/A on the same directory. This mirrors that approach.

## What

A new `npm/` package that ships **no server code**. It checks for the .NET SDK, reads `dotnet tool list --global`, installs or updates `RoslynCodeLens.Mcp` only when the version differs from its own, then execs the tool.

```json
{
  "mcpServers": {
    "roslyn-codelens": {
      "type": "stdio",
      "command": "npx",
      "args": ["-y", "roslyn-codelens-mcp"]
    }
  }
}
```

Design points worth review:

- **stdout stays the JSON-RPC channel.** Every diagnostic uses `process.stderr.write`, and dotnet's install output is routed with `stdio: ["ignore", 2, 2]` rather than captured, so a slow first-run restore still shows progress without corrupting the protocol.
- **No `shell: true`.** Solution paths with spaces would need quoting. The launcher resolves `~/.dotnet/tools/roslyn-codelens-mcp[.exe]` directly and prepends that directory to the child's `PATH`, which also covers the case where the installer just created the directory and it is not yet on `PATH` in this process.
- **A failed *update* is non-fatal when a working tool is present.** Offline or rate-limited NuGet degrades to the installed version rather than taking the server down. Only a failed *first* install is fatal.
- **Steady state is offline-safe** — matching versions skip the install round-trip entirely.
- `SIGINT`/`SIGTERM` are forwarded and signal exits re-raised.

Supporting changes:

- `server.json` and the packed `.mcp/server.json` advertise both packages — npm first with `runtimeHint: npx`, NuGet second with `runtimeHint: dnx` (which is what the README already tells VS Code users). The MSBuild version-stamping target already rewrites every `"version"` key, so the second package needs no build change.
- `release-please-config.json` gains `npm/package.json` and `server.json` `$.packages[1].version` so all four version sites stay in lockstep.
- The **release-please** publish job publishes to npm **after** the NuGet push — the launcher installs the NuGet tool, so the reverse order would ship a launcher pointing at a version that does not exist yet.
  - The step originally went into `release.yml`, which turned out to be **dormant**: it triggers on `release: published`, but release-please creates releases with `GITHUB_TOKEN` and GitHub does not fire workflow triggers for token-generated events. That workflow last ran 2026-03-15, while every release since (through 2.14.0) published from `release-please.yml`. Fixed in the second commit; `release.yml` is left untouched by this PR.
  - No version-stamping step is needed there: the job checks out the release commit, in which release-please has already bumped `npm/package.json` via `extra-files`.
- The `bin/` ignore rule (meant for .NET build output) also matched `npm/bin`, so the directory is negated explicitly. Git cannot re-include a file whose parent directory is excluded, so the directory itself has to be negated.

## Publishing

Trusted publishing (OIDC) with provenance, no token — the same setup as `LongtermMemory-MCP`. This is why the job gains `id-token: write` and why Node is pinned to 24 (npm must be >= 11.5.1 for OIDC).

**Before the first release after this merges**, the package has to be bootstrapped: trusted publishing cannot be configured for a package that does not exist yet. Publish `npm/` manually once, then enable trusted publishing in the npm package settings. `longterm-memory-mcp` shows the same history — `0.0.1` has no attestation, `1.0.0` onward all do.

## Verification

- `node --check` on the launcher; all four touched JSON files parse.
- The `dotnet tool list --global` regex tested against real output: `roslyncodelens.mcp  1.0.15  roslyn-codelens-mcp` → parses `1.0.15`.
- `npm pack --dry-run` → 3 files, 2.9 kB.
- **End-to-end launch**, using a scratch copy pinned to an already-installed version so nothing was installed or updated on the test machine. Piped in an `initialize` request and got a clean response on stdout with all Roslyn diagnostics on stderr:
  ```
  {"result":{"protocolVersion":"2024-11-05","capabilities":{...},"serverInfo":{"name":"RoslynCodeLens",...}},"id":1,"jsonrpc":"2.0"}
  ```
- No C# was touched, so the existing suite is unaffected; CI covers it.

## Known limitation

The launcher requires the .NET SDK on `PATH`, so this only fixes Glama's install path if its sandbox provides one. `sharplens-mcp` has the identical dependency and is graded A, which is the best available evidence that it works — but if the listing still reports "cannot be installed" after a release, the fallback is a fatter npm package bundling per-platform self-contained binaries via `optionalDependencies`, which removes the SDK requirement entirely. That is a much larger change, so the shim is worth trying first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


