### PR TITLE
fix(ci): re-authenticate on every MCP Registry publish attempt

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -21,18 +21,22 @@ jobs:
           tar xzf mcp-publisher.tar.gz
           chmod +x mcp-publisher
 
-      - name: Authenticate via OIDC
-        run: ./mcp-publisher login github-oidc
-
       - name: Publish to MCP Registry
         # Retry with backoff in case NuGet is still indexing the version the registry
         # validates against (~25 min window). Safe to run any time: succeeds on the
         # first attempt once the version is indexed.
+        #
+        # Authentication happens INSIDE the loop because the registry JWT expires a few
+        # minutes after it is minted, well inside this window. A token taken once up
+        # front made every later attempt a guaranteed 401 that the loop then blamed on
+        # NuGet indexing lag.
         run: |
           max_attempts=15
           delay=30
           for attempt in $(seq 1 "$max_attempts"); do
-            if ./mcp-publisher publish; then
+            if ! ./mcp-publisher login github-oidc; then
+              echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
+            elif ./mcp-publisher publish; then
               echo "Published to MCP Registry on attempt $attempt."
               exit 0
             fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,22 +86,27 @@ jobs:
           tar xzf mcp-publisher.tar.gz
           chmod +x mcp-publisher
 
-      - name: Authenticate via OIDC
-        run: ./mcp-publisher login github-oidc
-
       - name: Publish to MCP Registry
         # The registry validates the version against NuGet's search index, which for a
         # NEW version can lag 5-15+ min behind the upload the `publish` job just did
         # (new versions index far slower than updates to an existing package). The old
         # 6x30s (~3 min) window was too short and failed the release on indexing lag
         # (2.4.2). Retry with backoff over a ~25 min window so we ride it out.
+        #
+        # Authentication happens INSIDE the loop, and that is load-bearing. The registry
+        # JWT expires a few minutes after it is minted, which is well inside this
+        # window: with a token taken once up front, every attempt past roughly the
+        # fifth returned 401 "token is expired" while the loop reported the failure as
+        # NuGet indexing lag. That wasted ~20 of the 25 minutes and hid the real cause.
         env:
           VERSION: ${{ needs.release-please.outputs.version }}
         run: |
           max_attempts=15
           delay=30
           for attempt in $(seq 1 "$max_attempts"); do
-            if ./mcp-publisher publish; then
+            if ! ./mcp-publisher login github-oidc; then
+              echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
+            elif ./mcp-publisher publish; then
               echo "Published $VERSION to MCP Registry on attempt $attempt."
               exit 0
             fi


### PR DESCRIPTION
The MCP Registry retry loop could not do the job it was written for. Found while investigating why Glama reports this repo's CI as failing.

## The bug

The loop retries over a **~25 minute window** to ride out NuGet indexing lag, but the registry JWT was minted **once, in a preceding step**. It expires after a few minutes, so from roughly the fifth attempt onward every request returned:

```
401 Unauthorized: Invalid or expired Registry JWT token
      failed to parse token: token has invalid claims: token is expired
```

Two consequences:

1. **~20 of the 25 minutes were spent on requests that could not succeed.** Once the token died, no amount of waiting helped — the effective window was ~5 minutes, not 25.
2. **The log blamed the wrong thing.** Every failure, including the 401s, printed *"NuGet is likely still indexing"*. Release 2.15.0 failed exactly this way, and the run reads as a NuGet problem.

## The fix

Authentication moves inside the loop, so each attempt carries a fresh token. A failed login is now reported as a login failure and skips the publish, instead of being counted as indexing lag.

Both copies of the loop are fixed — `release-please.yml` and `publish-mcp-registry.yml`. The manual workflow had the identical bug, which matters because the error message tells you to fall back to it.

## Verification

Workflow YAML parses, and an assertion confirms every `mcp-publisher` script has its login inside the retry loop with no leftover standalone login step.

The loop was then extracted and run against a stubbed publisher:

| Scenario | Exit | Logins | Publishes |
|---|---|---|---|
| Succeeds first try | 0 | 1 | 1 |
| Succeeds on 4th (indexing lag) | 0 | **4** | 4 |
| Never succeeds | 1 | 15 | 15 |
| Login always fails | 1 | 15 | **0** |

Row 2 is the fix: four attempts now take four fresh tokens. Row 4 confirms a broken login skips publishing rather than erroring.

## Note on the other CI failures

This is one of two causes behind Glama's "CI Status: FAIL". The rest are six Dependabot security-update runs on `/docs/site` for `brace-expansion` and `js-yaml`, which report `security_update_not_possible` — `@docusaurus/core` requires `minimatch@3`, which cannot take a non-vulnerable `brace-expansion`. Not fixable without moving off docusaurus 3.10.x; loosening the existing override is what broke minimatch in #330. Silencing them would need a `.github/dependabot.yml` with `ignore` entries. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)