### PR TITLE
feat: Docker support and glama.json for Glama indexing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Everything the image does not need. Keeping bin/ and obj/ out matters most:
+# host build output leaking into the build context breaks the container restore.
+**/bin/
+**/obj/
+.git/
+.github/
+.worktrees/
+.vs/
+.vscode/
+.config/
+BenchmarkDotNet.Artifacts/
+TestResults/
+artifacts/
+
+benchmarks/
+tests/
+tools/
+docs/
+plugins/
+npm/
+scripts/
+samples/
+
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# syntax=docker/dockerfile:1
+#
+# Roslyn CodeLens MCP server.
+#
+# The solution under analysis is mounted at /workspace; with no arguments the
+# server scans the working directory for a .sln (see Program.cs). Pass explicit
+# solution paths as arguments to load several at once.
+#
+#   docker build -t roslyn-codelens-mcp .
+#   docker run -i --rm -v "$PWD:/workspace" roslyn-codelens-mcp
+#
+# See docs/docker.md for MCP client configuration and the NuGet cache mount.
+
+# ---------------------------------------------------------------- build -------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+WORKDIR /src
+
+# Restore against the project file alone so the (slow) restore layer survives
+# source-only edits. Directory.Build.props carries the shared analyzer set.
+COPY Directory.Build.props ./
+COPY src/RoslynCodeLens/RoslynCodeLens.csproj src/RoslynCodeLens/
+RUN dotnet restore src/RoslynCodeLens/RoslynCodeLens.csproj
+
+COPY src/ src/
+RUN dotnet publish src/RoslynCodeLens/RoslynCodeLens.csproj \
+      --configuration Release \
+      --no-restore \
+      --output /app
+
+# -------------------------------------------------------------- runtime -------
+# Must be the SDK image, not dotnet/runtime: MSBuildLocator.RegisterDefaults()
+# resolves a real MSBuild installation at startup, and MSBuildWorkspace needs it
+# to evaluate the mounted solution's project files.
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+# The SDK's first-run banner and telemetry notice write to stdout, which would
+# corrupt the MCP framing on the stdio transport.
+ENV DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+COPY --from=build /app /opt/roslyn-codelens
+
+# Solutions are analyzed from here, so an argument-less run finds a mounted .sln.
+WORKDIR /workspace
+
+ENTRYPOINT ["dotnet", "/opt/roslyn-codelens/RoslynCodeLens.dll"]

--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ Then add to your MCP client config:
 }
 ```
 
+### Docker
+
+Runs without a .NET SDK on the host; the solution is bind-mounted at `/workspace`.
+
+```bash
+docker build -t roslyn-codelens-mcp .
+docker run -i --rm -v "$PWD:/workspace" roslyn-codelens-mcp
+```
+
+The mounted solution must be restored for `MSBuildWorkspace` to resolve its
+references, and tool output reports container paths rather than host paths — see
+[docs/site/docs/getting-started/docker.md](docs/site/docs/getting-started/docker.md).
+
 ## Usage
 
 The server automatically discovers `.sln` files by walking up from the current directory. You can also pass one or more solution paths directly:

--- a/docs/site/docs/getting-started/docker.md
+++ b/docs/site/docs/getting-started/docker.md
@@ -1,0 +1,106 @@
+---
+title: Docker
+sidebar_position: 5
+---
+
+# Running in Docker
+
+The repository ships a `Dockerfile`, so you can run the server without a .NET SDK
+on the host. The solution under analysis is bind-mounted into the container.
+
+## Build the image
+
+```bash
+docker build -t roslyn-codelens-mcp .
+```
+
+## Run it
+
+The server communicates over stdio, so the container needs `-i` and must not
+allocate a TTY:
+
+```bash
+docker run -i --rm -v "$PWD:/workspace" roslyn-codelens-mcp
+```
+
+With no arguments the server scans its working directory (`/workspace`) for a
+`.sln`/`.slnx`. To load specific solutions, or several at once, pass them as
+arguments — as container paths, not host paths:
+
+```bash
+docker run -i --rm -v "$PWD:/workspace" roslyn-codelens-mcp \
+  /workspace/First.slnx /workspace/Second.slnx
+```
+
+## MCP client configuration
+
+```json
+{
+  "mcpServers": {
+    "roslyn-codelens": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "/absolute/path/to/your/repo:/workspace",
+        "-v", "roslyn-codelens-nuget:/root/.nuget/packages",
+        "roslyn-codelens-mcp"
+      ]
+    }
+  }
+}
+```
+
+## Restore the solution first
+
+`MSBuildWorkspace` needs the analyzed solution's NuGet packages on disk to
+resolve project references. An unrestored solution loads with missing references
+and tools then return incomplete results.
+
+Either restore on the host before starting the container, or restore inside it:
+
+```bash
+docker run --rm -v "$PWD:/workspace" \
+  -v roslyn-codelens-nuget:/root/.nuget/packages \
+  --entrypoint dotnet roslyn-codelens-mcp restore
+```
+
+Mounting a named volume at `/root/.nuget/packages` (as in the config above) keeps
+that cache between runs — without it every container start re-downloads packages.
+
+:::warning
+Restoring inside the container rewrites `obj/project.assets.json` in the **mounted
+host tree**, pointing it at `/root/.nuget/packages/`. Your next host build has to
+re-restore before it works. If you build on the host as well, restore there
+instead and let the container read the result.
+:::
+
+## Why the image is SDK-based
+
+The runtime stage uses `mcr.microsoft.com/dotnet/sdk:10.0` rather than the
+smaller `dotnet/runtime` image. `MSBuildLocator.RegisterDefaults()` resolves a
+real MSBuild installation at startup, and `MSBuildWorkspace` needs it to
+evaluate the mounted solution's project files. The runtime-only image has
+neither, and the server cannot load a solution without them.
+
+The cost is size: the image is ~1.3 GB, almost all of it the SDK base layer.
+
+## Windows hosts
+
+Under Git Bash / MSYS, path arguments are rewritten before Docker sees them —
+`/workspace/App.slnx` becomes `C:/Program Files/Git/workspace/App.slnx` and the
+solution is not found. Prefix the command with `MSYS_NO_PATHCONV=1`, or use
+PowerShell:
+
+```powershell
+docker run -i --rm -v "${PWD}:/workspace" roslyn-codelens-mcp
+```
+
+## Limitations
+
+- **Absolute paths are container paths.** Tools that report or accept file paths
+  see `/workspace/...`, not your host layout.
+- **Trust decisions do not persist.** The analyzer trust store lives in the
+  container filesystem and is lost on `--rm`. Solutions passed as arguments are
+  session-trusted automatically; mount a volume over the trust store path if you
+  need decisions to survive restarts.
+- **The container needs network access** on first run for any restore.

--- a/docs/site/sidebars.ts
+++ b/docs/site/sidebars.ts
@@ -11,6 +11,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/marketplace',
         'getting-started/configuration',
         'getting-started/first-use',
+        'getting-started/docker',
       ],
     },
     {

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["MarcelRoozekrans"]
+}


### PR DESCRIPTION
Raises the [Glama server score](https://glama.ai/mcp/servers/MarcelRoozekrans/roslyn-codelens-mcp/score), currently 25% with 7 of 11 criteria failing.

## What this addresses

| Glama criterion | Before | This PR |
|---|---|---|
| glama.json | ❌ Missing metadata file | ✅ Added |
| Glama Release | ❌ No release published | Unblocked — Glama builds from a Dockerfile |
| Server Coherence | ❌ *Requires a release to enable scoring* | Unblocked by the above |
| Tool Definition Quality | ❌ *Requires a release to enable scoring* | Unblocked by the above |

The profile page also reported the server "cannot be installed" with quality "not tested"; a Dockerfile is what Glama's sandbox needs to introspect and score the tool definitions.

## Why the image is SDK-based

The runtime stage uses `mcr.microsoft.com/dotnet/sdk:10.0` rather than the much smaller `dotnet/runtime`. This is forced, not a preference — `MSBuildLocator.RegisterDefaults()` resolves a real MSBuild installation at startup, and `MSBuildWorkspace` needs it to evaluate the mounted solution's project files. The cost is size: ~1.3 GB, almost all base layer.

`DOTNET_NOLOGO` and `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` are set because the SDK's first-run banner writes to stdout, which would corrupt MCP framing on the stdio transport.

## Verification

Built and ran the image, not just built it:

- **No mount** (the path Glama's sandbox scores): `tools/list` returns all **67 tools**, stdout is pure JSON-RPC, and the "no .sln found" notice correctly goes to stderr.
- **This repo bind-mounted**: solution loads — `list_solutions` reports 3 projects, `status: ready` — and `get_type_overview` returns real semantic data with container paths.
- Docusaurus site builds with the new page and sidebar entry.

## Two gotchas found while testing, now documented

- Restoring **inside** the container rewrites `obj/project.assets.json` in the mounted host tree to `/root/.nuget/packages/`, so the next host build has to re-restore.
- Under Git Bash / MSYS on Windows, `/workspace/App.slnx` is rewritten to `C:/Program Files/Git/workspace/App.slnx` before Docker sees it. Needs `MSYS_NO_PATHCONV=1` or PowerShell.

## Still outstanding on Glama

Profile Completion, Related Servers, and Recent Usage are admin-UI actions and can't be fixed from the repo. Once this lands, the release can be created from the Dockerfile admin page.

## Unrelated finding

[docs/site/docs/getting-started/installation.md](docs/site/docs/getting-started/installation.md) documents a `--solution` flag and a `ROSLYN_CODELENS_SOLUTION` env var that **do not exist** in the source. The real interface is positional solution paths, which the README describes correctly. Not fixed here to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)