### PR TITLE
fix(docs): document the solution arguments the server actually accepts

### DIFF
--- a/docs/site/docs/getting-started/configuration.md
+++ b/docs/site/docs/getting-started/configuration.md
@@ -9,26 +9,30 @@ sidebar_position: 3
 
 The server needs to know which `.sln` or `.slnx` file to load.
 
-**Option 1: CLI argument**
+**Option 1: arguments** — solution paths are passed bare, not behind a flag.
 ```json
-"args": ["--solution", "/path/to/Solution.sln"]
+"args": ["/path/to/Solution.sln"]
 ```
 
-**Option 2: Environment variable**
-```json
-"env": {"ROSLYN_CODELENS_SOLUTION": "/path/to/Solution.sln"}
-```
+**Option 2: automatic discovery** — pass no arguments and the server searches its
+working directory for a `.sln`/`.slnx`.
 
-**Option 3: At runtime** — call `set_active_solution` after the server starts. Useful for multi-solution workflows.
+**Option 3: at runtime** — call `load_solution` after the server starts.
 
 ## Multiple solutions
 
-`roslyn-codelens-mcp` has a built-in solution manager. Load and switch between solutions at runtime:
+`roslyn-codelens-mcp` has a built-in solution manager. Pass several paths at
+startup, or load more at runtime:
 
 ```
+Use load_solution with path /path/to/OtherSolution.sln
 Use list_solutions to see what's loaded
-Use set_active_solution with path /path/to/OtherSolution.sln
+Use set_active_solution with name OtherSolution
 ```
+
+The two tools are not interchangeable: `load_solution` takes a **path** and opens
+a solution the server has not seen; `set_active_solution` takes a partial,
+case-insensitive **name** and only switches between solutions already loaded.
 
 Only one solution is "active" at a time. All tool calls operate on the active solution.
 

--- a/docs/site/docs/getting-started/installation.md
+++ b/docs/site/docs/getting-started/installation.md
@@ -31,26 +31,32 @@ Add the server to your project's `.mcp.json` (or `~/.claude/.mcp.json` for globa
   "mcpServers": {
     "roslyn-codelens": {
       "command": "roslyn-codelens-mcp",
-      "args": ["--solution", "/absolute/path/to/YourSolution.sln"]
+      "args": ["/absolute/path/to/YourSolution.sln"]
     }
   }
 }
 ```
 
-The `--solution` argument is required on first start. Alternatively, use the `ROSLYN_CODELENS_SOLUTION` environment variable:
+Solution paths are passed as bare arguments — there is no `--solution` flag. Pass
+several to load them all at once and switch with `set_active_solution`:
 
 ```json
 {
   "mcpServers": {
     "roslyn-codelens": {
       "command": "roslyn-codelens-mcp",
-      "env": {
-        "ROSLYN_CODELENS_SOLUTION": "/absolute/path/to/YourSolution.sln"
-      }
+      "args": [
+        "/absolute/path/to/First.slnx",
+        "/absolute/path/to/Second.slnx"
+      ]
     }
   }
 }
 ```
+
+Arguments are optional. With none, the server searches the working directory for
+a `.sln`/`.slnx`; if it finds nothing it still starts, prints a notice to stderr,
+and tools return errors until you call `load_solution`.
 
 ## Verify the server starts
 

--- a/docs/site/docs/getting-started/marketplace.md
+++ b/docs/site/docs/getting-started/marketplace.md
@@ -17,8 +17,13 @@ The plugin configures the server command and loads the `SKILL.md` that teaches C
 
 ## After install
 
-Set your solution path. Either set `ROSLYN_CODELENS_SOLUTION` in your environment, or call `set_active_solution` once the server is running:
+Point the server at your solution. If the plugin starts it in your project
+directory it discovers the `.sln`/`.slnx` on its own; otherwise call
+`load_solution` once the server is running:
 
 ```
-Use set_active_solution with path /path/to/YourSolution.sln
+Use load_solution with path /path/to/YourSolution.sln
 ```
+
+Use `set_active_solution` only to switch between solutions that are already
+loaded — it matches on name, not path, and will not open a new one.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -33,7 +33,7 @@ Then add to your `.mcp.json`:
   "mcpServers": {
     "roslyn-codelens": {
       "command": "roslyn-codelens-mcp",
-      "args": ["--solution", "/path/to/your/Solution.sln"]
+      "args": ["/path/to/your/Solution.sln"]
     }
   }
 }


### PR DESCRIPTION
Follow-up to the finding flagged in #348. The docs site documented a CLI interface that does not exist.

## The problem

Four published pages told users to configure the server with a `--solution` flag or a `ROSLYN_CODELENS_SOLUTION` environment variable. **Neither appears anywhere in the source.** `Program.cs` treats bare arguments as solution paths and otherwise searches the working directory:

```csharp
var solutionPaths = args.Length > 0
    ? args.ToList()
    : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory()) is { } found
        ? [found]
        : [];
```

`grep -r 'ROSLYN_CODELENS_SOLUTION|--solution' src/` returns nothing. Anyone following these pages got a server that started, ignored the flag, found no solution, and returned errors from every tool.

## Also corrected: `load_solution` vs `set_active_solution`

The same pages conflated the two. `set_active_solution` takes a partial, case-insensitive **name** and only switches between solutions that are **already loaded** — it cannot open a new one. So it was the wrong tool in both places it was recommended:

- **marketplace.md** told users to run it as the post-install step to point the server at their solution.
- **configuration.md** passed it a *path* (`set_active_solution with path /path/to/OtherSolution.sln`).

Both now use `load_solution`, with a note on how the two differ.

## Files

| Page | Change |
|---|---|
| `getting-started/installation.md` | Bare args; documents the multi-solution and no-args cases |
| `getting-started/configuration.md` | Rewrote "Solution path"; corrected the multi-solution example |
| `getting-started/marketplace.md` | `load_solution` for post-install |
| `index.md` | Quick-start snippet |

Historical design docs under `docs/plans/` are left alone — they record what was planned, not what users should do.

## Verification

Docusaurus build passes. The README already described the interface correctly, so it needed no change — which is how the discrepancy was spotted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)