### PR TITLE
fix: run the SDK's source generators by matching its Roslyn version (#399)

### DIFF
--- a/src/RoslynCodeLens/Analyzers/AnalyzerCompilerVersionCheck.cs
+++ b/src/RoslynCodeLens/Analyzers/AnalyzerCompilerVersionCheck.cs
@@ -1,0 +1,123 @@
+using System.Collections.Concurrent;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace RoslynCodeLens.Analyzers;
+
+/// <summary>
+/// Detects analyzer/source-generator assemblies that Roslyn will silently refuse to load because
+/// they were built against a NEWER Microsoft.CodeAnalysis than the one this process runs
+/// (<c>AnalyzerLoadFailed</c> with <c>ReferencesNewerCompiler</c>).
+///
+/// This matters because the refusal is invisible: <c>GetGenerators</c> returns an empty list, the
+/// generator never contributes source, and every downstream answer is confidently wrong rather
+/// than merely incomplete. Issue #399 was exactly this — the .NET SDK's Razor generator targets a
+/// newer Roslyn than the one packaged here, so a Blazor solution that builds clean reported three
+/// phantom compile errors and had no symbols for any <c>.razor</c>-only component.
+///
+/// The SDK moves its Roslyn every feature band (10.0.1xx→5.0, 10.0.2xx→5.3, 10.0.3xx→5.5,
+/// 10.0.4xx→5.9), so a NuGet-distributed tool can never stay permanently ahead. Keeping the
+/// package current is necessary but not sufficient; reporting the skew is what keeps a lagging
+/// build honest instead of wrong.
+///
+/// The check reads PE metadata only — no assembly is loaded, so it is cheap and cannot itself
+/// fail on a skewed assembly.
+/// </summary>
+public static class AnalyzerCompilerVersionCheck
+{
+    private const string RoslynAssemblyName = "Microsoft.CodeAnalysis";
+
+    // Analyzer sets are shared across projects (every project in a solution typically references
+    // the same ~20 SDK analyzers), and the answer is a property of the file on disk.
+    private static readonly ConcurrentDictionary<string, Version?> s_cache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>The Microsoft.CodeAnalysis version this process is running.</summary>
+    public static Version RunningCompilerVersion { get; } =
+        typeof(Compilation).Assembly.GetName().Version ?? new Version(0, 0, 0, 0);
+
+    /// <summary>
+    /// The Microsoft.CodeAnalysis version <paramref name="analyzerPath"/> was compiled against, or
+    /// null when the file is unreadable, is not a managed assembly, or does not reference Roslyn
+    /// at all (a resource-only or utility assembly shipped alongside the real analyzer).
+    /// </summary>
+    public static Version? ReadRequiredCompilerVersion(string analyzerPath) =>
+        s_cache.GetOrAdd(analyzerPath, static path =>
+        {
+            try
+            {
+                using var stream = File.OpenRead(path);
+                using var peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return null;
+
+                var metadata = peReader.GetMetadataReader();
+                foreach (var handle in metadata.AssemblyReferences)
+                {
+                    var reference = metadata.GetAssemblyReference(handle);
+                    if (metadata.GetString(reference.Name).Equals(RoslynAssemblyName, StringComparison.Ordinal))
+                        return reference.Version;
+                }
+
+                return null;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or BadImageFormatException)
+            {
+                // Unreadable or native — nothing to report; Roslyn will ignore it too.
+                return null;
+            }
+        });
+
+    /// <summary>
+    /// Load diagnostics for every analyzer reference in <paramref name="solution"/> that Roslyn
+    /// will skip because it targets a newer compiler. One message per distinct analyzer assembly,
+    /// naming how many projects it affects — a large solution references the same skewed SDK
+    /// analyzer from every project and a per-project message would bury the signal.
+    /// </summary>
+    /// <param name="runningVersion">
+    /// Host compiler version to compare against; defaults to <see cref="RunningCompilerVersion"/>.
+    /// Injectable so tests can exercise the skewed branch without a mismatched assembly on disk.
+    /// </param>
+    public static IReadOnlyList<string> FindSkewedAnalyzers(Solution solution, Version? runningVersion = null)
+    {
+        var running = runningVersion ?? RunningCompilerVersion;
+        Dictionary<string, (Version Required, int Projects)>? skewed = null;
+
+        foreach (var project in solution.Projects)
+        {
+            foreach (var reference in project.AnalyzerReferences)
+            {
+                if (reference is not AnalyzerFileReference fileReference)
+                    continue;
+
+                var required = ReadRequiredCompilerVersion(fileReference.FullPath);
+                if (required is null || required <= running)
+                    continue;
+
+                var name = Path.GetFileNameWithoutExtension(fileReference.FullPath);
+                skewed ??= new Dictionary<string, (Version, int)>(StringComparer.OrdinalIgnoreCase);
+                skewed[name] = skewed.TryGetValue(name, out var existing)
+                    ? (required, existing.Projects + 1)
+                    : (required, 1);
+            }
+        }
+
+        if (skewed is null)
+            return Array.Empty<string>();
+
+        var messages = new List<string>(skewed.Count);
+        foreach (var (name, (required, projects)) in skewed)
+        {
+            messages.Add(
+                $"{name}: built against Roslyn {required} but roslyn-codelens runs {running} — Roslyn " +
+                $"skips it silently (ReferencesNewerCompiler), affecting {projects} project(s). Any source " +
+                "it generates is missing from the compilation, so diagnostics, symbols and references for " +
+                "generated code will be wrong. Upgrade roslyn-codelens, or pin an older .NET SDK via global.json.");
+        }
+
+        messages.Sort(StringComparer.Ordinal);
+        return messages;
+    }
+}

--- a/src/RoslynCodeLens/RoslynCodeLens.csproj
+++ b/src/RoslynCodeLens/RoslynCodeLens.csproj
@@ -36,10 +36,10 @@
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="2.2.0" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="5.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.9.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="11.0.0.9375" />
   </ItemGroup>

--- a/src/RoslynCodeLens/SolutionLoader.cs
+++ b/src/RoslynCodeLens/SolutionLoader.cs
@@ -189,7 +189,7 @@ public class SolutionLoader
                 bestWorkspace?.Dispose();
                 if (analyzerLoader is not null)
                     solution = RemapSolutionAnalyzers(solution, analyzerLoader);
-                return new SolutionOpen(solution, workspace, [], []);
+                return await WithAnalyzerSkewAsync(new SolutionOpen(solution, workspace, [], [])).ConfigureAwait(false);
             }
 
             // Degraded: retain the attempt with the fewest dropped projects.
@@ -218,7 +218,8 @@ public class SolutionLoader
         var finalSolution = analyzerLoader is not null
             ? RemapSolutionAnalyzers(bestSolution!, analyzerLoader)
             : bestSolution!;
-        return new SolutionOpen(finalSolution, bestWorkspace!, [], bestDropped);
+        return await WithAnalyzerSkewAsync(
+            new SolutionOpen(finalSolution, bestWorkspace!, [], bestDropped)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -238,6 +239,27 @@ public class SolutionLoader
                     $"{project.Name}: no metadata references resolved (design-time build dropped references)");
         }
         return (IReadOnlyList<string>?)dropped ?? Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Appends analyzer/generator compiler-version skew to a load's diagnostics (issue #399).
+    /// Kept out of <see cref="FindProjectsWithDroppedReferences"/> on purpose: dropped references
+    /// are a contention artefact a retry can clear, whereas skew is deterministic — folding it
+    /// into the retry predicate would buy nothing and cost two extra full solution loads.
+    /// </summary>
+    private static async Task<SolutionOpen> WithAnalyzerSkewAsync(SolutionOpen open)
+    {
+        var skew = AnalyzerCompilerVersionCheck.FindSkewedAnalyzers(open.Solution);
+        if (skew.Count == 0)
+            return open;
+
+        foreach (var message in skew)
+            await Console.Error.WriteLineAsync($"[roslyn-codelens] {message}").ConfigureAwait(false);
+
+        var combined = new List<string>(open.LoadDiagnostics.Count + skew.Count);
+        combined.AddRange(open.LoadDiagnostics);
+        combined.AddRange(skew);
+        return open with { LoadDiagnostics = combined };
     }
 
     private static Solution RemapSolutionAnalyzers(Solution solution, ShadowCopyAnalyzerAssemblyLoader loader)
@@ -436,7 +458,8 @@ public class SolutionLoader
         workspace.AddSolution(solutionInfo);
 
         var dropped = FindProjectsWithDroppedReferences(workspace.CurrentSolution);
-        return new SolutionOpen(workspace.CurrentSolution, workspace, skipped, dropped);
+        return await WithAnalyzerSkewAsync(
+            new SolutionOpen(workspace.CurrentSolution, workspace, skipped, dropped)).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetDiagnosticsTool.cs
@@ -33,7 +33,7 @@ public static class GetDiagnosticsTool
 
         // Sort severity-first so truncated top-N keeps the most important diagnostics.
         var sorted = SortBySeverityFileLine(raw);
-        var summary = BuildSummary(raw);
+        var summary = BuildSummary(raw, context.Loaded.LoadDiagnostics);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit, summary);
     }
 
@@ -55,7 +55,16 @@ public static class GetDiagnosticsTool
         _ => 4,
     };
 
-    internal static object BuildSummary(IReadOnlyList<DiagnosticInfo> items)
+    /// <summary>
+    /// Severity tallies, plus an explicit <c>unreliable</c> block when the solution loaded
+    /// degraded. get_diagnostics is the tool where a degraded load does the most damage: it
+    /// reports phantom errors with the same confidence as real ones, and an agent acting on that
+    /// output "fixes" code that was never broken (issue #399). Callers must be able to see that
+    /// from the response itself rather than having to call load_solution separately.
+    /// </summary>
+    internal static object BuildSummary(
+        IReadOnlyList<DiagnosticInfo> items,
+        IReadOnlyList<string>? loadDiagnostics = null)
     {
         var error = 0;
         var warning = 0;
@@ -71,6 +80,21 @@ public static class GetDiagnosticsTool
                 case "Hidden": hidden++; break;
             }
         }
-        return new { error, warning, info, hidden };
+        if (loadDiagnostics is null || loadDiagnostics.Count == 0)
+            return new { error, warning, info, hidden };
+
+        return new
+        {
+            error,
+            warning,
+            info,
+            hidden,
+            unreliable = new
+            {
+                reason = "The solution loaded degraded, so these diagnostics may include errors that "
+                       + "do not exist in a real build. Verify against 'dotnet build' before acting on them.",
+                loadDiagnostics,
+            },
+        };
     }
 }

--- a/tests/RoslynCodeLens.Tests/Analyzers/AnalyzerCompilerVersionCheckTests.cs
+++ b/tests/RoslynCodeLens.Tests/Analyzers/AnalyzerCompilerVersionCheckTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using RoslynCodeLens.Analyzers;
+
+namespace RoslynCodeLens.Tests.Analyzers;
+
+/// <summary>
+/// Issue #399. Roslyn's <see cref="AnalyzerFileReference"/> silently refuses any analyzer built
+/// against a NEWER Microsoft.CodeAnalysis than the host: it raises AnalyzerLoadFailed with
+/// ErrorCode ReferencesNewerCompiler, hands back zero generators, and reports nothing. The Razor
+/// generator hit exactly that, so a Blazor solution that builds clean reported phantom compile
+/// errors. These tests cover the metadata-only pre-check that turns that silence into a load
+/// diagnostic.
+/// </summary>
+public class AnalyzerCompilerVersionCheckTests
+{
+    private static readonly string s_analyzerLikeDll = typeof(CSharpSyntaxTree).Assembly.Location;
+
+    [Fact]
+    public void ReadRequiredCompilerVersion_ReturnsReferencedRoslynVersion()
+    {
+        // Microsoft.CodeAnalysis.CSharp.dll references Microsoft.CodeAnalysis, exactly as a real
+        // analyzer assembly does.
+        var version = AnalyzerCompilerVersionCheck.ReadRequiredCompilerVersion(s_analyzerLikeDll);
+
+        Assert.Equal(AnalyzerCompilerVersionCheck.RunningCompilerVersion, version);
+    }
+
+    [Fact]
+    public void ReadRequiredCompilerVersion_ReturnsNull_WhenAssemblyDoesNotReferenceRoslyn()
+    {
+        var version = AnalyzerCompilerVersionCheck.ReadRequiredCompilerVersion(typeof(object).Assembly.Location);
+
+        Assert.Null(version);
+    }
+
+    [Fact]
+    public void ReadRequiredCompilerVersion_ReturnsNull_ForMissingOrUnreadableFile()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "rcl-not-here-" + Guid.NewGuid().ToString("N") + ".dll");
+
+        Assert.Null(AnalyzerCompilerVersionCheck.ReadRequiredCompilerVersion(missing));
+    }
+
+    [Fact]
+    public void FindSkewedAnalyzers_ReportsAnalyzerBuiltAgainstNewerCompiler()
+    {
+        var solution = SolutionWithAnalyzer(s_analyzerLikeDll);
+
+        // Pretend the host runs an ancient Roslyn, so the real analyzer DLL is "newer".
+        var skew = AnalyzerCompilerVersionCheck.FindSkewedAnalyzers(solution, new Version(1, 0, 0, 0));
+
+        var message = Assert.Single(skew);
+        Assert.Contains("Microsoft.CodeAnalysis.CSharp", message, StringComparison.Ordinal);
+        Assert.Contains(AnalyzerCompilerVersionCheck.RunningCompilerVersion.ToString(), message, StringComparison.Ordinal);
+        Assert.Contains("1.0.0.0", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindSkewedAnalyzers_IsSilent_WhenHostCompilerIsNewEnough()
+    {
+        var solution = SolutionWithAnalyzer(s_analyzerLikeDll);
+
+        var skew = AnalyzerCompilerVersionCheck.FindSkewedAnalyzers(solution, new Version(999, 0, 0, 0));
+
+        Assert.Empty(skew);
+    }
+
+    [Fact]
+    public void FindSkewedAnalyzers_ReportsEachAnalyzerOnce_AcrossProjects()
+    {
+        var solution = SolutionWithAnalyzer(s_analyzerLikeDll, projectCount: 3);
+
+        var skew = AnalyzerCompilerVersionCheck.FindSkewedAnalyzers(solution, new Version(1, 0, 0, 0));
+
+        var message = Assert.Single(skew);
+        Assert.Contains("3 project(s)", message, StringComparison.Ordinal);
+    }
+
+    private static Solution SolutionWithAnalyzer(string analyzerPath, int projectCount = 1)
+    {
+        using var cache = new SharedAnalyzerAssemblyCache();
+        using var loader = new ShadowCopyAnalyzerAssemblyLoader(cache);
+        var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution;
+
+        for (var i = 0; i < projectCount; i++)
+        {
+            var projectId = ProjectId.CreateNewId();
+            solution = solution
+                .AddProject(projectId, $"Proj{i}", $"Proj{i}", LanguageNames.CSharp)
+                .AddAnalyzerReference(projectId, new AnalyzerFileReference(analyzerPath, loader));
+        }
+
+        return solution;
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetDiagnosticsToolTests.cs
@@ -246,6 +246,31 @@ public class GetDiagnosticsToolTests
         Assert.Contains("\"hidden\":0", json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BuildSummary_OmitsUnreliableBlock_WhenLoadIsHealthy()
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            GetDiagnosticsTool.BuildSummary(Array.Empty<DiagnosticInfo>(), Array.Empty<string>()));
+
+        Assert.DoesNotContain("unreliable", json, StringComparison.Ordinal);
+    }
+
+    // Issue #399: a degraded load (e.g. the SDK's Razor generator skipped because it targets a
+    // newer Roslyn) makes get_diagnostics report errors that do not exist in a real build. The
+    // response must say so — silently confident output is what makes an agent "fix" working code.
+    [Fact]
+    public void BuildSummary_FlagsDiagnosticsAsUnreliable_WhenLoadIsDegraded()
+    {
+        var loadDiagnostics = new[] { "Microsoft.CodeAnalysis.Razor.Compiler: built against Roslyn 5.9.0.0" };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(
+            GetDiagnosticsTool.BuildSummary(Array.Empty<DiagnosticInfo>(), loadDiagnostics));
+
+        Assert.Contains("unreliable", json, StringComparison.Ordinal);
+        Assert.Contains("Microsoft.CodeAnalysis.Razor.Compiler", json, StringComparison.Ordinal);
+        Assert.Contains("dotnet build", json, StringComparison.Ordinal);
+    }
+
     private sealed class TempTrustFile : IDisposable
     {
         public string Path { get; }


### PR DESCRIPTION
Fixes #399.

## Root cause

Not a missing generator driver — a **compiler version skew**.

```
LOAD-FAILED [ReferencesNewerCompiler]
  <sdk>/10.0.400/Sdks/Microsoft.NET.Sdk.Razor/source-generators/
    Microsoft.CodeAnalysis.Razor.Compiler.dll  →  refs Microsoft.CodeAnalysis 5.9.0.0
  roslyn-codelens loads                        →  Microsoft.CodeAnalysis 5.6.0.0
  generators returned: 0
```

Roslyn's `AnalyzerFileReference` refuses any analyzer built against a newer compiler. It raises `AnalyzerLoadFailed(ReferencesNewerCompiler)`, hands back zero generators, and reports nothing. The Razor generator therefore never ran → `Counter` never got its `ComponentBase` half (CS0115/CS0117) and `App` never existed (CS0246).

## Three claims in the issue that turned out to be wrong

Recorded here so nobody implements them later:

1. **".razor never enter the workspace as AdditionalDocuments."** They do — all 11 are present, with the `GeneratedMSBuildEditorConfig` per-file metadata.
2. **"The generator driver is never run."** The Roslyn workspace runs generators itself; `PublicProgramSourceGenerator` output was in the compilation even on 5.6.0. Adding a manual `CSharpGeneratorDriver` on top duplicates every generated file — measured: **56 bogus CS0111/CS0102/CS0579 errors**.
3. **"`search_symbols PublicTopLevelProgram` → 0, so there is no generator output."** `PublicTopLevelProgram` is the *hint filename*; the generated type is `Program`.

Also: `.slnx` auto-discovery works. `FindSolutionFile` handles it and a bare `.slnx` directory loads fine. The `"No .sln file found"` text also fires from `SolutionManager.EnsureLoaded()` whenever zero projects compiled, which is what that report most likely hit — tracked separately below.

## Changes

**1. Bump `Microsoft.CodeAnalysis.*` 5.6.0 → 5.9.0.**

| against the repro | 5.6.0 | 5.9.0 |
|---|---|---|
| `get_diagnostics severity=error` | 3 phantom errors | **0** |
| `search_symbols "Home"` (no code-behind) | 0 items | **finds `RazorRepro.Components.Pages.Home`** |
| Razor generator trees in compilation | none | 11 `*_razor.g.cs` |

**2. Detect the skew and report it — because the bump alone is not a fix.**

The SDK moves its Roslyn every feature band, so a NuGet-distributed tool can never stay permanently ahead:

| SDK | Razor compiler references |
|---|---|
| 9.0.1xx | Microsoft.CodeAnalysis 4.9.0.0 |
| 9.0.3xx | 4.14.0.0 |
| 10.0.1xx | 5.0.0.0 |
| 10.0.2xx | 5.3.0.0 |
| 10.0.3xx | 5.5.0.0 |
| 10.0.4xx | 5.9.0.0 |

The next SDK re-breaks this, silently, for anyone who hasn't upgraded. `AnalyzerCompilerVersionCheck` reads PE metadata only (no assembly load, cached per path) to compare each analyzer's referenced Roslyn against the running one, and feeds mismatches into `LoadDiagnostics` → `Degraded`. `get_diagnostics` then carries an explicit `unreliable` block, since it is the tool where a degraded load does the most damage.

Verified by rebuilding at 5.6.0 with the guard in place:

```
[roslyn-codelens] Microsoft.CodeAnalysis.Razor.Compiler: built against Roslyn 5.9.0.0
but roslyn-codelens runs 5.6.0.0 — Roslyn skips it silently (ReferencesNewerCompiler),
affecting 1 project(s). ...
```

```json
"summary": { "error": 3, ..., "unreliable": {
  "reason": "The solution loaded degraded, so these diagnostics may include errors that
             do not exist in a real build. Verify against 'dotnet build' before acting on them.",
  "loadDiagnostics": ["Microsoft.CodeAnalysis.Razor.Compiler: built against Roslyn 5.9.0.0 ..."] } }
```

Skew is deliberately kept out of the retry predicate — dropped references are a contention artefact a retry can clear, skew is deterministic, so folding it in would cost two extra full solution loads for nothing.

**Behaviour note:** `Degraded` also drives `SolutionChangeSafety.DegradedApplyRefusal`, so a skewed load now refuses `rename_symbol` / `change_signature` unless `force` is passed. That is intended — with the Razor generator missing, a component rename silently misses every markup reference.

## Testing

- 8 new tests; full suite **1158 passed, 0 failed**.
- End-to-end against a stock `dotnet new blazor` + `.slnx`, driven through the real MCP stdio server, in both directions (5.6.0 → warning fires; 5.9.0 → clean).

## Not fixed here

- `get_source_generators` still name-guesses from path segments — reports `"Components"` for the Razor generator instead of `Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator`. Should read identity from `Project.GetSourceGeneratedDocumentsAsync()`.
- `get_file_overview` on a `.razor` path returns `FileNotFound` (they are AdditionalDocuments).
- `search_symbols` returns `"project": ""` for source-generated symbols, and `isGenerated: false` there while `find_references` reports `isGenerated: true` for the same file.
- `EnsureLoaded()` says "No .sln file found" for any zero-project load, including loads where the solution was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
