### PR TITLE
fix: detect test projects from MSBuild-evaluated metadata references

### DIFF
--- a/src/RoslynCodeLens/TestDiscovery/TestProjectDetector.cs
+++ b/src/RoslynCodeLens/TestDiscovery/TestProjectDetector.cs
@@ -7,19 +7,60 @@ public static class TestProjectDetector
 {
     private static readonly string[] TestPackagePrefixes = ["xunit", "nunit", "mstest"];
 
+    // Matched against resolved metadata-reference assembly names. Covers xunit.core /
+    // xunit.assert (v2) and xunit.v3.* (v3), nunit.framework / nunitlite, and MSTest —
+    // whose framework assembly (Microsoft.VisualStudio.TestPlatform.TestFramework) does
+    // not share the package's name, so it needs its own entry.
+    private static readonly string[] TestAssemblyPrefixes =
+        ["xunit", "nunit", "mstest", "Microsoft.VisualStudio.TestPlatform.TestFramework"];
+
     public static ImmutableHashSet<ProjectId> GetTestProjectIds(Solution solution)
     {
         var builder = ImmutableHashSet.CreateBuilder<ProjectId>();
 
         foreach (var project in solution.Projects)
         {
-            if (HasTestPackageReference(project))
+            if (HasTestFrameworkReference(project) || HasTestPackageReference(project))
                 builder.Add(project.Id);
         }
 
         return builder.ToImmutable();
     }
 
+    /// <summary>
+    /// Primary signal: the project's resolved metadata references contain a test-framework
+    /// assembly. Unlike the csproj text scan this follows MSBuild evaluation, so it sees
+    /// packages declared in a Directory.Build.props, via Central Package Management, or through
+    /// property indirection, as well as references arriving transitively (#406).
+    /// </summary>
+    private static bool HasTestFrameworkReference(Project project)
+    {
+        foreach (var reference in project.MetadataReferences)
+        {
+            var path = (reference as PortableExecutableReference)?.FilePath ?? reference.Display;
+            if (path is not null && IsTestFrameworkAssembly(Path.GetFileNameWithoutExtension(path)))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsTestFrameworkAssembly(string assemblyName)
+    {
+        foreach (var prefix in TestAssemblyPrefixes)
+        {
+            if (assemblyName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Fallback for degraded loads: when the design-time build dropped a project's metadata
+    /// references (the #260/#263 flake), the csproj text still names any framework package the
+    /// project declares directly.
+    /// </summary>
     private static bool HasTestPackageReference(Project project)
     {
         if (project.FilePath is null || !File.Exists(project.FilePath))

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsFixture.slnx
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsFixture.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="PropsLib/PropsLib.csproj" />
+  <Project Path="tests/PropsDrivenTests/PropsDrivenTests.csproj" />
+</Solution>

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsLib/PropsLib.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsLib/PropsLib.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsLib/Widget.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/PropsLib/Widget.cs
@@ -1,0 +1,8 @@
+namespace PropsLib;
+
+public class Widget
+{
+    public string Describe(string name) => $"Widget {name}";
+
+    public int Uncalled() => 42;
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/Directory.Build.props
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/Directory.Build.props
@@ -1,0 +1,10 @@
+<!--
+  The whole point of this fixture: the test-framework package is declared HERE, shared by
+  every project under tests/, and never appears as literal text in any csproj. Guards #406 —
+  detection must follow MSBuild evaluation, not csproj text.
+-->
+<Project>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/PropsDrivenTests/PropsDrivenTests.csproj
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/PropsDrivenTests/PropsDrivenTests.csproj
@@ -1,0 +1,11 @@
+<!-- Deliberately NO test-framework PackageReference here — xunit comes from ../Directory.Build.props. -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\PropsLib\PropsLib.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/PropsDrivenTests/WidgetTests.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsFixture/tests/PropsDrivenTests/WidgetTests.cs
@@ -1,0 +1,15 @@
+using PropsLib;
+using Xunit;
+
+namespace PropsDrivenTests;
+
+public class WidgetTests
+{
+    [Fact]
+    public void DescribeContainsName()
+    {
+        var widget = new Widget();
+        var result = widget.Describe("gizmo");
+        Assert.Contains("gizmo", result);
+    }
+}

--- a/tests/RoslynCodeLens.Tests/Fixtures/PropsSolutionFixture.cs
+++ b/tests/RoslynCodeLens.Tests/Fixtures/PropsSolutionFixture.cs
@@ -1,0 +1,121 @@
+using System.Diagnostics;
+using RoslynCodeLens;
+using RoslynCodeLens.Symbols;
+
+namespace RoslynCodeLens.Tests.Fixtures;
+
+/// <summary>
+/// Loads a two-project solution whose test project gets its xunit reference exclusively from
+/// a shared <c>tests/Directory.Build.props</c> — the csproj itself contains no test-framework
+/// <c>PackageReference</c>. Guards #406: test-project detection must follow MSBuild evaluation,
+/// not csproj text.
+///
+/// Deliberately a SEPARATE solution rather than another project in TestSolution: the shared
+/// fixture is asserted against by solution-wide tests (project counts, symbol sets, coverage),
+/// and adding a project there would churn them for no benefit. The cost is one extra
+/// two-project solution load.
+/// </summary>
+public class PropsSolutionFixture : IAsyncLifetime
+{
+    // Same design-time-build flake as TestSolutionFixture guards against (#260): a load can
+    // drop a project's references. Here that failure mode would look exactly like the #406
+    // regression this fixture exists to catch, so the health probe below distinguishes them
+    // and we retry on a fresh workspace.
+    private const int MaxLoadAttempts = 4;
+
+    public string SolutionPath { get; private set; } = null!;
+    public LoadedSolution Loaded { get; private set; } = null!;
+    public SymbolResolver Resolver { get; private set; } = null!;
+
+    public async Task InitializeAsync()
+    {
+        SolutionPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "PropsFixture", "PropsFixture.slnx"));
+
+        await EnsureRestoredAsync().ConfigureAwait(false);
+
+        var problem = string.Empty;
+        for (var attempt = 1; attempt <= MaxLoadAttempts; attempt++)
+        {
+            Loaded = await new SolutionLoader().LoadAsync(SolutionPath).ConfigureAwait(false);
+            if (LoadIsHealthy(Loaded, out problem))
+            {
+                Resolver = new SymbolResolver(Loaded);
+                return;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"PropsFixture failed to load healthily after {MaxLoadAttempts} attempts: {problem}.");
+    }
+
+    /// <summary>
+    /// Checks that the design-time build actually resolved the props-declared xunit reference —
+    /// <c>Xunit.FactAttribute</c> must bind in the test project's compilation. That separates a
+    /// degraded load (references dropped, retry) from the detection regression the tests assert
+    /// on: the detector never sees compilations, so a healthy load proves nothing about it.
+    /// </summary>
+    private static bool LoadIsHealthy(LoadedSolution loaded, out string problem)
+    {
+        if (loaded.Compilations.Count != 2)
+        {
+            problem = $"expected 2 compiled projects, got {loaded.Compilations.Count}";
+            return false;
+        }
+
+        var testProject = loaded.Solution.Projects.FirstOrDefault(
+            p => string.Equals(p.Name, "PropsDrivenTests", StringComparison.Ordinal));
+        if (testProject is null)
+        {
+            problem = "PropsDrivenTests project missing from the loaded solution";
+            return false;
+        }
+
+        var compilation = loaded.Compilations[testProject.Id];
+        if (compilation.GetTypeByMetadataName("Xunit.FactAttribute") is null)
+        {
+            problem = "Xunit.FactAttribute does not resolve in PropsDrivenTests " +
+                      "(design-time build dropped the Directory.Build.props-declared reference)";
+            return false;
+        }
+
+        problem = string.Empty;
+        return true;
+    }
+
+    private async Task EnsureRestoredAsync()
+    {
+        var assets = Path.Combine(
+            Path.GetDirectoryName(SolutionPath)!, "tests", "PropsDrivenTests", "obj", "project.assets.json");
+        if (File.Exists(assets))
+            return;
+
+        var psi = new ProcessStartInfo("dotnet", $"restore \"{SolutionPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet restore' for the Props fixture.");
+
+        var stdout = process.StandardOutput.ReadToEndAsync();
+        var stderr = process.StandardError.ReadToEndAsync();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"'dotnet restore' for the Props fixture failed (exit {process.ExitCode}):\n" +
+                $"{await stdout.ConfigureAwait(false)}\n{await stderr.ConfigureAwait(false)}");
+        }
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}
+
+[CollectionDefinition("PropsSolution")]
+public class PropsSolutionCollection : ICollectionFixture<PropsSolutionFixture> { }

--- a/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
+++ b/tests/RoslynCodeLens.Tests/RoslynCodeLens.Tests.csproj
@@ -25,12 +25,14 @@
     <Compile Remove="Fixtures\GraphReader\**" />
     <Compile Remove="Fixtures\FilterableSolution\**" />
     <Compile Remove="Fixtures\RazorFixture\**" />
+    <Compile Remove="Fixtures\PropsFixture\**" />
     <None Include="Fixtures\TestSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\TestSolutionAlt\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\LegacySolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\GraphReader\**" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Fixtures\FilterableSolution\**" CopyToOutputDirectory="Never" />
     <None Include="Fixtures\RazorFixture\**" CopyToOutputDirectory="Never" />
+    <None Include="Fixtures\PropsFixture\**" CopyToOutputDirectory="Never" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/RoslynCodeLens.Tests/TestDiscovery/PropsFixtureDetectionTests.cs
+++ b/tests/RoslynCodeLens.Tests/TestDiscovery/PropsFixtureDetectionTests.cs
@@ -1,0 +1,64 @@
+using RoslynCodeLens.TestDiscovery;
+using RoslynCodeLens.Tests.Fixtures;
+using RoslynCodeLens.Tools;
+
+namespace RoslynCodeLens.Tests.TestDiscovery;
+
+/// <summary>
+/// Regression tests for #406: a test project whose xunit reference comes exclusively from a
+/// shared <c>tests/Directory.Build.props</c> (no test-framework <c>PackageReference</c> in the
+/// csproj text) must still be recognized as a test project, end to end.
+/// </summary>
+[Collection("PropsSolution")]
+public class PropsFixtureDetectionTests
+{
+    private readonly PropsSolutionFixture _fixture;
+
+    public PropsFixtureDetectionTests(PropsSolutionFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetTestProjectIds_DetectsPropsDeclaredTestProject()
+    {
+        var ids = TestProjectDetector.GetTestProjectIds(_fixture.Loaded.Solution);
+
+        var names = ids
+            .Select(id => _fixture.Loaded.Solution.GetProject(id)!.Name)
+            .ToList();
+
+        Assert.Contains("PropsDrivenTests", names);
+        Assert.DoesNotContain("PropsLib", names);
+    }
+
+    [Fact]
+    public void GetTestSummary_ReportsPropsDeclaredTestProject()
+    {
+        var result = GetTestSummaryLogic.Execute(_fixture.Loaded, _fixture.Resolver, project: null);
+
+        var project = Assert.Single(result.Projects);
+        Assert.Equal("PropsDrivenTests", project.Project);
+        Assert.Contains(project.Tests, t => t.MethodName.Contains("DescribeContainsName", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindUncoveredSymbols_TreatsPropsDeclaredProjectAsTests()
+    {
+        var result = FindUncoveredSymbolsLogic.Execute(_fixture.Loaded, _fixture.Resolver);
+
+        // Widget.Describe is called from the [Fact], so coverage must be non-zero …
+        Assert.True(result.Summary.CoveredCount > 0,
+            $"expected covered symbols, got CoveredCount={result.Summary.CoveredCount}");
+        Assert.DoesNotContain(result.UncoveredSymbols,
+            s => string.Equals(s.Symbol, "Widget.Describe", StringComparison.Ordinal));
+
+        // … Widget.Uncalled genuinely is not …
+        Assert.Contains(result.UncoveredSymbols,
+            s => string.Equals(s.Symbol, "Widget.Uncalled", StringComparison.Ordinal));
+
+        // … and the test project's own symbols must not be listed as uncovered production code.
+        Assert.DoesNotContain(result.UncoveredSymbols,
+            s => string.Equals(s.Project, "PropsDrivenTests", StringComparison.Ordinal));
+    }
+}

--- a/tests/RoslynCodeLens.Tests/TestDiscovery/TestProjectDetectorTests.cs
+++ b/tests/RoslynCodeLens.Tests/TestDiscovery/TestProjectDetectorTests.cs
@@ -40,4 +40,25 @@ public class TestProjectDetectorTests
         Assert.DoesNotContain("TestLib", names);
         Assert.DoesNotContain("TestLib2", names);
     }
+
+    [Theory]
+    [InlineData("xunit.core")] // xUnit v2
+    [InlineData("xunit.assert")]
+    [InlineData("xunit.v3.core")] // xUnit v3
+    [InlineData("nunit.framework")]
+    [InlineData("Microsoft.VisualStudio.TestPlatform.TestFramework")] // MSTest
+    public void IsTestFrameworkAssembly_RecognizesFrameworkAssemblyNames(string assemblyName)
+    {
+        Assert.True(TestProjectDetector.IsTestFrameworkAssembly(assemblyName));
+    }
+
+    [Theory]
+    [InlineData("System.Runtime")]
+    [InlineData("Microsoft.Extensions.DependencyInjection")]
+    [InlineData("Microsoft.VisualStudio.Threading")]
+    [InlineData("FluentAssertions")]
+    public void IsTestFrameworkAssembly_IgnoresNonFrameworkAssemblyNames(string assemblyName)
+    {
+        Assert.False(TestProjectDetector.IsTestFrameworkAssembly(assemblyName));
+    }
 }


### PR DESCRIPTION
Hi,

this is a possible fix for #406  I've created previously.
If anything does not meet your expectations or should be changed, please let me know.



Description created by Claude Fable:

## Summary

`TestProjectDetector` decided whether a project is a test project by string-scanning the raw csproj text for `PackageReference Include="xunit|nunit|mstest"`. Any solution declaring its test-framework packages elsewhere — a shared `tests/Directory.Build.props`, Central Package Management, or property indirection — had its test projects silently treated as production code:

- `get_test_summary` → `{"projects":[]}`
- `find_tests_for_symbol` → empty for symbols directly called by `[Fact]`s
- `find_uncovered_symbols` → `coveredCount: 0`, with the `[Fact]` methods themselves listed as uncovered production code
- every other tool excluding test projects via `GetTestProjectIds` (`find_async_violations`, `find_god_objects`, `get_public_api_surface`, `get_project_health`, …) skewed the same way

## Fix

Detection now checks each project's **resolved metadata references** for a test-framework assembly first (xunit v2 `xunit.core`/`xunit.assert`, xunit v3 `xunit.v3.*`, `nunit.*`, and MSTest's `Microsoft.VisualStudio.TestPlatform.TestFramework`, which doesn't share its package's name). This follows MSBuild evaluation, so it sees packages regardless of where they were declared, including transitively.

The csproj text scan stays as a fallback for degraded loads whose references were dropped by the design-time build (#260/#263), so existing behavior is strictly widened, never narrowed.

## Tests

- Unit tests for the assembly-name matcher (framework names incl. xunit.v3 and MSTest; negatives like `Microsoft.VisualStudio.Threading`, `FluentAssertions`).
- New `PropsFixture` regression solution mirroring the report's repro: the test project's xunit reference comes exclusively from a shared `tests/Directory.Build.props` — no test-framework `PackageReference` in the csproj text. Kept as a separate solution so TestSolution's solution-wide assertions stay untouched (same reasoning as the Razor fixture, #403). Its tests pin the end-to-end symptoms: `GetTestProjectIds` recognizes the project, `get_test_summary` reports its `[Fact]`, and `find_uncovered_symbols` counts its coverage instead of listing test symbols as uncovered.

Full suite: 1196 passed, 0 failed.

Fixes #406

Generated with [Claude Code](https://claude.com/claude-code) — Claude Fable 5
