### PR TITLE
feat: add streamable HTTP transport behind --http flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,34 @@ roslyn-codelens-mcp /path/to/A.sln /path/to/B.sln
 
 When multiple solutions are loaded, use `list_solutions` to see what's available and `set_active_solution("B")` to switch context. The first path is active by default.
 
+### HTTP transport
+
+By default the server speaks stdio. Pass `--http` to expose the same tools over
+[streamable HTTP](https://modelcontextprotocol.io/docs/concepts/transports) instead — useful for
+one long-lived server (warm Roslyn workspace, no per-client startup cost) shared by several
+local MCP clients:
+
+```bash
+roslyn-codelens-mcp /path/to/MySolution.sln --http            # http://127.0.0.1:3001
+roslyn-codelens-mcp /path/to/MySolution.sln --http --port 8080
+```
+
+```json
+{
+  "mcpServers": {
+    "roslyn-codelens": {
+      "type": "http",
+      "url": "http://127.0.0.1:3001"
+    }
+  }
+}
+```
+
+The HTTP endpoint binds to `127.0.0.1` only and is intended for **single-user, local use**: all
+connected clients share the same solution state (`set_active_solution` affects everyone), and
+there is no authentication. `--host` can widen the binding, but the server will warn — its tools
+can read and modify source files, so only do this on networks you fully trust.
+
 ## Performance
 
 All type lookups use pre-built reverse inheritance maps, member indexes, and attribute indexes for O(1) access. Benchmarked on an i9-12900HK with .NET 10.0.7:

--- a/src/RoslynCodeLens/CliOptions.cs
+++ b/src/RoslynCodeLens/CliOptions.cs
@@ -1,0 +1,92 @@
+namespace RoslynCodeLens;
+
+/// <summary>
+/// Parsed command-line options. Positional arguments are solution paths; flags select
+/// the transport. Stdio remains the default so existing MCP client configs keep working.
+/// </summary>
+public sealed class CliOptions
+{
+    public const int DefaultPort = 3001;
+    public const string DefaultHttpHost = "127.0.0.1";
+
+    public IReadOnlyList<string> SolutionPaths { get; }
+    public bool UseHttp { get; }
+    public int Port { get; }
+    public string HttpHost { get; }
+
+    private CliOptions(IReadOnlyList<string> solutionPaths, bool useHttp, int port, string httpHost)
+    {
+        SolutionPaths = solutionPaths;
+        UseHttp = useHttp;
+        Port = port;
+        HttpHost = httpHost;
+    }
+
+    public bool BindsLoopbackOnly =>
+        HttpHost is "127.0.0.1" or "localhost" or "::1" or "[::1]";
+
+    public static CliOptions Parse(string[] args)
+    {
+        var paths = new List<string>();
+        var useHttp = false;
+        var port = DefaultPort;
+        var httpHost = DefaultHttpHost;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (!arg.StartsWith("--", StringComparison.Ordinal))
+            {
+                paths.Add(arg);
+                continue;
+            }
+
+            var (name, inlineValue) = SplitFlag(arg);
+            switch (name)
+            {
+                case "--http":
+                    RejectInlineValue(name, inlineValue);
+                    useHttp = true;
+                    break;
+
+                case "--port":
+                    var portValue = inlineValue ?? NextValue(args, ref i, name);
+                    if (!int.TryParse(portValue, out port) || port is < 1 or > 65535)
+                        throw new ArgumentException($"Invalid value for --port: '{portValue}'. Expected an integer between 1 and 65535.");
+                    break;
+
+                case "--host":
+                    httpHost = inlineValue ?? NextValue(args, ref i, name);
+                    if (string.IsNullOrWhiteSpace(httpHost))
+                        throw new ArgumentException("Invalid value for --host: value is empty.");
+                    break;
+
+                default:
+                    throw new ArgumentException(
+                        $"Unknown option '{arg}'. Supported options: --http, --port <1-65535>, --host <address>. " +
+                        "Positional arguments are .sln/.slnx paths.");
+            }
+        }
+
+        return new CliOptions(paths, useHttp, port, httpHost);
+    }
+
+    private static (string Name, string? InlineValue) SplitFlag(string arg)
+    {
+        var eq = arg.IndexOf('=', StringComparison.Ordinal);
+        return eq < 0 ? (arg, null) : (arg[..eq], arg[(eq + 1)..]);
+    }
+
+    private static void RejectInlineValue(string name, string? inlineValue)
+    {
+        if (inlineValue is not null)
+            throw new ArgumentException($"Option '{name}' does not take a value.");
+    }
+
+    private static string NextValue(string[] args, ref int i, string name)
+    {
+        if (i + 1 >= args.Length)
+            throw new ArgumentException($"Option '{name}' requires a value.");
+        return args[++i];
+    }
+}

--- a/src/RoslynCodeLens/Program.cs
+++ b/src/RoslynCodeLens/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Build.Locator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -8,6 +9,17 @@ using RoslynCodeLens;
 using RoslynCodeLens.BackgroundTasks;
 using RoslynCodeLens.Security;
 
+CliOptions options;
+try
+{
+    options = CliOptions.Parse(args);
+}
+catch (ArgumentException ex)
+{
+    await Console.Error.WriteLineAsync($"[roslyn-codelens] {ex.Message}").ConfigureAwait(false);
+    return 1;
+}
+
 var instance = MSBuildLocator.RegisterDefaults();
 var dotnetSdkRoot = instance.MSBuildPath is not null
     ? Path.GetFullPath(Path.Combine(instance.MSBuildPath, "..", "..", ".."))
@@ -15,8 +27,8 @@ var dotnetSdkRoot = instance.MSBuildPath is not null
 
 MultiSolutionManager multiManager;
 
-var solutionPaths = args.Length > 0
-    ? args.ToList()
+var solutionPaths = options.SolutionPaths.Count > 0
+    ? options.SolutionPaths.ToList()
     : SolutionLoader.FindSolutionFile(Directory.GetCurrentDirectory()) is { } found
         ? [found]
         : [];
@@ -37,28 +49,70 @@ foreach (var sln in solutionPaths)
 
 var allowlist = new AnalyzerAllowlist(trustStore.AnalyzerPolicy, AnalyzerAllowlist.DefaultNugetGlobal(), dotnetSdkRoot);
 
-var builder = Host.CreateApplicationBuilder(args);
-builder.Logging.ClearProviders();
-builder.Services.AddSingleton(multiManager);
-builder.Services.AddSingleton(trustStore);
-builder.Services.AddSingleton(allowlist);
-builder.Services.AddSingleton<BackgroundTaskStore>();
+if (options.UseHttp)
+    await RunHttpAsync().ConfigureAwait(false);
+else
+    await RunStdioAsync().ConfigureAwait(false);
 
-builder.Services
-    .AddMcpServer()
-    .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+return 0;
 
-// Wrap every registered tool with StructuredErrorToolWrapper so thrown exceptions
-// surface as CallToolResult { IsError = true } carrying structured JSON.
-// OperationCanceledException intentionally bubbles unchanged.
-builder.Services.PostConfigure<McpServerOptions>(options =>
+void RegisterServices(IServiceCollection services)
 {
-    var coll = options.ToolCollection;
-    if (coll is null) return;
-    var wrapped = coll.Select(t => (McpServerTool)new StructuredErrorToolWrapper(t)).ToList();
-    coll.Clear();
-    foreach (var t in wrapped) coll.Add(t);
-});
+    services.AddSingleton(multiManager);
+    services.AddSingleton(trustStore);
+    services.AddSingleton(allowlist);
+    services.AddSingleton<BackgroundTaskStore>();
 
-await builder.Build().RunAsync().ConfigureAwait(false);
+    // Wrap every registered tool with StructuredErrorToolWrapper so thrown exceptions
+    // surface as CallToolResult { IsError = true } carrying structured JSON.
+    // OperationCanceledException intentionally bubbles unchanged.
+    services.PostConfigure<McpServerOptions>(o =>
+    {
+        var coll = o.ToolCollection;
+        if (coll is null) return;
+        var wrapped = coll.Select(t => (McpServerTool)new StructuredErrorToolWrapper(t)).ToList();
+        coll.Clear();
+        foreach (var t in wrapped) coll.Add(t);
+    });
+}
+
+async Task RunStdioAsync()
+{
+    var builder = Host.CreateApplicationBuilder(args);
+    builder.Logging.ClearProviders();
+    RegisterServices(builder.Services);
+
+    builder.Services
+        .AddMcpServer()
+        .WithStdioServerTransport()
+        .WithToolsFromAssembly();
+
+    await builder.Build().RunAsync().ConfigureAwait(false);
+}
+
+async Task RunHttpAsync()
+{
+    var builder = WebApplication.CreateBuilder();
+    builder.Logging.ClearProviders();
+    RegisterServices(builder.Services);
+
+    builder.Services
+        .AddMcpServer()
+        // Stateless streamable HTTP: no tool uses sampling/elicitation, so no
+        // server-to-client channel (or per-session state) is needed.
+        .WithHttpTransport(o => o.Stateless = true)
+        .WithToolsFromAssembly();
+
+    var app = builder.Build();
+    app.MapMcp();
+
+    var url = $"http://{options.HttpHost}:{options.Port}";
+    if (!options.BindsLoopbackOnly)
+        await Console.Error.WriteLineAsync(
+            $"[roslyn-codelens] WARNING: binding to non-loopback address '{options.HttpHost}'. " +
+            "This server has no authentication and its tools can read and modify source files; " +
+            "only expose it on networks you fully trust.").ConfigureAwait(false);
+    await Console.Error.WriteLineAsync($"[roslyn-codelens] HTTP transport listening on {url}").ConfigureAwait(false);
+
+    await app.RunAsync(url).ConfigureAwait(false);
+}

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -28,14 +28,19 @@
     <InternalsVisibleTo Include="RoslynCodeLens.Tests" />
   </ItemGroup>
 
+  <!-- HTTP transport (the http CLI flag) is hosted on ASP.NET Core -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.6.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.6.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="11.0.0.9375" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/CliOptionsTests.cs
+++ b/tests/RoslynCodeLens.Tests/CliOptionsTests.cs
@@ -1,0 +1,110 @@
+namespace RoslynCodeLens.Tests;
+
+public class CliOptionsTests
+{
+    [Fact]
+    public void Parse_NoArgs_DefaultsToStdio()
+    {
+        var options = CliOptions.Parse([]);
+
+        Assert.Empty(options.SolutionPaths);
+        Assert.False(options.UseHttp);
+        Assert.Equal(CliOptions.DefaultPort, options.Port);
+        Assert.Equal(CliOptions.DefaultHttpHost, options.HttpHost);
+    }
+
+    [Fact]
+    public void Parse_PositionalArgs_AreSolutionPaths()
+    {
+        var options = CliOptions.Parse(["a.sln", @"c:\repo\b.slnx"]);
+
+        Assert.Equal(["a.sln", @"c:\repo\b.slnx"], options.SolutionPaths);
+        Assert.False(options.UseHttp);
+    }
+
+    [Fact]
+    public void Parse_HttpFlag_EnablesHttpWithDefaults()
+    {
+        var options = CliOptions.Parse(["--http"]);
+
+        Assert.True(options.UseHttp);
+        Assert.Equal(CliOptions.DefaultPort, options.Port);
+        Assert.Equal(CliOptions.DefaultHttpHost, options.HttpHost);
+        Assert.True(options.BindsLoopbackOnly);
+    }
+
+    [Theory]
+    [InlineData("--http --port 8080")]
+    [InlineData("--http --port=8080")]
+    public void Parse_Port_BothSyntaxes(string argLine)
+    {
+        var options = CliOptions.Parse(argLine.Split(' '));
+
+        Assert.True(options.UseHttp);
+        Assert.Equal(8080, options.Port);
+    }
+
+    [Fact]
+    public void Parse_MixedPathsAndFlags_KeepsBoth()
+    {
+        var options = CliOptions.Parse(["my.sln", "--http", "--port", "9000", "other.sln"]);
+
+        Assert.Equal(["my.sln", "other.sln"], options.SolutionPaths);
+        Assert.True(options.UseHttp);
+        Assert.Equal(9000, options.Port);
+    }
+
+    [Fact]
+    public void Parse_NonLoopbackHost_IsFlagged()
+    {
+        var options = CliOptions.Parse(["--http", "--host", "0.0.0.0"]);
+
+        Assert.Equal("0.0.0.0", options.HttpHost);
+        Assert.False(options.BindsLoopbackOnly);
+    }
+
+    [Theory]
+    [InlineData("localhost")]
+    [InlineData("127.0.0.1")]
+    [InlineData("::1")]
+    [InlineData("[::1]")]
+    public void Parse_LoopbackHosts_AreLoopback(string host)
+    {
+        var options = CliOptions.Parse(["--http", $"--host={host}"]);
+
+        Assert.True(options.BindsLoopbackOnly);
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("0")]
+    [InlineData("65536")]
+    [InlineData("-1")]
+    public void Parse_InvalidPort_Throws(string port)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => CliOptions.Parse(["--port", port]));
+        Assert.Contains("--port", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("--port")]
+    [InlineData("--host")]
+    public void Parse_MissingValue_Throws(string flag)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => CliOptions.Parse([flag]));
+        Assert.Contains("requires a value", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_UnknownFlag_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => CliOptions.Parse(["--verbose"]));
+        Assert.Contains("--verbose", ex.Message);
+    }
+
+    [Fact]
+    public void Parse_HttpWithInlineValue_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CliOptions.Parse(["--http=yes"]));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in HTTP mode to the MCP server via `ModelContextProtocol.AspNetCore` (stateless streamable HTTP). **Stdio remains the default transport**, so existing MCP client configs are unaffected.

- New `CliOptions` parser: `--http`, `--port <n>` (default 3001), `--host <addr>` (default `127.0.0.1`); positional args are still solution paths, both `--flag value` and `--flag=value` syntaxes accepted
- Binds loopback-only by default and prints a security warning when `--host` widens the binding, since the server has no authentication and its tools can modify source files
- Service registration and the `StructuredErrorToolWrapper` are shared between both transport paths
- Drops the explicit `Microsoft.Extensions.Hosting` package: the new `Microsoft.AspNetCore.App` framework reference supplies it (fixes NU1510)
- README: new "HTTP transport" section with client config and the single-user caveat (all connected clients share solution state)

Intended use: one long-lived server with a warm Roslyn workspace shared by several local MCP clients, instead of a server per IDE window. Multi-user (per-session active solution, auth, write serialization) is intentionally out of scope.

## Test plan

- [x] 19 new unit tests for `CliOptions` (flag syntaxes, loopback detection, invalid/missing/unknown flag errors)
- [x] Full suite on the final commit: 1150/1150 passed, 0 skipped (includes the ModelContextProtocol 2.2.0 bump from main)
- [x] Live smoke test of the built binary with `--http`: initialize handshake, `tools/list` (67 tools), and a real `tools/call` all returned 200 over streamable HTTP
- [x] Pre-push review PASS (0 blockers, 1 warning: no automated integration test for the HTTP wiring — composition root is untested by pre-existing convention, smoke-tested manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)