### PR TITLE
test: add a Razor fixture guarding the #399 generated-code behaviours

### DIFF
--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorFixture.slnx
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorFixture.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="RazorLib/RazorLib.csproj" />
+</Solution>

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/Counter.razor
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/Counter.razor
@@ -1,0 +1,5 @@
+<h1>Counter</h1>
+
+<p role="status">Current count: @_currentCount</p>
+
+<button class="btn" @onclick="IncrementCount">Click me</button>

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/Counter.razor.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/Counter.razor.cs
@@ -1,0 +1,16 @@
+namespace RazorLib.Components;
+
+/// <summary>
+/// Code-behind for Counter.razor. Overriding OnInitialized only compiles when the Razor
+/// generator has produced the other half of this partial class (which derives from
+/// ComponentBase). Without it the compiler reports CS0115/CS0117 on a project that builds
+/// clean — the phantom-diagnostics symptom of issue #399.
+/// </summary>
+public partial class Counter
+{
+    private int _currentCount;
+
+    protected override void OnInitialized() => base.OnInitialized();
+
+    private void IncrementCount() => _currentCount++;
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/MainLayout.razor
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/MainLayout.razor
@@ -1,0 +1,11 @@
+@* NavMenu is referenced ONLY from markup here. Before the #399 fix, find_references on
+   NavMenu returned zero hits because the Razor generator never ran. *@
+<div class="page">
+    <NavMenu />
+    <main>@ChildContent</main>
+</div>
+
+@code {
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/NavMenu.razor
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/NavMenu.razor
@@ -1,0 +1,3 @@
+<nav class="nav-menu">
+    <a href="">Home</a>
+</nav>

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/_Imports.razor
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/Components/_Imports.razor
@@ -1,0 +1,2 @@
+@using Microsoft.AspNetCore.Components
+@using RazorLib.Components

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/RazorLib.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorFixture/RazorLib/RazorLib.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <!--
+    Razor class library, not a web app: the Razor source generator is what these tests are
+    about, and a component library exercises it without an ASP.NET host. Microsoft.AspNetCore.App
+    comes in as a FrameworkReference (a targeting pack shipped with the SDK) rather than a
+    PackageReference, so the fixture needs no NuGet download and cannot flake on a restore.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AddRazorSupportForMvc>false</AddRazorSupportForMvc>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/RazorSolutionFixture.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/RazorSolutionFixture.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tests.Fixtures;
+
+/// <summary>
+/// Loads a small Razor class library once per assembly, for the generated-code tests
+/// (<see cref="Tests.Tools.RazorGeneratedCodeTests"/>).
+///
+/// Deliberately a SEPARATE solution rather than another project in TestSolution: the shared
+/// fixture is asserted against by solution-wide tests (project counts, symbol sets, coverage),
+/// and adding a Razor project there would churn them for no benefit. The cost is one extra
+/// single-project solution load.
+/// </summary>
+public class RazorSolutionFixture : IAsyncLifetime
+{
+    // Same design-time-build flake as TestSolutionFixture guards against (#260): a load can drop
+    // a project's references. This fixture is one project so it is far less exposed, but the
+    // failure mode — an empty/degraded compilation — would surface as a confusing generator
+    // assertion failure rather than an obvious load problem, so retry on a fresh workspace.
+    private const int MaxLoadAttempts = 4;
+
+    public string SolutionPath { get; private set; } = null!;
+    public LoadedSolution Loaded { get; private set; } = null!;
+    public SymbolResolver Resolver { get; private set; } = null!;
+    public MetadataSymbolResolver Metadata { get; private set; } = null!;
+
+    /// <summary>Absolute path to a file inside the fixture project.</summary>
+    public string PathTo(params string[] parts) =>
+        Path.GetFullPath(Path.Combine(
+            new[] { Path.GetDirectoryName(SolutionPath)!, "RazorLib" }.Concat(parts).ToArray()));
+
+    public async Task InitializeAsync()
+    {
+        SolutionPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "RazorFixture", "RazorFixture.slnx"));
+
+        await EnsureRestoredAsync().ConfigureAwait(false);
+
+        var problem = string.Empty;
+        for (var attempt = 1; attempt <= MaxLoadAttempts; attempt++)
+        {
+            Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
+            if (LoadIsHealthy(Loaded, out problem))
+            {
+                Resolver = new SymbolResolver(Loaded);
+                Metadata = new MetadataSymbolResolver(Loaded, Resolver);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"RazorFixture failed to load healthily after {MaxLoadAttempts} attempts: {problem}.");
+    }
+
+    /// <summary>
+    /// Checks only that the project loaded with its references intact — deliberately NOT that
+    /// generators ran. Generator output is what the tests assert on; probing for it here would
+    /// turn a real regression into an opaque "fixture failed to load" error.
+    /// </summary>
+    private static bool LoadIsHealthy(LoadedSolution loaded, out string problem)
+    {
+        if (loaded.Compilations.Count != 1)
+        {
+            problem = $"expected 1 compiled project, got {loaded.Compilations.Count}";
+            return false;
+        }
+
+        var project = loaded.Solution.Projects.First();
+        if (project.MetadataReferences.Count == 0)
+        {
+            problem = $"{project.Name} loaded with no metadata references (design-time build dropped them)";
+            return false;
+        }
+
+        problem = string.Empty;
+        return true;
+    }
+
+    private async Task EnsureRestoredAsync()
+    {
+        var assets = Path.Combine(
+            Path.GetDirectoryName(SolutionPath)!, "RazorLib", "obj", "project.assets.json");
+        if (File.Exists(assets))
+            return;
+
+        var psi = new ProcessStartInfo("dotnet", $"restore \"{SolutionPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet restore' for the Razor fixture.");
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet restore' for the Razor fixture failed (exit {process.ExitCode}):\n" +
+                $"{await stdout.ConfigureAwait(false)}\n{await stderr.ConfigureAwait(false)}");
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+[CollectionDefinition("RazorSolution")]
+public class RazorSolutionCollection : ICollectionFixture<RazorSolutionFixture> { }

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -24,11 +24,13 @@
     <Compile Remove="Fixtures\LegacySolution\**" />
     <Compile Remove="Fixtures\GraphReader\**" />
     <Compile Remove="Fixtures\FilterableSolution\**" />
+    <Compile Remove="Fixtures\RazorFixture\**" />
     <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\GraphReader\**" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Fixtures\FilterableSolution\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\RazorFixture\**" CopyToOutputDirectory="Never" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/Tools/RazorGeneratedCodeTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/RazorGeneratedCodeTests.cs
@@ -1,0 +1,104 @@
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.Tools;
+
+/// <summary>
+/// Regression guard for issue #399, on a Razor class library that builds with zero errors.
+///
+/// The whole class of bug was invisible because the Razor source generator silently did not run:
+/// Roslyn refuses an analyzer built against a newer compiler than the host, returns zero
+/// generators, and reports nothing. Everything downstream then answered confidently and wrongly.
+/// These tests fail if generator output stops reaching the workspace, whatever the reason.
+/// </summary>
+[Collection("RazorSolution")]
+public class RazorGeneratedCodeTests
+{
+    private readonly RazorSolutionFixture _fixture;
+
+    public RazorGeneratedCodeTests(RazorSolutionFixture fixture) => _fixture = fixture;
+
+    /// <summary>
+    /// The headline symptom. Counter.razor.cs overrides OnInitialized, which only compiles
+    /// against the ComponentBase-derived half that the generator emits. Without the generator
+    /// this reports CS0115/CS0117 on a project that `dotnet build` compiles cleanly — and an
+    /// agent acting on that "fixes" code that was never broken.
+    /// </summary>
+    [Fact]
+    public void GetDiagnostics_ReportsNoErrors_OnACleanRazorProject()
+    {
+        var errors = GetDiagnosticsLogic.Execute(_fixture.Loaded, _fixture.Resolver, project: null, severity: "error");
+
+        Assert.Empty(errors);
+    }
+
+    /// <summary>NavMenu has no code-behind, so it exists only as generator output.</summary>
+    [Fact]
+    public void SearchSymbols_FindsAComponentThatHasNoCodeBehind()
+    {
+        var results = SearchSymbolsLogic.Execute(_fixture.Resolver, _fixture.Metadata, "NavMenu");
+
+        var navMenu = Assert.Single(results, r => r.FullName.Contains("NavMenu", StringComparison.Ordinal));
+        Assert.Equal("RazorLib", navMenu.Project);
+        Assert.True(navMenu.IsGenerated, "a symbol declared in generator output must report isGenerated");
+    }
+
+    /// <summary>
+    /// MainLayout.razor uses &lt;NavMenu /&gt; in markup and nowhere else. This returned zero
+    /// references before the fix, which is the answer most likely to mislead: "nothing uses this,
+    /// safe to delete".
+    /// </summary>
+    [Fact]
+    public void FindReferences_FindsAComponentUsedOnlyFromMarkup()
+    {
+        var references = FindReferencesLogic.Execute(
+            _fixture.Loaded, _fixture.Resolver, _fixture.Metadata, "RazorLib.Components.NavMenu");
+
+        Assert.NotEmpty(references);
+        Assert.Contains(references, r => r.File.Contains("MainLayout", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>.razor is an AdditionalDocument, so this used to be a flat FileNotFound.</summary>
+    [Fact]
+    public async Task GetFileOverview_ResolvesMarkupToItsGeneratedDocument()
+    {
+        var overview = await GetFileOverviewLogic.ExecuteAsync(
+            _fixture.Loaded, _fixture.Resolver,
+            _fixture.PathTo("Components", "Counter.razor"), CancellationToken.None);
+
+        Assert.Equal("RazorLib", overview.Project);
+        Assert.Contains("Counter", overview.TypesDefined);
+    }
+
+    [Fact]
+    public async Task GetSourceGenerators_NamesTheRazorGenerator_AndCountsItsOutput()
+    {
+        var generators = await GetSourceGeneratorsLogic.ExecuteAsync(_fixture.Loaded, project: null);
+
+        var razor = Assert.Single(generators, g =>
+            g.GeneratorName.Equals(
+                "Microsoft.NET.Sdk.Razor.SourceGenerators.RazorSourceGenerator", StringComparison.Ordinal));
+
+        Assert.Equal("RazorLib", razor.Project);
+        // One .g.cs per .razor file: _Imports, NavMenu, MainLayout, Counter.
+        Assert.Equal(4, razor.GeneratedFileCount);
+        Assert.All(razor.GeneratedFiles, f => Assert.EndsWith(".g.cs", f, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// MSBuild-authored intermediates (AssemblyInfo.cs, GlobalUsings.g.cs, .AssemblyAttributes.cs)
+    /// live in obj/ and were previously reported as generator output by a path heuristic.
+    /// </summary>
+    [Fact]
+    public async Task GetSourceGenerators_ExcludesMsBuildIntermediates()
+    {
+        var generators = await GetSourceGeneratorsLogic.ExecuteAsync(_fixture.Loaded, project: null);
+
+        var allFiles = generators.SelectMany(g => g.GeneratedFiles).ToList();
+
+        Assert.DoesNotContain(allFiles, f => f.EndsWith("AssemblyInfo.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(allFiles, f => f.EndsWith("GlobalUsings.g.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(generators, g =>
+            g.GeneratorName.Equals(GetSourceGeneratorsLogic.UnknownGenerator, StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Closes the coverage gap called out in #402. That PR's markup-to-generated-document work had unit tests on its mapping helpers and manual end-to-end verification, but nothing in CI that would catch generator output disappearing again — which is exactly how #399 stayed invisible in the first place.

## Why a separate fixture solution

`TestSolution` is asserted against by solution-wide tests (project counts, symbol sets, coverage probes), so adding a Razor project there would churn them for no benefit. `RazorFixture` follows the existing `TestSolutionAlt` / `LegacySolution` / `FilterableSolution` pattern: one project, loaded only by the new test class.

## Why it is a valid oracle

A Razor class library taking `Microsoft.AspNetCore.App` as a `FrameworkReference` rather than a `PackageReference` — the targeting pack ships with the SDK, so the fixture needs no NuGet download and cannot flake on restore.

It builds with **0 warnings and 0 errors**. That is the property the tests rest on: any diagnostic the tool reports against it is by definition a phantom.

It reproduces each shape from the issue:

| file | case it covers |
|---|---|
| `Counter.razor` + `Counter.razor.cs` | code-behind overriding `OnInitialized`, which compiles only against the generated `ComponentBase` half |
| `NavMenu.razor` | component with no code-behind — exists *only* as generator output |
| `MainLayout.razor` | uses `<NavMenu />` in markup and nowhere else |
| `_Imports.razor` | shared markup that line-maps into every component |

## These actually fail on regression

A test that passes both before and after a fix is decoration, so I verified rather than assumed. Pinning `Microsoft.CodeAnalysis` back to 5.6.0 — the exact skew that silently disabled the Razor generator — turns 5 of the 6 red:

```
GetDiagnostics_ReportsNoErrors_OnACleanRazorProject           [FAIL]
SearchSymbols_FindsAComponentThatHasNoCodeBehind              [FAIL]
FindReferences_FindsAComponentUsedOnlyFromMarkup              [FAIL]
GetFileOverview_ResolvesMarkupToItsGeneratedDocument          [FAIL]
GetSourceGenerators_NamesTheRazorGenerator_AndCountsItsOutput [FAIL]
Failed: 5, Passed: 1
```

The sixth (`GetSourceGenerators_ExcludesMsBuildIntermediates`) passes in both states by design — it guards the switch away from path sniffing, which is version-independent.

## Testing

Full suite **1178 passed, 0 failed**. The fixture adds roughly 0.7s.

The fixture directory is added to the `Compile Remove` / `None Include` lists in `RoslynCodeLens.Tests.csproj`, matching the other fixtures — without it the SDK globs `Counter.razor.cs` into the test assembly's own compilation and it fails to build.

## Note for future changes

`dotnet test` does not build `benchmarks/`. That is how the `GetSourceGeneratorsLogic.Execute` → `ExecuteAsync` rename in #402 slipped past local testing and only surfaced on a full `dotnet build`. Worth knowing when changing a logic class's signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
