### PR TITLE
feat: attribute generated-code results to their authored markup

### DIFF
--- a/src/RoslynCodeLens/Analysis/MarkupDocumentMap.cs
+++ b/src/RoslynCodeLens/Analysis/MarkupDocumentMap.cs
@@ -1,0 +1,91 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynCodeLens.Analysis;
+
+/// <summary>
+/// Maps between markup files (.razor/.cshtml) and the C# documents a source generator produces
+/// from them.
+///
+/// Markup is an <c>AdditionalDocument</c>, so the only C# that exists for it lives in generator
+/// output under <c>obj/</c>. Every symbol, reference and diagnostic for a component therefore
+/// reports a path the user never wrote and cannot edit. Carrying the authored file alongside is
+/// what makes those answers actionable — "NavMenu is unused" is not useful until it says the file
+/// to delete is <c>Components/NavMenu.razor</c>.
+///
+/// Line numbers deliberately are not mapped: the Razor generator emits <c>#line</c> directives
+/// only for user-written C# (<c>@code</c> blocks, expressions), not for the scaffolding a component
+/// tag compiles into. A <c>&lt;NavMenu /&gt;</c> usage has <c>HasMappedPath == false</c>, so there
+/// is no authored line to recover and inventing one would be worse than omitting it.
+/// </summary>
+public static class MarkupDocumentMap
+{
+    private static readonly string[] MarkupExtensions = [".razor", ".cshtml"];
+
+    public static bool IsMarkupPath(string? path) =>
+        path is not null &&
+        MarkupExtensions.Any(e => path.EndsWith(e, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The hint name the Razor generator gives a component's output: the markup file's
+    /// project-relative path with the extension folded into the name.
+    /// <c>Components/Pages/Counter.razor</c> becomes <c>Components/Pages/Counter_razor.g.cs</c>.
+    /// </summary>
+    public static string ExpectedHintName(TextDocument additional)
+    {
+        var fileName = additional.Name.Replace('.', '_') + ".g.cs";
+        return additional.Folders.Count == 0
+            ? fileName
+            : string.Join('/', additional.Folders) + "/" + fileName;
+    }
+
+    /// <summary>
+    /// Generated document path to the markup file it was produced from, across the solution.
+    ///
+    /// Matched by hint-name suffix against the compilation's syntax trees rather than by calling
+    /// <c>GetSourceGeneratedDocumentsAsync</c>, so this stays synchronous and can be built during
+    /// <see cref="SymbolResolver"/> construction alongside the other indexes.
+    /// </summary>
+    public static Dictionary<string, string> BuildGeneratedToMarkup(LoadedSolution loaded)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var project in loaded.Solution.Projects)
+        {
+            var markupDocuments = project.AdditionalDocuments
+                .Where(d => IsMarkupPath(d.FilePath))
+                .ToList();
+            if (markupDocuments.Count == 0)
+                continue;
+
+            if (!loaded.Compilations.TryGetValue(project.Id, out var compilation))
+                continue;
+
+            // Only generator output can match a hint name, and in a markup project that set is
+            // roughly the markup count — so the pairwise scan below stays small.
+            var generatedTrees = compilation.SyntaxTrees
+                .Where(t => !string.IsNullOrEmpty(t.FilePath) && t.FilePath.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (generatedTrees.Count == 0)
+                continue;
+
+            foreach (var markup in markupDocuments)
+            {
+                var hint = Normalize(ExpectedHintName(markup));
+                foreach (var tree in generatedTrees)
+                {
+                    if (!Normalize(tree.FilePath).EndsWith(hint, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    map[tree.FilePath] = markup.FilePath!;
+                    break;
+                }
+            }
+        }
+
+        return map;
+    }
+
+    // Roslyn builds a generated document's path from a directory portion using the platform
+    // separator and a hint name that keeps '/', so both forms can appear in one path.
+    private static string Normalize(string path) =>
+        path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+}

--- a/src/RoslynCodeLens/Models/SymbolLocation.cs
+++ b/src/RoslynCodeLens/Models/SymbolLocation.cs
@@ -7,4 +7,8 @@ public record SymbolLocation(
     int Line,
     string Project,
     bool IsGenerated = false,
-    SymbolOrigin? Origin = null);
+    SymbolOrigin? Origin = null,
+    /// <summary>Markup file this symbol's generated declaration came from, when applicable.</summary>
+    [property: System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    string? GeneratedFrom = null);

--- a/src/RoslynCodeLens/Models/SymbolReference.cs
+++ b/src/RoslynCodeLens/Models/SymbolReference.cs
@@ -7,4 +7,13 @@ public record SymbolReference(
     int Column,
     string Snippet,
     string Project,
-    bool IsGenerated = false);
+    bool IsGenerated = false,
+    /// <summary>
+    /// When <see cref="File"/> is generator output produced from markup, the .razor/.cshtml the
+    /// user actually wrote. Null otherwise, and omitted from the response so ordinary C# results
+    /// are unchanged. No line is carried: component markup compiles to scaffolding that has no
+    /// #line mapping back to the authored file.
+    /// </summary>
+    [property: System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    string? GeneratedFrom = null);

--- a/src/RoslynCodeLens/Models/UnusedSymbolInfo.cs
+++ b/src/RoslynCodeLens/Models/UnusedSymbolInfo.cs
@@ -6,4 +6,11 @@ public record UnusedSymbolInfo(
     string File,
     int Line,
     string Project,
-    bool IsGenerated = false);
+    bool IsGenerated = false,
+    /// <summary>
+    /// For a symbol declared in generator output, the markup file to delete. "NavMenu is unused"
+    /// is not actionable while the only path given is inside obj/.
+    /// </summary>
+    [property: System.Text.Json.Serialization.JsonIgnore(
+        Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    string? GeneratedFrom = null);

--- a/src/RoslynCodeLens/SymbolResolver.cs
+++ b/src/RoslynCodeLens/SymbolResolver.cs
@@ -17,6 +17,7 @@ public class SymbolResolver
     private readonly Dictionary<string, List<ISymbol>> _membersBySimpleName;
     private readonly Dictionary<string, List<(ISymbol Symbol, AttributeData Attribute)>> _attributeIndex;
     private readonly HashSet<string> _generatedFilePaths;
+    private readonly Dictionary<string, string> _generatedToMarkup;
 
     public SymbolResolver(LoadedSolution loaded)
     {
@@ -30,6 +31,7 @@ public class SymbolResolver
         BuildMemberAndAttributeIndexes();
 
         _generatedFilePaths = BuildGeneratedFileIndex(loaded);
+        _generatedToMarkup = Analysis.MarkupDocumentMap.BuildGeneratedToMarkup(loaded);
     }
 
     private static List<INamedTypeSymbol> CollectAllTypes(LoadedSolution loaded)
@@ -390,6 +392,14 @@ public class SymbolResolver
     {
         return _derivedTypes.TryGetValue(baseType, out var list) ? list : [];
     }
+
+    /// <summary>
+    /// The markup file (.razor/.cshtml) a generated document was produced from, or null when the
+    /// file is not generator output from markup. Lets results that necessarily point into obj/
+    /// name the file the user can actually edit.
+    /// </summary>
+    public string? GetMarkupSource(string? filePath) =>
+        filePath is not null && _generatedToMarkup.TryGetValue(filePath, out var markup) ? markup : null;
 
     public bool IsGenerated(string? filePath)
     {

--- a/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindReferencesLogic.cs
@@ -75,7 +75,8 @@ public static class FindReferencesLogic
                     var projectName = resolver.GetProjectName(location.Document.Project.Id);
 
                     results.Add(new SymbolReference(
-                        kind, file, line, column, snippet, projectName, resolver.IsGenerated(file)));
+                        kind, file, line, column, snippet, projectName, resolver.IsGenerated(file),
+                        resolver.GetMarkupSource(file)));
                 }
             }
         }

--- a/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/FindUnusedSymbolsLogic.cs
@@ -10,7 +10,7 @@ public static class FindUnusedSymbolsLogic
     public static (IReadOnlyList<UnusedSymbolInfo> Items, IReadOnlyDictionary<string, int> FilteredCounts) Execute(
         LoadedSolution loaded, SymbolResolver resolver, string? project, bool includeInternal)
     {
-        var referencedSymbols = CollectReferencedSymbols(loaded);
+        var referencedSymbols = CollectReferencedSymbols(loaded, resolver);
         var (items, counts) = FindUnusedTypesWithFilterCounts(resolver, referencedSymbols, project, includeInternal);
         return (items, counts);
     }
@@ -32,6 +32,16 @@ public static class FindUnusedSymbolsLogic
 
             if (ShouldSkipType(type, includeInternal)) continue;
 
+            var (typeFile, typeLine) = resolver.GetFileAndLine(type);
+            var markupSource = resolver.GetMarkupSource(typeFile);
+
+            // Razor infrastructure (_Imports.razor, _ViewImports/_ViewStart.cshtml) compiles to a
+            // type nothing ever names, so it looks unused by construction — but deleting the file
+            // strips every component's using directives and breaks the build. Reporting it is
+            // worse than silent: it is confidently actionable and wrong.
+            if (IsMarkupInfrastructure(markupSource))
+                continue;
+
             var typeReason = DeadCodeFilters.Classify(type);
             if (typeReason != DeadCodeFilters.Reason.None)
             {
@@ -41,10 +51,10 @@ public static class FindUnusedSymbolsLogic
 
             if (!referencedSymbols.Contains(type))
             {
-                var (file, line) = resolver.GetFileAndLine(type);
                 results.Add(new UnusedSymbolInfo(
                     type.ToDisplayString(), type.TypeKind.ToString(),
-                    file, line, projectName, resolver.IsGenerated(file)));
+                    typeFile, typeLine, projectName, resolver.IsGenerated(typeFile),
+                    markupSource));
                 continue;
             }
 
@@ -83,7 +93,8 @@ public static class FindUnusedSymbolsLogic
                 };
                 var memberSymbol = $"{type.ToDisplayString()}.{member.Name}";
                 results.Add(new UnusedSymbolInfo(
-                    memberSymbol, kind, file, line, projectName, resolver.IsGenerated(file)));
+                    memberSymbol, kind, file, line, projectName, resolver.IsGenerated(file),
+                    resolver.GetMarkupSource(file)));
             }
         }
     }
@@ -109,7 +120,25 @@ public static class FindUnusedSymbolsLogic
         _ => throw new ArgumentOutOfRangeException(nameof(reason)),
     };
 
-    private static HashSet<ISymbol> CollectReferencedSymbols(LoadedSolution loaded)
+    /// <summary>
+    /// Collects every symbol referenced anywhere in the solution.
+    ///
+    /// A generated document routinely references the very symbols it declares — the Razor
+    /// generator emits a component's render tree into the same file that declares the component —
+    /// and counting that as usage makes a component with no real consumers look used. That is why
+    /// unused-component detection was previously arbitrary: MainLayout had zero references yet
+    /// went unreported, while _Imports, whose generated file happens not to name it, was reported.
+    /// Self-references inside a generated file are therefore not counted.
+    ///
+    /// The check is per symbol, not per file: a member declared in hand-written code-behind and
+    /// genuinely called by the generated render tree stays used.
+    ///
+    /// Scoped to generated files on purpose. A component whose hand-written code-behind touches
+    /// its own members still counts as used, because that is how this tool treats every
+    /// hand-written type — suppressing self-reference there would change dead-code semantics for
+    /// all C#, not just Razor, which is a far wider change than this fix warrants.
+    /// </summary>
+    private static HashSet<ISymbol> CollectReferencedSymbols(LoadedSolution loaded, SymbolResolver resolver)
     {
         var referencedSymbols = new HashSet<ISymbol>(SymbolSignatureComparer.Instance);
 
@@ -119,6 +148,8 @@ public static class FindUnusedSymbolsLogic
             {
                 var semanticModel = compilation.GetSemanticModel(syntaxTree);
                 var root = syntaxTree.GetRoot();
+                var treePath = syntaxTree.FilePath;
+                var suppressSelfReferences = resolver.IsGenerated(treePath);
 
                 foreach (var node in root.DescendantNodes())
                 {
@@ -133,11 +164,15 @@ public static class FindUnusedSymbolsLogic
                     if (symbol == null)
                         continue;
 
-                    referencedSymbols.Add(symbol);
-                    if (symbol.OriginalDefinition != null)
-                        referencedSymbols.Add(symbol.OriginalDefinition);
+                    if (!(suppressSelfReferences && DeclaredInFile(symbol, treePath)))
+                    {
+                        referencedSymbols.Add(symbol);
+                        if (symbol.OriginalDefinition != null)
+                            referencedSymbols.Add(symbol.OriginalDefinition);
+                    }
 
-                    if (symbol.ContainingType != null)
+                    if (symbol.ContainingType != null
+                        && !(suppressSelfReferences && DeclaredInFile(symbol.ContainingType, treePath)))
                     {
                         referencedSymbols.Add(symbol.ContainingType);
                         if (symbol.ContainingType.OriginalDefinition != null)
@@ -149,6 +184,31 @@ public static class FindUnusedSymbolsLogic
 
         return referencedSymbols;
     }
+
+    /// <summary>True when one of the symbol's own declarations lives in <paramref name="path"/>.</summary>
+    private static bool DeclaredInFile(ISymbol symbol, string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        foreach (var location in symbol.Locations)
+        {
+            if (location.IsInSource &&
+                string.Equals(location.SourceTree?.FilePath, path, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly string[] MarkupInfrastructureNames =
+        ["_Imports.razor", "_ViewImports.cshtml", "_ViewStart.cshtml"];
+
+    private static bool IsMarkupInfrastructure(string? markupPath) =>
+        markupPath is not null &&
+        MarkupInfrastructureNames.Any(n => Path.GetFileName(markupPath).Equals(n, StringComparison.OrdinalIgnoreCase));
 
     private static bool ShouldSkipType(INamedTypeSymbol type, bool includeInternal)
     {

--- a/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
+++ b/src/RoslynCodeLens/Tools/GetFileOverviewLogic.cs
@@ -89,10 +89,10 @@ public static class GetFileOverviewLogic
 
             var generated = (await project.GetSourceGeneratedDocumentsAsync(ct).ConfigureAwait(false)).ToList();
 
-            var expectedHint = ExpectedHintName(additional);
+            var expectedHint = Analysis.MarkupDocumentMap.ExpectedHintName(additional);
             foreach (var candidate in generated)
             {
-                if (NormalizeHint(candidate.HintName).Equals(expectedHint, StringComparison.OrdinalIgnoreCase))
+                if (NormalizeHint(candidate.HintName).Equals(NormalizeHint(expectedHint), StringComparison.OrdinalIgnoreCase))
                     return (project, candidate);
             }
 
@@ -110,14 +110,6 @@ public static class GetFileOverviewLogic
         }
 
         return (null, null);
-    }
-
-    internal static string ExpectedHintName(TextDocument additional)
-    {
-        var fileName = additional.Name.Replace('.', '_') + ".g.cs";
-        return additional.Folders.Count == 0
-            ? fileName
-            : string.Join('/', additional.Folders) + "/" + fileName;
     }
 
     private static string NormalizeHint(string hintName) => hintName.Replace('\\', '/');

--- a/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
+++ b/src/RoslynCodeLens/Tools/SearchSymbolsLogic.cs
@@ -51,7 +51,8 @@ public static class SearchSymbolsLogic
                 results.Add(new SymbolLocation(
                     kind, type.ToDisplayString(), file, line, project,
                     IsGenerated: resolver.IsGenerated(file),
-                    Origin: MetadataSymbolResolver.SourceOrigin));
+                    Origin: MetadataSymbolResolver.SourceOrigin,
+                    GeneratedFrom: resolver.GetMarkupSource(file)));
 
                 if (results.Count >= MaxResults)
                     return;
@@ -90,7 +91,8 @@ public static class SearchSymbolsLogic
                     kind, member.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                     file, line, project,
                     IsGenerated: resolver.IsGenerated(file),
-                    Origin: MetadataSymbolResolver.SourceOrigin));
+                    Origin: MetadataSymbolResolver.SourceOrigin,
+                    GeneratedFrom: resolver.GetMarkupSource(file)));
 
                 if (results.Count >= MaxResults)
                     return;

--- a/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/GetFileOverviewToolTests.cs
@@ -64,6 +64,6 @@ public class GetFileOverviewToolTests
 
         var additional = solution.GetAdditionalDocument(documentId)!;
 
-        Assert.Equal(expected, GetFileOverviewLogic.ExpectedHintName(additional));
+        Assert.Equal(expected, RoslynCodeLens.Analysis.MarkupDocumentMap.ExpectedHintName(additional));
     }
 }

--- a/tests/RoslynCodeLens.Tests/Tools/RazorGeneratedCodeTests.cs
+++ b/tests/RoslynCodeLens.Tests/Tools/RazorGeneratedCodeTests.cs
@@ -86,6 +86,90 @@ public class RazorGeneratedCodeTests
     }
 
     /// <summary>
+    /// A reference inside generator output has to report the obj/ path — that is genuinely where
+    /// the code is — but on its own that is not actionable, because the user cannot edit it. The
+    /// authored markup travels alongside. No line is claimed: the OpenComponent scaffolding a
+    /// component tag compiles to has no #line mapping (HasMappedPath is false), so there is no
+    /// authored line to point at.
+    /// </summary>
+    [Fact]
+    public void FindReferences_AttributesGeneratedHitsToTheMarkupTheyCameFrom()
+    {
+        var references = FindReferencesLogic.Execute(
+            _fixture.Loaded, _fixture.Resolver, _fixture.Metadata, "RazorLib.Components.NavMenu");
+
+        var hit = Assert.Single(references);
+        Assert.True(hit.IsGenerated);
+        Assert.EndsWith("MainLayout.razor", hit.GeneratedFrom ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SearchSymbols_AttributesAGeneratedDeclarationToItsMarkup()
+    {
+        var results = SearchSymbolsLogic.Execute(_fixture.Resolver, _fixture.Metadata, "NavMenu");
+
+        var navMenu = Assert.Single(results, r => r.FullName.Contains("NavMenu", StringComparison.Ordinal));
+        Assert.EndsWith("NavMenu.razor", navMenu.GeneratedFrom ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Ordinary C# must be untouched: GeneratedFrom is meaningful only for generator output, and
+    /// is omitted from the response entirely when null.
+    /// </summary>
+    [Fact]
+    public void SearchSymbols_LeavesGeneratedFromNull_ForHandWrittenCode()
+    {
+        var results = SearchSymbolsLogic.Execute(_fixture.Resolver, _fixture.Metadata, "Counter");
+
+        var codeBehind = results.FirstOrDefault(r => r.File.EndsWith("Counter.razor.cs", StringComparison.OrdinalIgnoreCase));
+        if (codeBehind is not null)
+            Assert.Null(codeBehind.GeneratedFrom);
+    }
+
+    /// <summary>
+    /// NavMenu is rendered by MainLayout, so it is used. MainLayout and Counter have no consumer
+    /// at all and must be reported — they were not, because each one's own generated file
+    /// references it, which made dead-component detection depend on incidental generator output.
+    /// </summary>
+    [Fact]
+    public void FindUnusedSymbols_ReportsComponentsWithNoConsumer_AndNotOnesThatAreRendered()
+    {
+        var (items, _) = FindUnusedSymbolsLogic.Execute(
+            _fixture.Loaded, _fixture.Resolver, project: null, includeInternal: false);
+
+        var names = items.Select(i => i.SymbolName).ToList();
+
+        Assert.Contains("RazorLib.Components.MainLayout", names);
+        Assert.DoesNotContain("RazorLib.Components.NavMenu", names);
+    }
+
+    /// <summary>An unused component is only actionable once it names the .razor file to delete.</summary>
+    [Fact]
+    public void FindUnusedSymbols_PointsAtTheMarkupFileToDelete()
+    {
+        var (items, _) = FindUnusedSymbolsLogic.Execute(
+            _fixture.Loaded, _fixture.Resolver, project: null, includeInternal: false);
+
+        var mainLayout = Assert.Single(items, i => i.SymbolName.EndsWith("MainLayout", StringComparison.Ordinal));
+
+        Assert.True(mainLayout.IsGenerated);
+        Assert.EndsWith("MainLayout.razor", mainLayout.GeneratedFrom ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// _Imports.razor compiles to a type nothing ever names, so it looks unused by construction —
+    /// but deleting it strips every component's using directives and breaks the build.
+    /// </summary>
+    [Fact]
+    public void FindUnusedSymbols_NeverReportsRazorInfrastructure()
+    {
+        var (items, _) = FindUnusedSymbolsLogic.Execute(
+            _fixture.Loaded, _fixture.Resolver, project: null, includeInternal: false);
+
+        Assert.DoesNotContain(items, i => i.SymbolName.EndsWith("_Imports", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// MSBuild-authored intermediates (AssemblyInfo.cs, GlobalUsings.g.cs, .AssemblyAttributes.cs)
     /// live in obj/ and were previously reported as generator output by a path heuristic.
     /// </summary>


### PR DESCRIPTION
Follow-on from #400 / #402 / #403. Two problems that only surface once generator output is actually in the workspace, both in the same class as #399: the answer is confidently wrong or unusable, rather than merely incomplete.

## 1. Results in generated code now name the file you can edit

A component's C# exists only under `obj/`, so every symbol, reference and diagnostic for it reports a path the user never wrote. `find_references`, `search_symbols` and `find_unused_symbols` now carry `generatedFrom`:

```json
{ "referenceKind": "type_argument",
  "file": ".../obj/.../Components/MainLayout_razor.g.cs", "line": 34,
  "isGenerated": true,
  "generatedFrom": ".../Components/MainLayout.razor" }
```

The field is omitted when null, so ordinary C# output is byte-identical.

**No line is mapped, deliberately.** The Razor generator emits `#line` only for user-written C# (`@code` blocks, expressions), not for the scaffolding a component tag compiles into. I measured the `<NavMenu />` usage site directly:

```
raw    : MainLayout_razor.g.cs:34
mapped : MainLayout_razor.g.cs:34
HasMappedPath=False
```

There is no authored line to recover. Inventing a nearest-match one would be worse than omitting it.

## 2. find_unused_symbols was arbitrary for components

A generated document references the symbols it declares — the Razor generator emits a component's render tree into the same file that declares the component — so a component with **no consumers at all** looked used. Measured on the fixture, every one of these has zero references:

| type | before | after |
|---|---|---|
| `MainLayout` | not reported (own generated file names it) | **reported**, with `generatedFrom` |
| `_Imports` | **reported** (its generated file happens not to name it) | not reported — see below |
| `NavMenu` | not reported (genuinely rendered by MainLayout) | not reported ✔ |

Self-references inside a generated file no longer count. The check is **per symbol, not per file**, so a member declared in hand-written code-behind and genuinely called by the render tree stays used.

**Scoped to generated files on purpose.** A component whose hand-written code-behind touches its own members still counts as used — that is how this tool treats every hand-written type. Suppressing self-reference there would change dead-code semantics for all C#, not just Razor, which is far wider than this fix warrants. Concretely: `Counter` still is not reported, because its code-behind touches `_currentCount`. That is a known limit, not an oversight.

`_Imports.razor` is now never reported. It compiles to a type nothing ever names, so it looks unused by construction — but deleting it strips every component's `@using` directives and breaks the build. Confidently actionable and wrong is exactly the failure mode this line of work exists to remove.

## Shared mapping

`MarkupDocumentMap` holds both directions, so `get_file_overview`'s markup resolution and the new attribution share one definition of the Razor hint-name convention instead of two copies. It is built synchronously from additional documents plus compilation trees, so it slots into `SymbolResolver` alongside the existing indexes.

## Testing

Full suite **1184 passed, 0 failed** (1178 → +6), full solution build clean. New tests extend the `RazorFixture` from #403 and cover attribution on references, on symbol search, absence on hand-written code, both dead-code directions, and the `_Imports` guard.

Verified end-to-end through the real MCP stdio server, not only through the logic classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
