### PR TITLE
fix: resolve generated-code blind spots surfaced by #399

### DIFF
--- a/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
+++ b/benchmarks/RoslynCodeLens.Benchmarks/CodeGraphBenchmarks.cs
@@ -301,9 +301,9 @@ public class CodeGraphBenchmarks
     }
 
     [Benchmark(Description = "get_source_generators: all")]
-    public object GetSourceGenerators()
+    public async Task<object> GetSourceGenerators()
     {
-        return GetSourceGeneratorsLogic.Execute(_loaded, _resolver, null);
+        return await GetSourceGeneratorsLogic.ExecuteAsync(_loaded, null).ConfigureAwait(false);
     }
 
     [Benchmark(Description = "get_generated_code: all")]

--- a/src/RoslynCodeLens/SolutionManager.cs
+++ b/src/RoslynCodeLens/SolutionManager.cs
@@ -182,8 +182,31 @@ public sealed class SolutionManager : IDisposable
             throw new InvalidOperationException("Solution warmup failed.", _warmupException);
         if (_loaded.IsEmpty)
             throw new InvalidOperationException(
-                "No .sln file found. Either run from a directory containing a .sln/.slnx file, " +
-                "or pass the solution path as argument: roslyn-codelens-mcp /path/to/Solution.sln");
+                DescribeEmptyWorkspace(_solutionPath, _loaded.SkippedProjects));
+    }
+
+    /// <summary>
+    /// An empty workspace has two very different causes and they need different messages. Saying
+    /// "No .sln file found" when a solution WAS found but every project failed to open sends the
+    /// reader off hunting for a missing file instead of at the load failure that actually happened
+    /// (issue #399 was reported partly on the strength of this message).
+    /// </summary>
+    internal static string DescribeEmptyWorkspace(string? solutionPath, IReadOnlyList<SkippedProject> skipped)
+    {
+        if (solutionPath is null)
+        {
+            return "No solution found. Either run from a directory containing a .sln/.slnx file, " +
+                   "or pass the solution path as argument: roslyn-codelens-mcp /path/to/Solution.sln";
+        }
+
+        var name = Path.GetFileName(solutionPath);
+        if (skipped.Count == 0)
+            return $"Solution '{name}' loaded but contains no projects that could be compiled.";
+
+        var reasons = string.Join("; ", skipped.Take(5).Select(p => $"{p.Name}: {p.Reason}"));
+        var more = skipped.Count > 5 ? $" (and {skipped.Count - 5} more)" : "";
+        return $"Solution '{name}' loaded but all {skipped.Count} project(s) were skipped, so there is " +
+               $"nothing to query. Reasons: {reasons}{more}";
     }
 
     private void ThrowIfLoadFailed()

--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -111,6 +111,20 @@ public class SymbolResolver
                 if (doc.FilePath != null)
                     fileToProject[doc.FilePath] = project.Name;
             }
+
+            // Source-generated documents are not in project.Documents, but their symbols are
+            // real and get returned by search_symbols/find_references. Indexing only the
+            // on-disk documents left every generated symbol reporting an empty project name
+            // — which is most symbols in a Blazor project, where components live in
+            // generator output. The compilation is the only place both kinds appear together.
+            if (loaded.Compilations.TryGetValue(project.Id, out var compilation))
+            {
+                foreach (var tree in compilation.SyntaxTrees)
+                {
+                    if (!string.IsNullOrEmpty(tree.FilePath))
+                        fileToProject[tree.FilePath] = project.Name;
+                }
+            }
         }
 
         return (fileToProject, idToName);

--- a/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
@@ -10,23 +10,14 @@ public static class GetFileOverviewLogic
         LoadedSolution loaded, SymbolResolver resolver, string filePath, CancellationToken ct)
     {
         var normalizedPath = Path.GetFullPath(filePath);
-        Project? targetProject = null;
-        Document? targetDocument = null;
 
-        foreach (var project in loaded.Solution.Projects)
-        {
-            foreach (var doc in project.Documents)
-            {
-                if (doc.FilePath != null &&
-                    doc.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
-                {
-                    targetProject = project;
-                    targetDocument = doc;
-                    break;
-                }
-            }
-            if (targetProject != null) break;
-        }
+        var (targetProject, targetDocument) = FindDocument(loaded, normalizedPath);
+
+        // Markup files (.razor/.cshtml) are AdditionalDocuments, not C# documents — the C# for
+        // them only exists as source-generator output. Resolving through to that output is what
+        // makes a component with no code-behind inspectable at all (issue #399).
+        if (targetDocument == null)
+            (targetProject, targetDocument) = await FindGeneratedDocumentForMarkupAsync(loaded, normalizedPath, ct).ConfigureAwait(false);
 
         if (targetDocument == null || targetProject == null)
             throw new McpToolException(ToolErrorCode.FileNotFound, $"File '{filePath}' not found in any loaded project.", new { filePath });
@@ -44,12 +35,107 @@ public static class GetFileOverviewLogic
                 .ToList();
         }
 
-        // Diagnostics scoped to this file
+        // Diagnostics scoped to this file. When the request resolved through to generated output,
+        // diagnostics can be attributed to either path: Razor emits #line directives, so the
+        // compiler reports most of them against the .razor file, but anything outside a mapped
+        // region still carries the generated path.
+        var generatedPath = targetDocument.FilePath;
         var projectName = resolver.GetProjectName(targetProject.Id);
         var diagnostics = GetDiagnosticsLogic.Execute(loaded, resolver, project: null, severity: null)
-            .Where(d => d.File.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+            .Where(d => d.File.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase)
+                     || (generatedPath != null && d.File.Equals(generatedPath, StringComparison.OrdinalIgnoreCase)))
             .ToList();
 
         return new FileOverview(normalizedPath, projectName, typesDefined, diagnostics);
+    }
+
+    private static (Project?, Document?) FindDocument(LoadedSolution loaded, string normalizedPath)
+    {
+        foreach (var project in loaded.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath != null &&
+                    doc.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return (project, doc);
+                }
+            }
+        }
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Maps a markup file to the source-generated document produced from it, in two tiers.
+    ///
+    /// First by hint-name convention: the Razor generator names its output after the component's
+    /// project-relative path, so <c>Components/Pages/Counter.razor</c> becomes hint
+    /// <c>Components/Pages/Counter_razor.g.cs</c>. That is exact when it matches.
+    ///
+    /// Then by line mappings, which any generator emitting <c>#line</c> directives provides, so the
+    /// mapping survives a change in naming convention. A unique match is required: a shared file
+    /// such as <c>_Imports.razor</c> line-maps into every component in the project, and picking an
+    /// arbitrary one of those would be worse than reporting nothing.
+    /// </summary>
+    private static async Task<(Project?, Document?)> FindGeneratedDocumentForMarkupAsync(
+        LoadedSolution loaded, string normalizedPath, CancellationToken ct)
+    {
+        foreach (var project in loaded.Solution.Projects)
+        {
+            var additional = project.AdditionalDocuments.FirstOrDefault(
+                d => d.FilePath != null && d.FilePath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+            if (additional == null)
+                continue;
+
+            var generated = (await project.GetSourceGeneratedDocumentsAsync(ct).ConfigureAwait(false)).ToList();
+
+            var expectedHint = ExpectedHintName(additional);
+            foreach (var candidate in generated)
+            {
+                if (NormalizeHint(candidate.HintName).Equals(expectedHint, StringComparison.OrdinalIgnoreCase))
+                    return (project, candidate);
+            }
+
+            Document? unique = null;
+            foreach (var candidate in generated)
+            {
+                if (!await MapsToSourceFileAsync(candidate, normalizedPath, ct).ConfigureAwait(false))
+                    continue;
+                if (unique != null)
+                    return (null, null); // ambiguous — shared markup such as _Imports.razor
+                unique = candidate;
+            }
+
+            return unique != null ? (project, unique) : (null, null);
+        }
+
+        return (null, null);
+    }
+
+    internal static string ExpectedHintName(TextDocument additional)
+    {
+        var fileName = additional.Name.Replace('.', '_') + ".g.cs";
+        return additional.Folders.Count == 0
+            ? fileName
+            : string.Join('/', additional.Folders) + "/" + fileName;
+    }
+
+    private static string NormalizeHint(string hintName) => hintName.Replace('\\', '/');
+
+    private static async Task<bool> MapsToSourceFileAsync(Document generated, string normalizedPath, CancellationToken ct)
+    {
+        var tree = await generated.GetSyntaxTreeAsync(ct).ConfigureAwait(false);
+        if (tree == null)
+            return false;
+
+        foreach (var mapping in tree.GetLineMappings(ct))
+        {
+            if (mapping.IsHidden || !mapping.MappedSpan.HasMappedPath)
+                continue;
+            if (mapping.MappedSpan.Path.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewTool.cs
@@ -9,10 +9,11 @@ public static class GetFileOverviewTool
 {
     [McpServerTool(Name = "get_file_overview"),
      Description("Get a summary of a C# file: which types are defined in it and any compiler diagnostics. " +
-                 "Useful for quickly understanding a file's contents without reading it.")]
+                 "Useful for quickly understanding a file's contents without reading it. " +
+                 "Also accepts .razor/.cshtml markup, resolving it to the C# document its source generator produced.")]
     public static async Task<FileOverview> Execute(
         MultiSolutionManager manager,
-        [Description("Full path to the C# source file")] string filePath,
+        [Description("Full path to the source file (.cs, or .razor/.cshtml)")] string filePath,
         CancellationToken ct = default)
     {
         manager.EnsureLoaded();

--- a/src/RoslynCodeLens/Tools/GetSourceGeneratorsLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetSourceGeneratorsLogic.cs
@@ -5,7 +5,20 @@ namespace RoslynCodeLens.Tools;
 
 public static class GetSourceGeneratorsLogic
 {
-    public static IReadOnlyList<SourceGeneratorInfo> Execute(LoadedSolution loaded, SymbolResolver resolver, string? project)
+    internal const string UnknownGenerator = "Unknown";
+
+    /// <summary>
+    /// Groups a project's real source-generator output by the generator that produced it.
+    ///
+    /// Uses <see cref="Project.GetSourceGeneratedDocumentsAsync"/> rather than sniffing syntax-tree
+    /// paths for an <c>obj/</c> segment. The old path heuristic was wrong in both directions: it
+    /// swept in MSBuild-authored intermediates that no generator produced (AssemblyInfo.cs,
+    /// GlobalUsings.g.cs, .AssemblyAttributes.cs), and it could not name the generator, reporting
+    /// "Unknown" — or, once real generators started running, whichever path segment happened to
+    /// have no dot in it, e.g. "Components" for the Razor generator (issue #399).
+    /// </summary>
+    public static async Task<IReadOnlyList<SourceGeneratorInfo>> ExecuteAsync(
+        LoadedSolution loaded, string? project, CancellationToken ct = default)
     {
         var results = new List<SourceGeneratorInfo>();
 
@@ -14,59 +27,52 @@ public static class GetSourceGeneratorsLogic
             if (project != null && !proj.Name.Equals(project, StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            if (!loaded.Compilations.TryGetValue(proj.Id, out var compilation))
-                continue;
+            var generated = await proj.GetSourceGeneratedDocumentsAsync(ct).ConfigureAwait(false);
 
             var byGenerator = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-            foreach (var tree in compilation.SyntaxTrees)
+            foreach (var document in generated)
             {
-                if (!resolver.IsGenerated(tree.FilePath))
-                    continue;
-                var genName = InferGeneratorName(tree.FilePath);
-                if (!byGenerator.TryGetValue(genName, out var fileList))
+                var generatorName = InferGeneratorName(document.FilePath, document.HintName);
+                if (!byGenerator.TryGetValue(generatorName, out var files))
                 {
-                    fileList = new List<string>();
-                    byGenerator[genName] = fileList;
+                    files = new List<string>();
+                    byGenerator[generatorName] = files;
                 }
-                fileList.Add(tree.FilePath);
+                files.Add(document.FilePath ?? document.HintName);
             }
 
-            if (byGenerator.Count == 0)
-                continue;
-
-            foreach (var (genName, files) in byGenerator)
+            foreach (var (generatorName, files) in byGenerator)
             {
-                results.Add(new SourceGeneratorInfo(
-                    genName,
-                    proj.Name,
-                    files.Count,
-                    files));
+                files.Sort(StringComparer.Ordinal);
+                results.Add(new SourceGeneratorInfo(generatorName, proj.Name, files.Count, files));
             }
         }
 
         return results;
     }
 
-    private static string InferGeneratorName(string filePath)
+    /// <summary>
+    /// Recovers the generator's type name from the synthetic path Roslyn gives a source-generated
+    /// document: <c>&lt;intermediateOutput&gt;/&lt;analyzerAssembly&gt;/&lt;generatorType&gt;/&lt;hintName&gt;</c>.
+    /// The hint name may itself contain directory separators (the Razor generator uses the
+    /// component's relative path), so it is stripped by length rather than by taking a fixed
+    /// number of trailing segments.
+    /// </summary>
+    internal static string InferGeneratorName(string? filePath, string hintName)
     {
-        var parts = filePath.Replace('\\', '/').Split('/');
-        var objIndex = Array.FindIndex(parts, p => p.Equals("obj", StringComparison.OrdinalIgnoreCase));
+        if (string.IsNullOrEmpty(filePath) || string.IsNullOrEmpty(hintName))
+            return UnknownGenerator;
 
-        if (objIndex >= 0 && objIndex + 3 < parts.Length)
-        {
-#pragma warning disable HLQ013
-            for (var i = objIndex + 3; i < parts.Length - 1; i++)
-#pragma warning restore HLQ013
-            {
-                var segment = parts[i];
-                if (!segment.Equals("generated", StringComparison.OrdinalIgnoreCase)
-                    && !segment.Contains('.', StringComparison.Ordinal))
-                {
-                    return segment;
-                }
-            }
-        }
+        var path = filePath.Replace('\\', '/');
+        var hint = hintName.Replace('\\', '/');
+        if (!path.EndsWith(hint, StringComparison.OrdinalIgnoreCase))
+            return UnknownGenerator;
 
-        return "Unknown";
+        var directory = path[..^hint.Length].TrimEnd('/');
+        var lastSeparator = directory.LastIndexOf('/');
+        if (lastSeparator < 0 || lastSeparator == directory.Length - 1)
+            return UnknownGenerator;
+
+        return directory[(lastSeparator + 1)..];
     }
 }

--- a/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
+++ b/src/RoslynCodeLens/Tools/GetSourceGeneratorsTool.cs
@@ -12,15 +12,16 @@ public static class GetSourceGeneratorsTool
     [McpServerTool(Name = "get_source_generators"),
      Description("List source generators and their output per project. " +
                  "Returns an envelope with items sorted by project then generator name, totalCount, truncated, and limit (default 100).")]
-    public static ToolListResult<SourceGeneratorInfo> Execute(
+    public static async Task<ToolListResult<SourceGeneratorInfo>> Execute(
         MultiSolutionManager manager,
         [Description("Optional project name filter")] string? project = null,
         [Description("Maximum number of items to return (default: 100). Items are sorted by project, then generator name.")]
-            int? limit = null)
+            int? limit = null,
+        CancellationToken ct = default)
     {
         manager.EnsureLoaded();
         var context = manager.GetAnalysisContext();
-        var raw = GetSourceGeneratorsLogic.Execute(context.Loaded, context.Resolver, project);
+        var raw = await GetSourceGeneratorsLogic.ExecuteAsync(context.Loaded, project, ct).ConfigureAwait(false);
 
         var sorted = Sort(raw);
         return ToolListResult.Create(sorted, limit ?? DefaultLimit);

--- a/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
@@ -50,7 +50,7 @@ public static class SearchSymbolsLogic
                 var project = resolver.GetProjectName(type);
                 results.Add(new SymbolLocation(
                     kind, type.ToDisplayString(), file, line, project,
-                    IsGenerated: false,
+                    IsGenerated: resolver.IsGenerated(file),
                     Origin: MetadataSymbolResolver.SourceOrigin));
 
                 if (results.Count >= MaxResults)
@@ -89,7 +89,7 @@ public static class SearchSymbolsLogic
                 results.Add(new SymbolLocation(
                     kind, member.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                     file, line, project,
-                    IsGenerated: false,
+                    IsGenerated: resolver.IsGenerated(file),
                     Origin: MetadataSymbolResolver.SourceOrigin));
 
                 if (results.Count >= MaxResults)

--- a/tests/RoslynCodeLens.Tests/SolutionManagerTests.cs
+++ b/tests/RoslynCodeLens.Tests/SolutionManagerTests.cs
@@ -45,6 +45,58 @@ public class SolutionManagerTests : IAsyncLifetime
         manager.Dispose();
     }
 
+    // Issue #399: an empty workspace has two causes that need different messages. Reporting
+    // "No .sln file found" for a solution that WAS found but whose projects all failed to open
+    // sends the reader hunting for a missing file instead of at the actual load failure.
+    [Fact]
+    public void DescribeEmptyWorkspace_SaysNoSolution_WhenNonePassedOrDiscovered()
+    {
+        var message = SolutionManager.DescribeEmptyWorkspace(null, Array.Empty<SkippedProject>());
+
+        Assert.Contains("No solution found", message, StringComparison.Ordinal);
+        Assert.Contains(".slnx", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DescribeEmptyWorkspace_NamesTheSolution_WhenItLoadedWithNoProjects()
+    {
+        var message = SolutionManager.DescribeEmptyWorkspace(
+            @"C:/code/MyApp.slnx", Array.Empty<SkippedProject>());
+
+        Assert.Contains("MyApp.slnx", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("No solution found", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DescribeEmptyWorkspace_ReportsSkipReasons_WhenEveryProjectWasSkipped()
+    {
+        var skipped = new[]
+        {
+            new SkippedProject(@"C:/code/A.csproj", "A", "Legacy", "non-SDK project"),
+            new SkippedProject(@"C:/code/B.csproj", "B", "Failed", "design-time build failed"),
+        };
+
+        var message = SolutionManager.DescribeEmptyWorkspace(@"C:/code/MyApp.slnx", skipped);
+
+        Assert.Contains("MyApp.slnx", message, StringComparison.Ordinal);
+        Assert.Contains("all 2 project(s) were skipped", message, StringComparison.Ordinal);
+        Assert.Contains("A: non-SDK project", message, StringComparison.Ordinal);
+        Assert.Contains("B: design-time build failed", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DescribeEmptyWorkspace_TruncatesLongSkipLists()
+    {
+        var skipped = Enumerable.Range(0, 8)
+            .Select(i => new SkippedProject($"C:/code/P{i}.csproj", $"P{i}", "Failed", "boom"))
+            .ToArray();
+
+        var message = SolutionManager.DescribeEmptyWorkspace(@"C:/code/MyApp.slnx", skipped);
+
+        Assert.Contains("all 8 project(s) were skipped", message, StringComparison.Ordinal);
+        Assert.Contains("(and 3 more)", message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task CreateAsync_ReturnsBeforeCompilationCompletes()
     {

--- a/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
@@ -43,4 +43,27 @@ public class GetFileOverviewToolTests
 
         Assert.Equal(ToolErrorCode.FileNotFound, ex.Code);
     }
+
+    // Issue #399: a .razor file is an AdditionalDocument, so it has no C# document of its own and
+    // get_file_overview reported FileNotFound. It is resolved through to the source generator's
+    // output instead, and the Razor generator names that output after the component's
+    // project-relative path: Components/Pages/Counter.razor -> Components/Pages/Counter_razor.g.cs.
+    [Theory]
+    [InlineData("Counter.razor", new[] { "Components", "Pages" }, "Components/Pages/Counter_razor.g.cs")]
+    [InlineData("App.razor", new[] { "Components" }, "Components/App_razor.g.cs")]
+    [InlineData("Index.cshtml", new string[0], "Index_cshtml.g.cs")]
+    [InlineData("Weather.Details.razor", new[] { "Pages" }, "Pages/Weather_Details_razor.g.cs")]
+    public void ExpectedHintName_MirrorsProjectRelativePath(string name, string[] folders, string expected)
+    {
+        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
+        var projectId = Microsoft.CodeAnalysis.ProjectId.CreateNewId();
+        var documentId = Microsoft.CodeAnalysis.DocumentId.CreateNewId(projectId);
+        var solution = workspace.CurrentSolution
+            .AddProject(projectId, "Markup", "Markup", Microsoft.CodeAnalysis.LanguageNames.CSharp)
+            .AddAdditionalDocument(documentId, name, "", folders);
+
+        var additional = solution.GetAdditionalDocument(documentId)!;
+
+        Assert.Equal(expected, GetFileOverviewLogic.ExpectedHintName(additional));
+    }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetSourceGeneratorsToolTests.cs
@@ -17,19 +17,47 @@ public class GetSourceGeneratorsToolTests
     }
 
     [Fact]
-    public void Execute_ReturnsEmptyList_WhenNoGenerators()
+    public async Task Execute_ReturnsEmptyList_WhenNoGenerators()
     {
-        var results = GetSourceGeneratorsLogic.Execute(_loaded, _resolver, null);
+        var results = await GetSourceGeneratorsLogic.ExecuteAsync(_loaded, null);
         Assert.NotNull(results);
     }
 
     [Fact]
-    public void Execute_FiltersByProject_WhenProjectSpecified()
+    public async Task Execute_FiltersByProject_WhenProjectSpecified()
     {
         var projectName = _loaded.Solution.Projects.First().Name;
-        var results = GetSourceGeneratorsLogic.Execute(_loaded, _resolver, projectName);
+        var results = await GetSourceGeneratorsLogic.ExecuteAsync(_loaded, projectName);
         Assert.NotNull(results);
         Assert.All(results, r => Assert.Equal(projectName, r.Project));
+    }
+
+    // Issue #399: the old implementation sniffed syntax-tree paths for an obj/ segment and named
+    // the generator after the first dot-free path segment. For the Razor generator that produced
+    // "Components" — a directory inside the hint name, not a generator.
+    [Theory]
+    [InlineData(
+        @"C:/proj/obj/Debug/net10.0/Microsoft.CodeAnalysis.Razor.Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator/Components/Pages/Counter_razor.g.cs",
+        "Components/Pages/Counter_razor.g.cs",
+        "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator")]
+    [InlineData(
+        @"C:/proj/obj/Debug/net10.0/Microsoft.AspNetCore.App.SourceGenerators/Microsoft.AspNetCore.SourceGenerators.PublicProgramSourceGenerator/PublicTopLevelProgram.Generated.g.cs",
+        "PublicTopLevelProgram.Generated.g.cs",
+        "Microsoft.AspNetCore.SourceGenerators.PublicProgramSourceGenerator")]
+    public void InferGeneratorName_RecoversGeneratorTypeName(string filePath, string hintName, string expected)
+    {
+        Assert.Equal(expected, GetSourceGeneratorsLogic.InferGeneratorName(filePath, hintName));
+    }
+
+    [Theory]
+    [InlineData(null, "Some.g.cs")]
+    [InlineData("C:/proj/Some.g.cs", "")]
+    [InlineData("C:/completely-unrelated.cs", "Some.g.cs")]
+    [InlineData("Some.g.cs", "Some.g.cs")]
+    public void InferGeneratorName_FallsBackToUnknown_WhenPathShapeIsUnexpected(string? filePath, string hintName)
+    {
+        Assert.Equal(GetSourceGeneratorsLogic.UnknownGenerator,
+            GetSourceGeneratorsLogic.InferGeneratorName(filePath, hintName));
     }
 
     [Fact]


### PR DESCRIPTION
Follow-ups from #400, which merged before this work landed on its branch. Same area throughout: things that only misbehave once source-generator output is actually present in the compilation — which, before #400, it never was for Razor.

## 1. `get_source_generators` misnamed the generator

It sniffed syntax-tree paths for an `obj/` segment and took the first path segment without a dot in it. For a hint name like `Components/Pages/Counter_razor.g.cs` that is a **directory**, so the Razor generator was reported as `"Components"`. The same heuristic also swept in six MSBuild-authored intermediates (`AssemblyInfo.cs`, `GlobalUsings.g.cs`, `.AssemblyAttributes.cs`) that no generator produced and reported them as generator output.

Rebuilt on `Project.GetSourceGeneratedDocumentsAsync`, which is authoritative about what is generated, with the generator's type name recovered from the synthetic path Roslyn assigns (hint name stripped by length, since it may itself contain separators).

```
before:  Unknown        6 files   ← all MSBuild intermediates, no generator output
         Components    11 files   ← after #400; "Components" is a directory

after:   Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator        11 files
         Microsoft.AspNetCore.SourceGenerators.PublicProgramSourceGenerator    1 file
```

## 2. `get_file_overview` returned `FileNotFound` for `.razor` / `.cshtml`

Markup is an `AdditionalDocument`, so it has no C# document of its own. It now resolves through to the generated document in two tiers: hint-name convention first (`Components/Pages/Counter.razor` → `Components/Pages/Counter_razor.g.cs`), then `#line` mappings for generators that name their output differently. The line-mapping tier requires a **unique** match — `_Imports.razor` line-maps into every component in the project, and picking an arbitrary one would be worse than reporting nothing.

```
get_file_overview ".../Components/Pages/Counter.razor"
→ { "project": "RazorRepro", "typesDefined": ["Counter", "__PrivateComponentRenderModeAttribute"] }
```

## 3. `search_symbols` reported wrong project and generated flags

`project` came back `""` and `isGenerated` `false` for every symbol living in generator output — most symbols in a Blazor project — and directly contradicted `find_references`, which reported `isGenerated: true` for the same file.

The project index was built from `project.Documents`, which excludes source-generated documents; it now also indexes the compilation's syntax trees, where both kinds appear. `isGenerated` was simply hardcoded `false`.

## 4. Misleading empty-workspace message

`EnsureLoaded()` said `"No .sln file found"` for *any* empty workspace, including a solution that was found and loaded but whose projects all failed to open. I reproduced that exact message from a load that had resolved the `.slnx` correctly — this is what produced the ".slnx is not discovered" report in #399. It now distinguishes the two cases and lists the skip reasons.

## Testing

- Full suite **1172 passed, 0 failed** (1150 before #399 work → +22).
- All three tool fixes verified end-to-end against a stock `dotnet new blazor` repro, driven through the real MCP stdio server.
- Separate commit fixes the benchmarks project, which calls `GetSourceGeneratorsLogic` and is not built by `dotnet test` — the rename only surfaced on a full solution build.

**Coverage gap worth flagging:** there is no Razor project in `tests/Fixtures/TestSolution`, so the markup→generated-document resolution has unit coverage on its mapping helpers plus manual end-to-end verification, but no automated regression test. Adding a Blazor fixture would perturb the solution-wide tests that assert project counts and symbol sets, so I kept that churn out of this PR. Happy to add it as a follow-up if you want the guard rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
