### PR TITLE
fix(build): let contributors opt out of ZeroAlloc.Analyzers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,6 +58,17 @@ dotnet test
 
 Tests use xUnit with `IAsyncLifetime` for solution loading. The test fixture at `tests/RoslynCodeLens.Tests/Fixtures/TestSolution/` provides a multi-project solution for integration tests.
 
+## Building on Windows 11 with Smart App Control
+
+[Smart App Control](https://support.microsoft.com/en-US/Windows/Security/Threat-Malware-Protection/smart-app-control-has-blocked-part-of-this-app) blocks binaries that are both unsigned and low-reputation. The `ZeroAlloc.Analyzers` package currently meets both criteria, so SAC may block it during a build. If you hit this, opt out of that analyzer:
+
+```bash
+dotnet build -p:EnableZeroAllocAnalyzers=false
+dotnet test -p:EnableZeroAllocAnalyzers=false
+```
+
+Only the analyzer is skipped; nothing else about the build changes. The single suppression that depends on its rules (`ZA0601` in `src/RoslynCodeLens/SolutionLoader.cs`) is inert without it.
+
 ## Releasing
 
 Releases are automatic on merge to `main`:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZeroAlloc.Analyzers" Version="1.5.0">
+    <!--
+      Windows 11 Smart App Control blocks this analyzer: its assemblies are unsigned and the
+      package has too few downloads to carry a reputation in Microsoft's Intelligent Security
+      Graph. Build with -p:EnableZeroAllocAnalyzers=false to opt out. See issue #369.
+    -->
+    <PackageReference Include="ZeroAlloc.Analyzers" Version="1.5.0"
+                      Condition="'$(EnableZeroAllocAnalyzers)' != 'false'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes #369.

## Problem

Windows 11 Smart App Control blocks binaries that are both unsigned **and** low-reputation in Microsoft's Intelligent Security Graph. A contributor reported it blocking their build.

All six analyzer packages in `Directory.Build.props` are unsigned, so signing is not the discriminator — prevalence is:

| Package | Signed | Downloads |
|---|---|---|
| Roslynator.Analyzers | No | 55.7M |
| Meziantou.Analyzer | No | 22.0M |
| ErrorProne.NET.CoreAnalyzers | No | 1.55M |
| NetFabric.Hyperlinq.Analyzer | No | 349k |
| **ZeroAlloc.Analyzers** | **No** | **18.8k** |

The other five clear SAC on reputation alone. ZeroAlloc.Analyzers has none yet, so it is the one that gets blocked. CI is `ubuntu-latest` only and SAC is Windows-exclusive, so no CI signal will ever fire on this.

## Change

Make the reference conditional on `EnableZeroAllocAnalyzers`. Affected contributors can build with `-p:EnableZeroAllocAnalyzers=false`; the analyzer stays on by default for everyone else. Documented in CONTRIBUTING.

## Verification

| Build | Result |
|---|---|
| `dotnet build` | 0 errors, 515 warnings — ZA rules firing, analyzer active |
| `dotnet build -p:EnableZeroAllocAnalyzers=false` | 0 errors, 433 warnings — analyzer skipped |

The 82-warning delta is exactly the ZeroAlloc rules, confirming the condition gates that package and nothing else.

## Follow-up

This is a stopgap. The durable fix is Authenticode-signing the ZeroAlloc.Analyzers assemblies upstream in [ZeroAlloc-Net/ZeroAlloc.Analyzers](https://github.com/ZeroAlloc-Net/ZeroAlloc.Analyzers), which resolves it for every consumer rather than per-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
